### PR TITLE
Harvest http codes out of type errors

### DIFF
--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -847,7 +847,7 @@ async function fetchModelLoop(
             httpCode = e.cause.statusCode;
           }
           if ("headers" in e.cause) {
-            httpHeaders = e.cause.headers;
+            httpHeaders = new Headers(e.cause.headers);
           }
         }
         if (!httpCode) {


### PR DESCRIPTION
Type errors can be opaque but in Node.js `fetch` will often throw them (even for rate limit errors). This change tries to harvest the HTTP code out of the type error so we can use our rate-limit handling, etc. if we encounter one.