### PR TITLE
Add support for together.xyx Mixtral models

### DIFF
--- a/packages/proxy/schema/index.ts
+++ b/packages/proxy/schema/index.ts
@@ -12,6 +12,7 @@ export const ModelEndpointType = [
   "perplexity",
   "replicate",
   "anthropic",
+  "together",
   "js",
 ] as const;
 export type ModelEndpointType = (typeof ModelEndpointType)[number];
@@ -185,6 +186,7 @@ export const AvailableModels: { [name: string]: ModelSpec } = {
   "claude-2.0": { format: "anthropic", flavor: "chat" },
   "claude-2.1": { format: "anthropic", flavor: "chat" },
   "claude-instant-1.2": { format: "anthropic", flavor: "chat" },
+  "DiscoResearch/DiscoLM-mixtral-8x7b-v2": { format: "openai", flavor: "chat" },
   "meta/llama-2-70b-chat": { format: "openai", flavor: "chat" },
   "llama-2-70b-chat": { format: "openai", flavor: "chat" },
   "llama-2-13b-chat": { format: "openai", flavor: "chat" },
@@ -221,6 +223,7 @@ export const AvailableEndpointTypes: { [name: string]: ModelEndpointType[] } = {
   "pplx-7b-online": ["perplexity"],
   "pplx-70b-online": ["perplexity"],
   "meta/llama-2-70b-chat": ["replicate"],
+  "DiscoResearch/DiscoLM-mixtral-8x7b-v2": ["together"],
 };
 
 export function getModelEndpointTypes(model: string): ModelEndpointType[] {
@@ -244,6 +247,7 @@ export const EndpointProviderToBaseURL: {
   anthropic: "https://api.anthropic.com/v1",
   perplexity: "https://api.perplexity.ai",
   replicate: "https://openai-proxy.replicate.com/v1",
+  together: "https://api.together.xyz/inference",
   azure: null,
   js: null,
 };
@@ -263,6 +267,17 @@ export function buildAnthropicPrompt(messages: Message[]) {
         }
       })
       .join("\n\n") + "\n\nAssistant:"
+  );
+}
+
+export function buildClassicChatPrompt(messages: Message[]) {
+  return (
+    messages
+      .map(
+        ({ content, role }) => `<|im_start|>${role}
+${content}<|im_end|>`,
+      )
+      .join("\n") + "\n<|im_start|>assistant"
   );
 }
 
