### PR TITLE
Remove MessageTypes

### DIFF
--- a/packages/proxy/schema/index.ts
+++ b/packages/proxy/schema/index.ts
@@ -27,7 +27,7 @@ export const ModelEndpointType = [
 export type ModelEndpointType = (typeof ModelEndpointType)[number];
 
 export const MessageTypes: { [name in ModelFormat]: MessageRole[] } = {
-  openai: ["system", "user", "assistant" /*, "function" */],
+  openai: ["system", "user", "assistant", "tool"],
   anthropic: ["system", "user", "assistant"],
   google: ["user", "model"],
   js: ["user"],


### PR DESCRIPTION
This is only used within Braintrust's product, not the proxy, so removing.