### PR TITLE
Ignore (strip out) max_tokens_to_sample from anthropic prompts

### DIFF
--- a/packages/proxy/schema/index.ts
+++ b/packages/proxy/schema/index.ts
@@ -94,7 +94,8 @@ export interface OpenAIModelParams {
 
 // https://docs.anthropic.com/claude/reference/complete_post
 interface AnthropicModelParams {
-  max_tokens_to_sample: number;
+  max_tokens: number;
+  max_tokens_to_sample?: number; // This is a legacy parameter that should not be used.
   temperature: number;
   top_p?: number;
   top_k?: number;
@@ -126,7 +127,7 @@ export const defaultModelParams: { [name in ModelFormat]: ModelParams } = {
   },
   anthropic: {
     temperature: 0,
-    max_tokens_to_sample: 1024,
+    max_tokens: 1024,
     use_cache: true,
   },
   google: {
@@ -143,12 +144,12 @@ export const modelParamToModelParam: {
     GoogleModelParams &
     BrainTrustModelParams)]:
     | keyof (OpenAIModelParams & AnthropicModelParams & BrainTrustModelParams)
-    | undefined;
+    | null;
 } = {
   temperature: "temperature",
   top_p: "top_p",
   max_tokens: "max_tokens",
-  max_tokens_to_sample: "max_tokens",
+  max_tokens_to_sample: null,
   use_cache: "use_cache",
   maxOutputTokens: "max_tokens",
   topP: "top_p",
@@ -162,7 +163,6 @@ export const sliderSpecs: {
   temperature: [0, 1, 0.01, false],
   top_p: [0, 1, 0.01, false],
   max_tokens: [1, 10240, 1, false],
-  max_tokens_to_sample: [1, 10240, 1, true],
   maxOutputTokens: [1, 10240, 1, true],
   frequency_penalty: [0, 1, 0.01, false],
   presence_penalty: [0, 1, 0.01, false],
@@ -379,8 +379,11 @@ export function translateParams(
   for (const [k, v] of Object.entries(params || {})) {
     const translatedKey = modelParamToModelParam[k as keyof ModelParams] as
       | keyof ModelParams
-      | undefined;
-    if (
+      | undefined
+      | null;
+    if (translatedKey === null) {
+      continue;
+    } else if (
       translatedKey !== undefined &&
       defaultModelParamSettings[toProvider][translatedKey] !== undefined
     ) {
@@ -389,5 +392,6 @@ export function translateParams(
       translatedParams[k] = v;
     }
   }
+
   return translatedParams;
 }

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -668,7 +668,6 @@ async function fetchAnthropic(
     max_tokens: 256, // Required param
     ...translateParams("anthropic", oaiParams),
   };
-  console.log("PARAMS", params);
 
   const proxyResponse = await fetch(fullURL.toString(), {
     method,

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -668,6 +668,7 @@ async function fetchAnthropic(
     max_tokens: 256, // Required param
     ...translateParams("anthropic", oaiParams),
   };
+  console.log("PARAMS", params);
 
   const proxyResponse = await fetch(fullURL.toString(), {
     method,


### PR DESCRIPTION
The playground can set both `max_tokens` and `max_tokens_to_sample` (since `max_tokens_to_sample` was listed as a possible Anthropic param).

With these changes, new prompts won't have it, and old prompts will have it stripped out.