### PR TITLE
add gemini-2.0-flash-001

### DIFF
--- a/packages/proxy/schema/models.ts
+++ b/packages/proxy/schema/models.ts
@@ -1033,6 +1033,14 @@ export const AvailableModels: { [name: string]: ModelSpec } = {
     displayName: "Gemini 1.5 Flash",
     multimodal: true,
   },
+  "gemini-2.0-flash-001": {
+    format: "google",
+    flavor: "chat",
+    input_cost_per_mil_tokens: 0.1,
+    output_cost_per_mil_tokens: 0.4,
+    displayName: "Gemini 2.0 Flash",
+    multimodal: true,
+  },
   "gemini-2.0-flash-latest": {
     format: "google",
     flavor: "chat",


### PR DESCRIPTION
from the [gemini api docs](https://ai.google.dev/gemini-api/docs/models/gemini#gemini-2.0-flash) it seems like the alias `gemini-2.0-flash-latest` is not yet active. Need to use `gemini-2.0-flash-001` instead.