### PR TITLE
Fix caching to store binary data

### DIFF
--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -43,6 +43,7 @@ type CachedData = {
   headers: Record<string, string>;
 } & (
   | {
+      // DEPRECATION_NOTICE: This can be removed in a couple weeks since writing (e.g. June 9 2024 onwards)
       body: string;
     }
   | {

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -16,6 +16,7 @@ import {
 } from "@schema";
 import {
   flattenChunks,
+  flattenChunksArray,
   getRandomInt,
   isEmpty,
   isObject,
@@ -38,10 +39,16 @@ import { Message } from "@braintrust/core/typespecs";
 import { ChatCompletionCreateParams } from "openai/resources";
 import { fetchBedrockAnthropic } from "./providers/bedrock";
 
-interface CachedData {
+type CachedData = {
   headers: Record<string, string>;
-  body: string;
-}
+} & (
+  | {
+      body: string;
+    }
+  | {
+      data: string;
+    }
+);
 
 const CACHE_HEADER = "x-bt-use-cache";
 const CREDS_CACHE_HEADER = "x-bt-use-creds-cache";
@@ -205,7 +212,16 @@ export async function proxyV1({
 
       stream = new ReadableStream<Uint8Array>({
         start(controller) {
-          controller.enqueue(new TextEncoder().encode(cachedData.body));
+          if ("body" in cachedData && cachedData.body) {
+            controller.enqueue(new TextEncoder().encode(cachedData.body));
+          } else if ("data" in cachedData && cachedData.data) {
+            const data = atob(cachedData.data);
+            const uint8Array = new Uint8Array(data.length);
+            for (let i = 0; i < data.length; i++) {
+              uint8Array[i] = data.charCodeAt(i);
+            }
+            controller.enqueue(uint8Array);
+          }
           controller.close();
         },
       });
@@ -300,11 +316,12 @@ export async function proxyV1({
           controller.enqueue(chunk);
         },
         async flush(controller) {
-          const text = flattenChunks(allChunks);
+          const data = flattenChunksArray(allChunks);
+          const dataB64 = btoa(String.fromCharCode(...data));
           cachePut(
             encryptionKey,
             cacheKey,
-            JSON.stringify({ headers: proxyResponseHeaders, body: text }),
+            JSON.stringify({ headers: proxyResponseHeaders, data: dataB64 }),
           );
         },
       });

--- a/packages/proxy/src/util.ts
+++ b/packages/proxy/src/util.ts
@@ -31,12 +31,17 @@ export function getTimestampInSeconds() {
   return Math.floor(Date.now() / 1000);
 }
 
-export function flattenChunks(allChunks: Uint8Array[]) {
+export function flattenChunksArray(allChunks: Uint8Array[]): Uint8Array {
   const flatArray = new Uint8Array(allChunks.reduce((a, b) => a + b.length, 0));
   for (let i = 0, offset = 0; i < allChunks.length; i++) {
     flatArray.set(allChunks[i], offset);
     offset += allChunks[i].length;
   }
+  return flatArray;
+}
+
+export function flattenChunks(allChunks: Uint8Array[]) {
+  const flatArray = flattenChunksArray(allChunks);
   return new TextDecoder().decode(flatArray);
 }
 


### PR DESCRIPTION
If the data is compressed, the way we store cached data only sometimes works. This change updates it to be base64 encoded, and uses that (if present).

We can eventually remove the `text` case, but I didn't want to break people's existing cached data.