### PR TITLE
Fix type error in `proxy.ts`

### DIFF
--- a/packages/proxy/schema/index.ts
+++ b/packages/proxy/schema/index.ts
@@ -268,7 +268,7 @@ export function buildAnthropicPrompt(messages: Message[]) {
 
 export function translateParams(
   toProvider: ModelFormat,
-  params: Record<string, string>
+  params: Record<string, string>,
 ): Record<string, unknown> {
   const translatedParams: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(params || {})) {

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -431,11 +431,7 @@ async function fetchOpenAI(
     fullURL.searchParams.set("api-version", secret.metadata.api_version);
     headers["api-key"] = secret.secret;
     delete bodyData["seed"];
-  } else if (
-    secret.type === "openai" &&
-    !isEmpty(secret.metadata?.organization_id) &&
-    secret.metadata.organization_id.length > 0
-  ) {
+  } else if (secret.type === "openai" && secret.metadata?.organization_id) {
     headers["OpenAI-Organization"] = secret.metadata.organization_id;
   }
 


### PR DESCRIPTION
A benign error. Typescript was not smart enough to recognize that metadata would not be undefined:

```
    } else if (
      secret.type === "openai" &&
      !isEmpty(secret.metadata?.organization_id) &&
E     secret.metadata.organization_id.length > 0     ■ 'secret.metadata' is possibly 'undefined'.
    ) {
```