### PR TITLE
Ignore some params

### DIFF
--- a/packages/proxy/schema/index.ts
+++ b/packages/proxy/schema/index.ts
@@ -70,7 +70,7 @@ export const defaultModelParams: { [name in ModelFormat]: ModelParams } = {
 };
 
 export const modelParamToModelParam: {
-  [name in keyof AnyModelParam]: keyof AnyModelParam | null;
+  [name: string]: keyof AnyModelParam | null;
 } = {
   temperature: "temperature",
   top_p: "top_p",
@@ -81,6 +81,8 @@ export const modelParamToModelParam: {
   topP: "top_p",
   topK: "top_k",
   tool_choice: null,
+  function_call: null,
+  n: null,
 };
 
 export const sliderSpecs: {

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -681,11 +681,6 @@ async function fetchAnthropic(
     ...translateParams("anthropic", oaiParams),
   };
 
-  if (params.function_call) {
-    // This should be in the params object, but since it's deprecated we haven't added it.
-    delete params.function_call;
-  }
-
   const isFunction = !!params.functions;
   if (params.tools || params.functions) {
     headers["anthropic-beta"] = "tools-2024-04-04";


### PR DESCRIPTION
Do not constrain `modelParamToModelParam` to the whitelist of supported params, and block out `function_call` and `n` from non-openai providers.