### PR TITLE
Add typescript to node API devDeps.

### DIFF
--- a/apis/node/package.json
+++ b/apis/node/package.json
@@ -42,6 +42,7 @@
     "@types/express": "^4.17.17",
     "@types/node": "^20.5.0",
     "nodemon": "^3.0.1",
-    "npm-run-all": "^4.1.5"
+    "npm-run-all": "^4.1.5",
+    "typescript": "^5.0.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
+      typescript:
+        specifier: ^5.0.4
+        version: 5.3.3
 
   apis/vercel:
     dependencies:


### PR DESCRIPTION
It's needed to build the node package (standalone)