### PR TITLE
Local proxy: resolve after forwarding stream to express stream.

### DIFF
--- a/apis/node/src/node-proxy.ts
+++ b/apis/node/src/node-proxy.ts
@@ -45,7 +45,10 @@ export async function nodeProxyV1(
 
   let { readable, writable } = new TransformStream();
 
-  await proxyV1(
+  // Note: we must resolve the proxy after forwarding the stream to `res`,
+  // because the proxy promise resolves after its internal stream has finished
+  // writing.
+  const proxyPromise = proxyV1(
     method,
     url,
     proxyHeaders,
@@ -64,4 +67,5 @@ export async function nodeProxyV1(
   const res = getRes();
   const readableNode = Readable.fromWeb(readable as streamWeb.ReadableStream);
   readableNode.pipe(res, { end: true });
+  await proxyPromise;
 }

--- a/packages/proxy/edge/index.ts
+++ b/packages/proxy/edge/index.ts
@@ -72,10 +72,10 @@ export function EdgeProxyV1(opts: ProxyOpts) {
       useCache: boolean,
       authToken: string,
       types: ModelEndpointType[],
-      org_name?: string
+      org_name?: string,
     ): Promise<APISecret[]> => {
       const cacheKey = await digestMessage(
-        `${types.join(":")}/${org_name ? org_name + ":" : ""}${authToken}`
+        `${types.join(":")}/${org_name ? org_name + ":" : ""}${authToken}`,
       );
 
       const response =
@@ -108,7 +108,7 @@ export function EdgeProxyV1(opts: ProxyOpts) {
               org_name,
               mode: "full",
             }),
-          }
+          },
         );
         if (response.ok) {
           secrets = await response.json();
@@ -120,7 +120,7 @@ export function EdgeProxyV1(opts: ProxyOpts) {
         lookupFailed = true;
         console.warn(
           "Failed to lookup api key. Falling back to provided key",
-          e
+          e,
         );
       }
 
@@ -140,8 +140,8 @@ export function EdgeProxyV1(opts: ProxyOpts) {
             JSON.stringify(secrets),
             {
               ttl,
-            }
-          )
+            },
+          ),
         );
       }
 
@@ -159,14 +159,14 @@ export function EdgeProxyV1(opts: ProxyOpts) {
     const cachePut = async (
       encryptionKey: string,
       key: string,
-      value: string
+      value: string,
     ) => {
       if (opts.completionsCache) {
         ctx.waitUntil(
           encryptedPut(opts.completionsCache, encryptionKey, key, value, {
             // 1 week
             ttl: 60 * 60 * 24 * 7,
-          })
+          }),
         );
       }
     };
@@ -191,7 +191,7 @@ export function EdgeProxyV1(opts: ProxyOpts) {
         cacheGet,
         cachePut,
         digestMessage,
-        meterProvider
+        meterProvider,
       );
     } catch (e) {
       return new Response(`${e}`, {
@@ -226,7 +226,7 @@ async function encryptedPut(
   encryptionKey: string,
   key: string,
   value: string,
-  options?: { ttl?: number }
+  options?: { ttl?: number },
 ) {
   options = options || {};
 


### PR DESCRIPTION
It seems the node stream's `pipeTo` `Promise` will resolve after it has finished writing everything, which means we need to hook it up to the final destination before we can resolve the proxy's promise.