### PR TITLE
Add stop->stopSequences to OpenAI-Google params mapping

### DIFF
--- a/packages/proxy/src/providers/google.ts
+++ b/packages/proxy/src/providers/google.ts
@@ -75,6 +75,7 @@ export const OpenAIParamsToGoogleParams: {
 } = {
   temperature: "temperature",
   top_p: "topP",
+  stop: "stopSequences",
   max_tokens: "maxOutputTokens",
   frequency_penalty: null,
   presence_penalty: null,


### PR DESCRIPTION
Hi! 

I don't know typescript and I just found out about your project (and I wasn't able to run the proxy locally to test the changes...), but.

When I tried to run an evaluation w/ the EleutherAI eval harness through your public proxy (thank you, BTW!), I got this:

```
openai.BadRequestError: Error code: 400 - {'error': {'code': 400, 'message': 'Invalid JSON payload received. Unknown name "stop" at \'generation_config\': Cannot find field.', 'status': 'INVALID_ARGUMENT', 'details': [{'@type': 'type.googleapis.com/google.rpc.BadRequest', 'fieldViolations': [{'field': 'generation_config', 'description': 'Invalid JSON payload received. Unknown name "stop" at \'generation_config\': Cannot find field.'}]}]}}
```

I assume it's because the 'when to stop generating' strings in OpenAI are passed through the `stop` parameter are actually `StopSequences` in Gemini API: https://ai.google.dev/api/rest/v1/GenerationConfig. 

If I understood the code right, this should fix this, but again — I didn't test it.

Thank you for the public proxy again :) Will be a lifesaver as soon as I figure out how to run my evaluations through it

Serhii