### PR TITLE
Add flag to use fake streaming for custom providers

### DIFF
--- a/packages/proxy/schema/secrets.ts
+++ b/packages/proxy/schema/secrets.ts
@@ -7,6 +7,7 @@ export const BaseMetadataSchema = z
     customModels: z.record(ModelSchema).nullish(),
     excludeDefaultModels: z.boolean().nullish(),
     additionalHeaders: z.record(z.string(), z.string()).nullish(),
+    supportsStreaming: z.boolean().default(true),
   })
   .strict();
 

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -1050,6 +1050,17 @@ async function fetchOpenAI(
     */
   }
 
+  if (secret.metadata?.supportsStreaming === false) {
+    return fetchOpenAIFakeStream({
+      method,
+      fullURL,
+      headers,
+      bodyData,
+      setHeader,
+      fakeStream: true,
+    });
+  }
+
   const proxyResponse = await fetch(
     fullURL.toString(),
     method === "POST"
@@ -1078,16 +1089,18 @@ async function fetchOpenAIFakeStream({
   headers,
   bodyData,
   setHeader,
+  fakeStream = false,
 }: {
   method: "GET" | "POST";
   fullURL: URL;
   headers: Record<string, string>;
   bodyData: null | any;
   setHeader: (name: string, value: string) => void;
+  fakeStream?: boolean;
 }): Promise<ModelResponse> {
   let isStream = false;
   if (bodyData) {
-    isStream = !!bodyData["stream"];
+    isStream = !!bodyData["stream"] || fakeStream;
     delete bodyData["stream"];
     delete bodyData["stream_options"];
   }


### PR DESCRIPTION
Uses the existing `fetchOpenAIFakeStream` method so if a custom provider has the flag `supportsStreaming = false`, we call the method. This allows custom provider endpoints that don't support streaming to work in the playground