### PR TITLE
Fix typo in console.warn

### DIFF
--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -757,7 +757,7 @@ async function fetchModelLoop(
             10,
           );
           console.warn(
-            `Ran out of endpoints and hite rate limit errors, so sleeping for ${delayMs}ms`,
+            `Ran out of endpoints and hit rate limit errors, so sleeping for ${delayMs}ms`,
             loopIndex,
           );
           await new Promise((r) => setTimeout(r, delayMs));


### PR DESCRIPTION
I noticed this typo when the Stripe folks were talking about an error they were seeing...