### PR TITLE
Improve type errors

### DIFF
--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -956,7 +956,7 @@ async function fetchModelLoop(
         `AI provider returned ${httpCode} error.\n\nHeaders:\n` +
         headersString.join("\n");
       proxyResponse = {
-        response: new Response(null, { status: 400 }),
+        response: new Response(null, { status: httpCode }),
         stream: new ReadableStream({
           start(controller) {
             controller.enqueue(new TextEncoder().encode(errorText));

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -879,7 +879,7 @@ async function fetchModelLoop(
           ))
       ) {
         break;
-      } else {
+      } else if (i < secrets.length - 1) {
         console.warn(
           "Received retryable error. Will try the next endpoint",
           proxyResponse.response.status,
@@ -941,6 +941,29 @@ async function fetchModelLoop(
 
       totalWaitedTime += delayMs;
       i = -1; // Reset the loop variable
+    } else if (
+      httpCode !== undefined &&
+      i === secrets.length - 1 &&
+      !proxyResponse
+    ) {
+      // Convert the HTTP code into a more reasonable error that is easier to parse
+      // and display to the user.
+      const headersString: string[] = [];
+      httpHeaders.forEach((value, key) => {
+        headersString.push(`${key}: ${value}`);
+      });
+      const errorText =
+        `AI provider returned ${httpCode} error.\n\nHeaders:\n` +
+        headersString.join("\n");
+      proxyResponse = {
+        response: new Response(null, { status: 400 }),
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(errorText));
+            controller.close();
+          },
+        }),
+      };
     }
 
     endpointRetryableErrors.add(1, {


### PR DESCRIPTION
Certain `fetch` implementations, for example Node/Undici, will throw `TypeError`s when there's a 500-* error. This is unfortunate because we lose the mechanics of forwarding these errors along to the client in a way that they can interpret cleanly.

This change converts those errors into a nicely formatted `Response`, so at least it's clear what actually happened.