### PR TITLE
Model params can be unknown

### DIFF
--- a/packages/proxy/schema/index.ts
+++ b/packages/proxy/schema/index.ts
@@ -263,7 +263,7 @@ ${content}<|im_end|>`,
 
 export function translateParams(
   toProvider: ModelFormat,
-  params: Record<string, string>,
+  params: Record<string, unknown>,
 ): Record<string, unknown> {
   const translatedParams: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(params || {})) {


### PR DESCRIPTION
I think the values can already be non-strings.