### PR TITLE
Generalize CORS further

### DIFF
--- a/apis/cloudflare/src/index.ts
+++ b/apis/cloudflare/src/index.ts
@@ -1,4 +1,10 @@
-import { proxyV1Prefix, handleProxyV1, handlePrometheusScrape } from "./proxy";
+import {
+  proxyV1Prefix,
+  handleProxyV1,
+  handlePrometheusScrape,
+  originWhitelist,
+} from "./proxy";
+import { getCorsHeaders } from "@braintrust/proxy/edge";
 export { PrometheusMetricAggregator } from "./metric-aggregator";
 
 // The fetch handler is invoked when this worker receives a HTTP(S) request
@@ -18,10 +24,7 @@ export default {
     } else if (url.pathname === "/") {
       return new Response("Hello World!", {
         status: 200,
-        headers: {
-          "access-control-allow-origin": "*",
-          "access-control-allow-methods": "GET,OPTIONS",
-        },
+        headers: getCorsHeaders(request, originWhitelist(env)),
       });
     }
 

--- a/apis/cloudflare/src/proxy.ts
+++ b/apis/cloudflare/src/proxy.ts
@@ -19,6 +19,12 @@ function apiCacheKey(key: string) {
   return `http://apikey.cache/${encodeURIComponent(key)}.jpg`;
 }
 
+export function originWhitelist(env: Env) {
+  return env.BRAINTRUST_ALLOWED_ORIGIN
+    ? [new RegExp(env.BRAINTRUST_ALLOWED_ORIGIN)]
+    : undefined;
+}
+
 export async function handleProxyV1(
   request: Request,
   env: Env,
@@ -52,9 +58,7 @@ export async function handleProxyV1(
     "cloudflare-metrics",
   );
 
-  const whitelist = env.BRAINTRUST_ALLOWED_ORIGIN
-    ? [new RegExp(env.BRAINTRUST_ALLOWED_ORIGIN)]
-    : undefined;
+  const whitelist = originWhitelist(env);
 
   const cacheGetLatency = meter.createHistogram("results_cache_get_latency");
   const cacheSetLatency = meter.createHistogram("results_cache_set_latency");


### PR DESCRIPTION
This change refactors the CORS checking logic and then reuses it in the `/` endpoint on the Cloudflare proxy, so we send exactly the CORS headers for the health check as we do for the actual proxy.