### PR TITLE
Propagate compression headers

### DIFF
--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -260,8 +260,6 @@ export async function proxyV1({
     proxyResponse.headers.forEach((value, name) => {
       const lowerName = name.toLowerCase();
       if (
-        lowerName === "content-length" ||
-        lowerName === "content-encoding" ||
         lowerName === "transfer-encoding" ||
         lowerName === "connection" ||
         lowerName === "keep-alive" ||


### PR DESCRIPTION
OpenAI now can brotli compress responses, which we were not properly handling