### PR TITLE
Disallow issuing temp credential with another temp credential.

### DIFF
--- a/packages/proxy/utils/tempCredentials.ts
+++ b/packages/proxy/utils/tempCredentials.ts
@@ -128,6 +128,16 @@ export async function makeTempCredentials({
     ttl_seconds?: number,
   ) => Promise<void>;
 }) {
+  if (isTempCredential(authToken)) {
+    // Disallow issuing a temp credential that wraps another temp credential.
+    // This is fine from a security standpoint because such a credential will
+    // fail later while fetching API secrets. However, allowing this is a
+    // confusing and perhaps hard to debug behavior, so we prefer to fail fast.
+    throw new Error(
+      "Temporary credential cannot be used to issue another temp credential.",
+    );
+  }
+
   const body = credentialsRequestSchema.safeParse(rawBody);
   if (!body.success) {
     throw new Error(body.error.message);


### PR DESCRIPTION
We should not allow users to "wrap" a temporary credential with another temporary credential. This is fine from a security standpoint because such a credential will fail later while fetching API secrets. However, allowing this is a confusing and perhaps hard to debug behavior, so we prefer to fail fast.