### PR TITLE
Fix cache header

### DIFF
--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -234,7 +234,7 @@ export async function proxyV1({
         setHeader(name, value);
       }
       setHeader("x-cached", "true");
-      setHeader("x-bt-cached", "true");
+      setHeader("x-bt-cached", "HIT");
 
       spanType = guessSpanType(url, bodyData?.model);
       if (spanLogger && spanType) {
@@ -346,7 +346,7 @@ export async function proxyV1({
       setHeader(name, value);
     }
     setHeader("x-cached", "false"); // We're moving to x-bt-cached
-    setHeader("x-bt-cached", "false");
+    setHeader("x-bt-cached", "MISS");
 
     if (stream && proxyResponse.ok && useCache) {
       const allChunks: Uint8Array[] = [];

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -63,6 +63,9 @@ export const ORG_NAME_HEADER = "x-bt-org-name";
 export const ENDPOINT_NAME_HEADER = "x-bt-endpoint-name";
 export const FORMAT_HEADER = "x-bt-stream-fmt";
 
+export const LEGACY_CACHED_HEADER = "x-cached";
+export const CACHED_HEADER = "x-bt-proxy-cached";
+
 const CACHE_MODES = ["auto", "always", "never"] as const;
 
 // Options to control how the cache key is generated.
@@ -233,8 +236,8 @@ export async function proxyV1({
       for (const [name, value] of Object.entries(cachedData.headers)) {
         setHeader(name, value);
       }
-      setHeader("x-cached", "true");
-      setHeader("x-bt-cached", "HIT");
+      setHeader(LEGACY_CACHED_HEADER, "true");
+      setHeader(CACHED_HEADER, "HIT");
 
       spanType = guessSpanType(url, bodyData?.model);
       if (spanLogger && spanType) {
@@ -345,8 +348,8 @@ export async function proxyV1({
     for (const [name, value] of Object.entries(proxyResponseHeaders)) {
       setHeader(name, value);
     }
-    setHeader("x-cached", "false"); // We're moving to x-bt-cached
-    setHeader("x-bt-cached", "MISS");
+    setHeader(LEGACY_CACHED_HEADER, "false"); // We're moving to x-bt-cached
+    setHeader(CACHED_HEADER, "MISS");
 
     if (stream && proxyResponse.ok && useCache) {
       const allChunks: Uint8Array[] = [];

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -64,7 +64,7 @@ export const ENDPOINT_NAME_HEADER = "x-bt-endpoint-name";
 export const FORMAT_HEADER = "x-bt-stream-fmt";
 
 export const LEGACY_CACHED_HEADER = "x-cached";
-export const CACHED_HEADER = "x-bt-proxy-cached";
+export const CACHED_HEADER = "x-bt-cached";
 
 const CACHE_MODES = ["auto", "always", "never"] as const;
 


### PR DESCRIPTION
While adding caching elsewhere, I realized we should move towards more standard terminology: `HIT` / `MISS`