### PR TITLE
Convert image urls to base64 for claude models

### DIFF
--- a/packages/proxy/src/providers/anthropic.ts
+++ b/packages/proxy/src/providers/anthropic.ts
@@ -166,33 +166,10 @@ const allowedImageTypes = [
 ];
 
 function arrayBufferToBase64(buf: ArrayBuffer): string {
-  const base64Chars =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
   const bytes = new Uint8Array(buf);
-
-  const binary = bytes.reduce((acc, b) => acc + String.fromCharCode(b), "");
-
-  let base64 = "";
-  for (let i = 0; i < binary.length; i += 3) {
-    const triplet =
-      (binary.charCodeAt(i) << 16) |
-      (binary.charCodeAt(i + 1) << 8) |
-      binary.charCodeAt(i + 2);
-    base64 +=
-      base64Chars[(triplet >> 18) & 0x3f] +
-      base64Chars[(triplet >> 12) & 0x3f] +
-      base64Chars[(triplet >> 6) & 0x3f] +
-      base64Chars[triplet & 0x3f];
-  }
-
-  const padding = binary.length % 3;
-  if (padding === 1) {
-    base64 = base64.slice(0, -2) + "==";
-  } else if (padding === 2) {
-    base64 = base64.slice(0, -1) + "=";
-  }
-
-  return base64;
+  let binaryString = "";
+  bytes.forEach((b) => (binaryString += String.fromCharCode(b)));
+  return btoa(binaryString);
 }
 
 async function convertImageUrl(url: string): Promise<AnthropicImageBlock> {

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -651,7 +651,7 @@ async function fetchAnthropic(
   const messages = [];
   let system = undefined;
   for (const m of oaiMessages as Message[]) {
-    const content = openAIContentToAnthropicContent(m.content);
+    const content = await openAIContentToAnthropicContent(m.content);
     if (m.role === "system") {
       system = content;
     } else if (


### PR DESCRIPTION
Claude doesn't natively support image URLs, so for convenience we should download valid image URLs and convert them to base64 format.