### PR TITLE
CORS allow `localhost` as an origin.

### DIFF
--- a/packages/proxy/edge/index.ts
+++ b/packages/proxy/edge/index.ts
@@ -41,6 +41,7 @@ const defaultWhitelist: (string | RegExp)[] = [
   "https://www.braintrust.dev",
   new RegExp("https://.*-braintrustdata.vercel.app"),
   new RegExp("https://.*.preview.braintrust.dev"),
+  "http://localhost",
 ];
 
 const baseCorsHeaders = {


### PR DESCRIPTION
To assist with localhost development that makes requests to the staging or production proxy.