@@ -302,7 +317,7 @@ interface BaseMetadata {
 export type APISecret = APISecretBase &
   (
     | {
-        type: "perplexity" | "anthropic" | "replicate" | "js";
+        type: "perplexity" | "anthropic" | "replicate" | "together" | "js";
         metadata?: BaseMetadata;
       }
     | {

--- a/packages/proxy/schema/index.ts
+++ b/packages/proxy/schema/index.ts
@@ -192,6 +192,7 @@ export const AvailableModels: { [name: string]: ModelSpec } = {
   "llama-2-13b-chat": { format: "openai", flavor: "chat" },
   "codellama-34b-instruct": { format: "openai", flavor: "chat" },
   "mistral-7b-instruct": { format: "openai", flavor: "chat" },
+  "mistralai/mixtral-8x7b-32kseqlen": { format: "openai", flavor: "chat" },
   "openhermes-2-mistral-7b": { format: "openai", flavor: "chat" },
   "openhermes-2.5-mistral-7b": { format: "openai", flavor: "chat" },
   "pplx-7b-chat": { format: "openai", flavor: "chat" },
@@ -223,13 +224,16 @@ export const AvailableEndpointTypes: { [name: string]: ModelEndpointType[] } = {
   "pplx-7b-online": ["perplexity"],
   "pplx-70b-online": ["perplexity"],
   "meta/llama-2-70b-chat": ["replicate"],
+  "mistralai/mixtral-8x7b-32kseqlen": ["together"],
   "DiscoResearch/DiscoLM-mixtral-8x7b-v2": ["together"],
 };
 
 export function getModelEndpointTypes(model: string): ModelEndpointType[] {
   return (
     AvailableEndpointTypes[model] ||
-    DefaultEndpointTypes[AvailableModels[model].format]
+    (AvailableModels[model] &&
+      DefaultEndpointTypes[AvailableModels[model].format]) ||
+    []
   );
 }
 

--- a/packages/proxy/src/providers/together.ts
+++ b/packages/proxy/src/providers/together.ts
@@ -1,0 +1,102 @@
+/*
+Example events:
+
+data: {"choices":[{"text":"\n"}],"id":"83405eaa0f0a6899-SJC","token":{"id":13,"text":"\n","logprob":0,"special":false},"generated_text":null,"details":null,"stats":null}
+data: {"choices":[{"text":"San"}],"id":"83405eaa0f0a6899-SJC","token":{"id":17904,"text":"San","logprob":0,"special":false},"generated_text":null,"details":null,"stats":null}
+data: {"choices":[{"text":" Francisco"}],"id":"83405eaa0f0a6899-SJC","token":{"id":9686,"text":" Francisco","logprob":0,"special":false},"generated_text":null,"details":null,"stats":null}
+data: {"choices":[{"text":" is"}],"id":"83405eaa0f0a6899-SJC","token":{"id":349,"text":" is","logprob":0,"special":false},"generated_text":null,"details":null,"stats":null}
+data: {"choices":[{"text":" city"}],"id":"83405eaa0f0a6899-SJC","token":{"id":2990,"text":" city","logprob":-1.1162109,"special":false},"generated_text":null,"details":null,"stats":null}
+data: {"choices":[{"text":" located"}],"id":"83405eaa0f0a6899-SJC","token":{"id":5651,"text":" located","logprob":-0.4074707,"special":false},"generated_text":null,"details":null,"stats":null}
+data: {"choices":[{"text":" on"}],"id":"83405eaa0f0a6899-SJC","token":{"id":356,"text":" on","logprob":-0.95458984,"special":false},"generated_text":null,"details":null,"stats":null}
+data: {"choices":[{"text":" the"}],"id":"83405eaa0f0a6899-SJC","token":{"id":272,"text":" the","logprob":0,"special":false},"generated_text":null,"details":null,"stats":null}
+data: {"choices":[{"text":" west"}],"id":"83405eaa0f0a6899-SJC","token":{"id":7635,"text":" west","logprob":0,"special":false},"generated_text":null,"details":null,"stats":null}
+data: {"choices":[{"text":" coast"}],"id":"83405eaa0f0a6899-SJC","token":{"id":9437,"text":" coast","logprob":0,"special":false},"generated_text":null,"details":null,"stats":null}
+*/
+
+import { ChatCompletion, ChatCompletionChunk } from "openai/resources";
+import { getTimestampInSeconds } from "..";
+
+export interface ClassicChatStreamEvent {
+  choices: { text: string }[];
+  id: string;
+  token: { id: number; text: string; logprob: number; special: boolean };
+  generated_text: string | null;
+  details: string | null;
+  stats: null; // Haven't seen this filled in
+}
+
+/* Example completion:
+
+{"id":"83405e7d7f985c1b-SJC","status":"finished","prompt":["<|im_start|>user\nTell me about San Francisco<|im_end|>\n<|im_start|>assistant"],"model":"DiscoResearch/DiscoLM-mixtral-8x7b-v2","model_owner":"","num_returns":1,"args":{"model":"DiscoResearch/DiscoLM-mixtral-8x7b-v2","max_tokens":512,"prompt":"<|im_start|>user\nTell me about San
+Francisco<|im_end|>\n<|im_start|>assistant","temperature":0.7,"top_p":0.7,"top_k":50,"repetition_penalty":1},"subjobs":[],"output":{"result_type":"language-model-inference","choices":[{"text":"\nSan Francisco is a city located on the west coast of the United States in the state of California. It is known for its diverse culture, beautiful
+architecture, and iconic landmarks such as the Golden Gate Bridge and Alcatraz Island. The city is also home to a thriving technology industry, earning it the nickname \"Silicon Valley.\" San Francisco is a popular tourist destination, attracting millions of visitors each year who come to experience its unique blend of history, culture, an
+d natural beauty.普普普くくくくくくくくくくくくくくくくくく\n\nThe city of San Francisco is a vibrant and bustling metropolis located on the western coast of the United States in the state of California. It is known for its diverse culture, stunning architecture, and iconic landmarks such as the Golden Gate Bridge, the infamous Alcatraz Is
+land, and the picturesque Lombard Street. The city is also home to a thriving technology industry, earning it the nickname \"Silicon Valley.\" San Francisco's unique blend of history, culture, and natural beauty attracts millions of tourists each year.\n\nThe climate in San Francisco is mild year-round, with average temperatures ranging fr
+om the mid-50s to the mid-60s Fahrenheit (approximately 12-18 degrees Celsius). The city is known for its frequent fog, which can roll in off the Pacific Ocean and cover the city in a blanket of mist.\n\nSan Francisco is a popular destination for foodies, with a diverse culinary scene that reflects the city's multicultural heritage. The ci
+ty is also known for its vibrant arts and music scene, with numerous galleries, museums, and theaters showcasing the work of local and international artists.\n\nOverall, San Francisco is a fascinating and dynamic city that offers something for everyone, from its stunning natural beauty to its rich cultural heritage, vibrant arts scene, and
+ thriving technology industry.普 \n\n"}]}}
+ */
+export interface ClassicChatCompletion {
+  id: string;
+  status: string;
+  prompt: string[];
+  model: string;
+  model_owner: string;
+  num_returns: number;
+  args: Record<string, any>;
+  subjobs: any[];
+  output: {
+    result_type: string;
+    choices: { text: string }[];
+  };
+}
+
+export function classicChatEventToOpenAIEvent(
+  idx: number,
+  model: string,
+  event: ClassicChatStreamEvent,
+): { event: ChatCompletionChunk | null; finished: boolean } {
+  if (!event.choices) {
+    return {
+      event: null,
+      finished: false,
+    };
+  }
+
+  return {
+    event: {
+      id: event.id,
+      choices: event.choices.map((choice) => ({
+        delta: {
+          content: idx === 0 ? choice.text.trimStart() : choice.text,
+          role: "assistant",
+        },
+        index: 0,
+        finish_reason: null /* together never sets this */,
+      })),
+      created: getTimestampInSeconds(),
+      model,
+      object: "chat.completion.chunk",
+    },
+    finished: false,
+  };
+}
+
+export function classicChatCompletionToOpenAICompletion(
+  completion: ClassicChatCompletion,
+): ChatCompletion {
+  return {
+    id: completion.id,
+    created: getTimestampInSeconds(),
+    model: completion.model,
+    object: "chat.completion",
+    choices: completion.output.choices.map((choice) => ({
+      finish_reason: "stop",
+      index: 0,
+      message: {
+        content: choice.text.trimStart(),
+        role: "assistant",
+      },
+    })),
+  };
+}


### PR DESCRIPTION
Together just released [Mixtral support](https://www.together.ai/blog/mixtral). This change extends the proxy to support two new models:

* `mistralai/mixtral-8x7b-32kseqlen`: The "raw" model, in completion mode.
* `DiscoResearch/DiscoLM-mixtral-8x7b-v2`: A chat-tuned version of the model

Most of this change is converting the formats to be OpenAI friendly. After this change, you can do drop-in OpenAI chat and completions with these models:

```python
In [10]: client.chat.completions.create(model="DiscoResearch/DiscoLM-mixtral-8x7b-v2", messages=[{"role": "user", "content": "Tell me about San Francisco"}]).choices[0].message
Out[10]: ChatCompletionMessage(content='San Francisco is a beautiful city located in the state of California, United States. It is known', role='assistant', function_call=None, tool_calls=None)

In [24]: client.completions.create(model="mistralai/mixtral-8x7b-32kseqlen", prompt="Tell me about San Francisco", max_tokens=128)
Out[24]: Completion(id='8340f038eb42cf65-SJC', choices=[CompletionChoice(finish_reason='stop', index=0, logprobs=None, text='.\n\nI’m from the Bay Area, and I’ve been in San Francisco for about 10 years. I’ve been in the Bay Area my whole life. I’m a Bay Area girl. I love San Francisco. I love the people. I love the culture. I love the diversity. I love the food. I love the weather. I love the fact that it’s a city that’s always changing. I love the fact that it’s a city that’s always evolving. I love the fact that it’s a city that’s always growing. I love the')], created=1702331376, model='mistralai/mixtral-8x7b-32kseqlen', object='text_completion', system_fingerprint=None, usage=None)
```