### PR TITLE
Fix spread operator and default model params

### DIFF
--- a/packages/proxy/schema/index.ts
+++ b/packages/proxy/schema/index.ts
@@ -44,25 +44,6 @@ export const MessageTypeToMessageType: {
   model: "assistant",
 };
 
-export const defaultModelParams: { [name in ModelFormat]: ModelParams } = {
-  openai: {
-    temperature: 0,
-    max_tokens: 1024,
-    use_cache: true,
-  },
-  anthropic: {
-    temperature: 0,
-    max_tokens: 1024,
-    use_cache: true,
-  },
-  google: {
-    temperature: 0,
-    maxOutputTokens: 1024,
-    use_cache: true,
-  },
-  js: {},
-};
-
 export const modelParamToModelParam: {
   [name: string]: keyof AnyModelParam | null;
 } = {
@@ -100,8 +81,8 @@ export const defaultModelParamSettings: {
   [name in ModelFormat]: ModelParams;
 } = {
   openai: {
-    temperature: 0,
-    max_tokens: 1024,
+    temperature: undefined,
+    max_tokens: undefined,
     top_p: 1,
     frequency_penalty: 0,
     presence_penalty: 0,
@@ -109,15 +90,15 @@ export const defaultModelParamSettings: {
     use_cache: true,
   },
   anthropic: {
-    temperature: 0,
-    max_tokens: 1024,
+    temperature: undefined,
+    max_tokens: undefined,
     top_p: 0.7,
     top_k: 5,
     use_cache: true,
   },
   google: {
-    temperature: 0,
-    maxOutputTokens: 1024,
+    temperature: undefined,
+    maxOutputTokens: undefined,
     topP: 0.7,
     topK: 5,
     use_cache: true,

--- a/packages/proxy/src/encrypt.ts
+++ b/packages/proxy/src/encrypt.ts
@@ -10,6 +10,16 @@ function base64ToArrayBuffer(base64: string) {
   return bytes.buffer;
 }
 
+function arrayBufferToBase64(buffer: ArrayBuffer) {
+  var binary = "";
+  var bytes = new Uint8Array(buffer);
+  var len = bytes.byteLength;
+  for (var i = 0; i < len; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
 // https://github.com/mdn/dom-examples/blob/main/web-crypto/encrypt-decrypt/aes-gcm.js
 export async function decryptMessage(
   keyString: string,
@@ -65,7 +75,7 @@ export async function encryptMessage(
   );
 
   return {
-    iv: btoa(String.fromCharCode(...new Uint8Array(iv))),
-    data: btoa(String.fromCharCode(...new Uint8Array(decoded))),
+    iv: arrayBufferToBase64(new Uint8Array(iv.buffer)),
+    data: arrayBufferToBase64(decoded),
   };
 }

--- a/packages/proxy/src/encrypt.ts
+++ b/packages/proxy/src/encrypt.ts
@@ -75,7 +75,7 @@ export async function encryptMessage(
   );
 
   return {
-    iv: arrayBufferToBase64(new Uint8Array(iv.buffer)),
+    iv: arrayBufferToBase64(new Uint8Array(iv)),
     data: arrayBufferToBase64(decoded),
   };
 }

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -191,7 +191,9 @@ export async function proxyV1({
   // OpenAI now allows you to set a seed, and if that is set, we should cache even
   // if temperature is non-zero.
   const temperatureNonZero =
-    (url === "/chat/completions" || url === "/completions") &&
+    (url === "/chat/completions" ||
+      url === "/completions" ||
+      url === "/auto") &&
     bodyData &&
     bodyData.temperature !== 0 &&
     (bodyData.seed === undefined || bodyData.seed === null);


### PR DESCRIPTION
* Remove the spread operator from base64 conversion. The spread operator appears to be recursive, internally, so with a sufficiently long input string returned:

```
RangeError: Maximum call stack size exceeded
```

* Remove some default model params.