### PR TITLE
Enable customized caching in local proxy

### DIFF
--- a/apis/node/src/env.ts
+++ b/apis/node/src/env.ts
@@ -1,10 +1,3 @@
-interface EnvParams {
-  braintrustApiUrl: string;
-  orgName?: string;
-  redisHost?: string;
-  redisPort?: number;
-}
-
 function reloadEnv() {
   return {
     braintrustApiUrl:
@@ -12,6 +5,7 @@ function reloadEnv() {
     orgName: process.env.ORG_NAME || "*",
     redisHost: process.env.REDIS_HOST,
     redisPort: parseInt(process.env.REDIS_PORT || "6379"),
+    localCachePath: process.env.BRAINTRUST_PROXY_LOCAL_CACHE_PATH || "",
   };
 }
 

--- a/apis/node/src/local.ts
+++ b/apis/node/src/local.ts
@@ -1,3 +1,4 @@
+import fs from "fs";
 import express, { Response } from "express";
 import dotenv from "dotenv";
 import cors from "cors";
@@ -5,7 +6,9 @@ import { pipeline } from "stream/promises";
 
 import { completion } from "./ai";
 import { nodeProxyV1 } from "./node-proxy";
-import { resetEnv } from "./env";
+import { Env, resetEnv } from "./env";
+
+import { CacheKeyOptions } from "@braintrust/proxy";
 
 dotenv.config({ path: ".env.local" });
 resetEnv();
@@ -22,7 +25,51 @@ function processError(res: Response, err: any) {
   res.write(`${err}`);
 }
 
-app.post("/stream/completion", async (req, res, next) => {
+function isTestingMode() {
+  return Env.localCachePath.length > 0;
+}
+
+let _testingCache: Record<string, string> | null = null;
+async function loadTestingCache() {
+  if (_testingCache === null) {
+    const contents = await fs.promises.readFile(Env.localCachePath, {
+      encoding: "utf-8",
+    });
+    _testingCache = JSON.parse(contents) as Record<string, string>;
+  }
+  return _testingCache;
+}
+
+async function dumpTestingCache() {
+  if (_testingCache !== null) {
+    await fs.promises.writeFile(
+      Env.localCachePath,
+      JSON.stringify(_testingCache),
+      { encoding: "utf-8" },
+    );
+  }
+}
+
+async function testingCacheGet(_encryptionKey: string, key: string) {
+  const cache = await loadTestingCache();
+  return cache[key] ?? null;
+}
+
+async function testingCachePut(
+  _encryptionKey: string,
+  key: string,
+  value: string,
+) {
+  const cache = await loadTestingCache();
+  cache[key] = value;
+}
+
+const TESTING_CACHE_KEY_OPTIONS: CacheKeyOptions = {
+  excludeAuthToken: true,
+  excludeOrgName: true,
+};
+
+app.post("/stream/completion", async (req, res) => {
   res.setHeader("Content-Type", "text/plain");
   const body = JSON.parse(req.body);
   try {
@@ -39,42 +86,53 @@ app.post("/stream/completion", async (req, res, next) => {
   return res.end();
 });
 
-app.get("/proxy/v1/*", async (req, res, next) => {
+app.get("/proxy/v1/*", async (req, res) => {
   const url = req.url.slice("/proxy/v1".length);
   try {
-    await nodeProxyV1(
-      "GET",
+    await nodeProxyV1({
+      method: "GET",
       url,
-      req.headers,
-      null,
-      res.setHeader.bind(res),
-      res.status.bind(res),
-      () => res,
-    );
+      proxyHeaders: req.headers,
+      body: null,
+      setHeader: res.setHeader.bind(res),
+      setStatusCode: res.status.bind(res),
+      getRes: () => res,
+      cacheGet: isTestingMode() ? testingCacheGet : undefined,
+      cachePut: isTestingMode() ? testingCachePut : undefined,
+      cacheKeyOptions: isTestingMode() ? TESTING_CACHE_KEY_OPTIONS : undefined,
+    });
   } catch (e: any) {
     console.error(e);
     throw e;
   }
 });
 
-app.post("/proxy/v1/*", async (req, res, next) => {
+app.post("/proxy/v1/*", async (req, res) => {
   const url = req.url.slice("/proxy/v1".length);
   try {
-    await nodeProxyV1(
-      "POST",
+    await nodeProxyV1({
+      method: "POST",
       url,
-      req.headers,
-      req.body,
-      res.setHeader.bind(res),
-      res.status.bind(res),
-      () => res,
-    );
+      proxyHeaders: req.headers,
+      body: req.body,
+      setHeader: res.setHeader.bind(res),
+      setStatusCode: res.status.bind(res),
+      getRes: () => res,
+      cacheGet: isTestingMode() ? testingCacheGet : undefined,
+      cachePut: isTestingMode() ? testingCachePut : undefined,
+      cacheKeyOptions: isTestingMode() ? TESTING_CACHE_KEY_OPTIONS : undefined,
+    });
   } catch (e: any) {
     console.error(e);
     throw e;
   }
+});
+
+app.get("/proxy/dump-testing-cache", async (_req, res) => {
+  await dumpTestingCache();
+  res.send(`Wrote testing cache to ${Env.localCachePath}`);
 });
 
 app.listen(port, () => {
-  console.log(`[server]: Server is running at http://localhost:${port}`);
+  console.log(`[server]: Server is running at http://${host}:${port}`);
 });

--- a/apis/node/src/login.ts
+++ b/apis/node/src/login.ts
@@ -32,6 +32,8 @@ export async function lookupApiSecret(
       secrets = (await response.json()).filter(
         (row: APISecret) => Env.orgName === "*" || row.org_name === Env.orgName,
       );
+    } else {
+      throw new Error(await response.text());
     }
   } catch (e) {
     console.warn("Failed to lookup api key. Falling back to provided key", e);

--- a/apis/node/src/node-proxy.ts
+++ b/apis/node/src/node-proxy.ts
@@ -4,62 +4,78 @@ import * as crypto from "crypto";
 // https://stackoverflow.com/questions/73308289/typescript-error-converting-a-native-fetch-body-webstream-to-a-node-stream
 import type * as streamWeb from "node:stream/web";
 
-import { proxyV1 } from "@braintrust/proxy";
+import { CacheKeyOptions, proxyV1 } from "@braintrust/proxy";
 
 import { getRedis } from "./cache";
 import { lookupApiSecret } from "./login";
 
-export async function nodeProxyV1(
-  method: "GET" | "POST",
-  url: string,
-  proxyHeaders: any,
-  body: any,
-  setHeader: (name: string, value: string) => void,
-  setStatusCode: (code: number) => void,
-  getRes: () => Writable,
-): Promise<void> {
+async function defaultCacheGet(_encryptionKey: string, key: string) {
+  const redis = await getRedis();
+  if (!redis) {
+    return null;
+  }
+  return await redis.get(key);
+}
+
+async function defaultCachePut(
+  _encryptionKey: string,
+  key: string,
+  value: string,
+) {
+  const redis = await getRedis();
+  if (!redis) {
+    return null;
+  }
+  redis.set(key, value, {
+    // Cache it for a week
+    EX: 60 * 60 * 24 * 7,
+  });
+}
+
+export async function nodeProxyV1({
+  method,
+  url,
+  proxyHeaders,
+  body,
+  setHeader,
+  setStatusCode,
+  getRes,
+  cacheGet,
+  cachePut,
+  cacheKeyOptions,
+}: {
+  method: "GET" | "POST";
+  url: string;
+  proxyHeaders: any;
+  body: any;
+  setHeader: (name: string, value: string) => void;
+  setStatusCode: (code: number) => void;
+  getRes: () => Writable;
+  cacheGet?: (encryptionKey: string, key: string) => Promise<string | null>;
+  cachePut?: (encryptionKey: string, key: string, value: string) => void;
+  cacheKeyOptions?: CacheKeyOptions;
+}): Promise<void> {
   // Unlike the Cloudflare worker API, which supports public access, this API
   // mandates authentication
 
-  const cacheGet = async (encryptionKey: string, key: string) => {
-    const redis = await getRedis();
-    if (!redis) {
-      return null;
-    }
-    return await redis.get(key);
-  };
-  const cachePut = async (
-    encryptionKey: string,
-    key: string,
-    value: string,
-  ) => {
-    const redis = await getRedis();
-    if (!redis) {
-      return null;
-    }
-    redis.set(key, value, {
-      // Cache it for a week
-      EX: 60 * 60 * 24 * 7,
-    });
-  };
-
   let { readable, writable } = new TransformStream();
 
-  await proxyV1(
+  await proxyV1({
     method,
     url,
     proxyHeaders,
     body,
     setHeader,
     setStatusCode,
-    writable,
-    lookupApiSecret,
-    cacheGet,
-    cachePut,
-    async (message: string) => {
+    res: writable,
+    getApiSecrets: lookupApiSecret,
+    cacheGet: cacheGet ?? defaultCacheGet,
+    cachePut: cachePut ?? defaultCachePut,
+    digest: async (message: string) => {
       return crypto.createHash("md5").update(message).digest("hex");
     },
-  );
+    cacheKeyOptions,
+  });
 
   const res = getRes();
   const readableNode = Readable.fromWeb(readable as streamWeb.ReadableStream);

--- a/packages/proxy/edge/index.ts
+++ b/packages/proxy/edge/index.ts
@@ -175,19 +175,19 @@ export function EdgeProxyV1(opts: ProxyOpts) {
     };
 
     try {
-      await proxyV1(
-        request.method,
-        relativeURL,
+      await proxyV1({
+        method: request.method,
+        url: relativeURL,
         proxyHeaders,
-        await request.text(),
+        body: await request.text(),
         setHeader,
-        setStatus,
-        writable,
-        fetchApiSecrets,
+        setStatusCode: setStatus,
+        res: writable,
+        getApiSecrets: fetchApiSecrets,
         cacheGet,
         cachePut,
-        digestMessage,
-      );
+        digest: digestMessage,
+      });
     } catch (e) {
       return new Response(`${e}`, {
         status: 400,

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,7 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"],
-      "env": ["BRAINTRUST_API_URL", "ORG_NAME", "REDIS_HOST", "REDIS_PORT"]
+      "env": ["BRAINTRUST_API_URL", "ORG_NAME", "REDIS_HOST", "REDIS_PORT", "BRAINTRUST_PROXY_LOCAL_CACHE_PATH"]
     },
     "test": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
For unit testing, it is convenient to be able to control the lifetime and contents of the cache precisely. To accomplish this, we allow users to specify a `BRAINTRUST_PROXY_LOCAL_CACHE_PATH` environment variable, pointing to a JSON file of the cache contents. If specified, the local nodeJS version of the proxy will use this as the cache instead of redis, and supports dumping the cache contents back to this file at any point in time.

Other changes are just cleaning up some function signatures and passing more hooks through to control caching behavior.