### PR TITLE
Implement cache-control directives for max-age, no-cache, and no-store

### DIFF
--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -89,6 +89,7 @@
     "@opentelemetry/resources": "^1.19.0",
     "@opentelemetry/sdk-metrics": "^1.19.0",
     "ai": "2.2.37",
+    "cache-control-parser": "^2.0.6",
     "eventsource-parser": "^1.1.1",
     "jose": "^5.9.6",
     "jsonwebtoken": "^9.0.2",

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -90,6 +90,7 @@
     "@opentelemetry/sdk-metrics": "^1.19.0",
     "ai": "2.2.37",
     "cache-control-parser": "^2.0.6",
+    "date-fns": "^4.1.0",
     "eventsource-parser": "^1.1.1",
     "jose": "^5.9.6",
     "jsonwebtoken": "^9.0.2",

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -68,15 +68,20 @@ import {
   makeTempCredentials,
   verifyTempCredentials,
 } from "utils";
+import { differenceInSeconds, formatISO, parseISO } from "date-fns";
 import { openAIChatCompletionToChatEvent } from "./providers/openai";
 import { ChatCompletionCreateParamsBase } from "openai/resources/chat/completions";
 import { importPKCS8, SignJWT } from "jose";
 import { z } from "zod";
 
+type CachedMetadata = {
+  cached_at: string;
+  ttl: number;
+};
 type CachedData = {
   headers: Record<string, string>;
   // XXX make this a required field once deployed and cache data is cycled for 1 week (previous max cache TTL)
-  timestamp?: number;
+  metadata?: CachedMetadata;
 } & (
   | {
       // DEPRECATION_NOTICE: This can be removed in a couple weeks since writing (e.g. June 9 2024 onwards)
@@ -333,8 +338,12 @@ export async function proxyV1({
     if (cached !== null) {
       const cachedData: CachedData = JSON.parse(cached);
       // XXX simplify once all cached data has a timestamp - assume existing data has age of 7 days
-      const age = cachedData.timestamp
-        ? Math.floor(getCurrentUnixTimestamp() - cachedData.timestamp)
+      const ttl = cachedData.metadata?.ttl ?? DEFAULT_CACHE_TTL;
+      const age = cachedData.metadata
+        ? differenceInSeconds(
+            new Date(),
+            parseISO(cachedData.metadata.cached_at),
+          )
         : DEFAULT_CACHE_TTL;
 
       if (!cacheMaxAge || age <= cacheMaxAge) {
@@ -343,7 +352,7 @@ export async function proxyV1({
           setHeader(name, value);
         }
         setHeader(CACHED_HEADER, "HIT");
-        setHeader("cache-control", `max-age=${cacheTTL}`);
+        setHeader("cache-control", `max-age=${ttl}`);
         setHeader("age", `${age}`);
 
         spanType = guessSpanType(url, bodyData?.model);
@@ -540,7 +549,12 @@ export async function proxyV1({
             cacheKey,
             JSON.stringify({
               headers: proxyResponseHeaders,
-              timestamp: getCurrentUnixTimestamp(),
+              metadata: {
+                cached_at: formatISO(new Date(), {
+                  representation: "complete",
+                }),
+                ttl: cacheTTL,
+              },
               data: dataB64,
             }),
             cacheTTL,

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -92,7 +92,7 @@ type CachedData = {
     }
 );
 
-const MAX_CACHE_TTL = 90 * 24 * 60 * 60; // 90 days
+const MAX_CACHE_TTL = 7 * 24 * 60 * 60; // 7 days
 const DEFAULT_CACHE_TTL = 7 * 24 * 60 * 60; // 7 days
 export const CACHE_HEADER = "x-bt-use-cache";
 export const CACHE_TTL_HEADER = "x-bt-cache-ttl";

--- a/packages/proxy/src/util.ts
+++ b/packages/proxy/src/util.ts
@@ -22,6 +22,24 @@ export function parseAuthHeader(
   return parts[1];
 }
 
+export function parseNumericHeader(
+  headers: Record<string, string | string[] | undefined>,
+  headerKey: string,
+): number | null {
+  let value = headers[headerKey];
+  if (Array.isArray(value)) {
+    value = value[value.length - 1];
+  }
+
+  if (value !== undefined) {
+    try {
+      return parseInt(value, 10);
+    } catch (e) {}
+  }
+
+  return null;
+}
+
 // This is duplicated from app/utils/object.ts
 export function isObject(value: any): value is { [key: string]: any } {
   return value instanceof Object && !(value instanceof Array);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,10 +19,10 @@ importers:
         version: 2.3.3
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2
+        version: 4.3.2(typescript@5.3.3)
       vitest:
         specifier: ^2.1.3
-        version: 2.1.3
+        version: 2.1.3(@types/node@20.10.5)
 
   apis/cloudflare:
     dependencies:
@@ -224,6 +224,9 @@ importers:
       ai:
         specifier: 2.2.37
         version: 2.2.37(react@18.3.1)(solid-js@1.9.4)(svelte@4.2.19)(vue@3.5.13)
+      cache-control-parser:
+        specifier: ^2.0.6
+        version: 2.0.6
       eventsource-parser:
         specifier: ^1.1.1
         version: 1.1.2
@@ -3392,7 +3395,7 @@ packages:
       '@vitest/spy': 2.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.11
-      vite: 5.4.10
+      vite: 5.4.10(@types/node@20.10.5)
     dev: true
 
   /@vitest/pretty-format@2.1.3:
@@ -4100,6 +4103,10 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
     dev: true
+
+  /cache-control-parser@2.0.6:
+    resolution: {integrity: sha512-N4rxCk7V8NLfUVONXG0d7S4IyTQh3KEDW5k2I4CAcEUcMQCmVkfAMn37JSWfUQudiR883vDBy5XM5+TS2Xo7uQ==}
+    dev: false
 
   /call-bind@1.0.5:
     resolution: {integrity: sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==}
@@ -7965,17 +7972,6 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /tsconfck@3.1.4:
-    resolution: {integrity: sha512-kdqWFGVJqe+KGYvlSO9NIaWn9jT1Ny4oKVzAJsKii5eoE9snzTJzL4+MMVOMn+fikWGFmKEylcXL710V/kIPJQ==}
-    engines: {node: ^18 || >=20}
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dev: true
-
   /tsconfck@3.1.4(typescript@5.3.3):
     resolution: {integrity: sha512-kdqWFGVJqe+KGYvlSO9NIaWn9jT1Ny4oKVzAJsKii5eoE9snzTJzL4+MMVOMn+fikWGFmKEylcXL710V/kIPJQ==}
     engines: {node: ^18 || >=20}
@@ -8367,27 +8363,6 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
-  /vite-node@2.1.3:
-    resolution: {integrity: sha512-I1JadzO+xYX887S39Do+paRePCKoiDrWRRjp9kkG5he0t7RXNvPAJPCQSJqbGN4uCrFFeS3Kj3sLqY8NMYBEdA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    dependencies:
-      cac: 6.7.14
-      debug: 4.3.7
-      pathe: 1.1.2
-      vite: 5.4.10
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
   /vite-node@2.1.3(@types/node@20.10.5):
     resolution: {integrity: sha512-I1JadzO+xYX887S39Do+paRePCKoiDrWRRjp9kkG5he0t7RXNvPAJPCQSJqbGN4uCrFFeS3Kj3sLqY8NMYBEdA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -8409,22 +8384,6 @@ packages:
       - terser
     dev: true
 
-  /vite-tsconfig-paths@4.3.2:
-    resolution: {integrity: sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==}
-    peerDependencies:
-      vite: '*'
-    peerDependenciesMeta:
-      vite:
-        optional: true
-    dependencies:
-      debug: 4.3.7
-      globrex: 0.1.2
-      tsconfck: 3.1.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /vite-tsconfig-paths@4.3.2(typescript@5.3.3):
     resolution: {integrity: sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==}
     peerDependencies:
@@ -8439,44 +8398,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
-
-  /vite@5.4.10:
-    resolution: {integrity: sha512-1hvaPshuPUtxeQ0hsVH3Mud0ZanOLwVTneA1EgbAM5LhaZEqyPWGRQ7BtaMvUrTDeEaC8pxtj6a6jku3x4z6SQ==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.4.47
-      rollup: 4.24.0
-    optionalDependencies:
-      fsevents: 2.3.3
     dev: true
 
   /vite@5.4.10(@types/node@20.10.5):
@@ -8516,62 +8437,6 @@ packages:
       rollup: 4.24.0
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
-
-  /vitest@2.1.3:
-    resolution: {integrity: sha512-Zrxbg/WiIvUP2uEzelDNTXmEMJXuzJ1kCpbDvaKByFA9MNeO95V+7r/3ti0qzJzrxdyuUw5VduN7k+D3VmVOSA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 2.1.3
-      '@vitest/ui': 2.1.3
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-    dependencies:
-      '@vitest/expect': 2.1.3
-      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(vite@5.4.10)
-      '@vitest/pretty-format': 2.1.3
-      '@vitest/runner': 2.1.3
-      '@vitest/snapshot': 2.1.3
-      '@vitest/spy': 2.1.3
-      '@vitest/utils': 2.1.3
-      chai: 5.1.2
-      debug: 4.3.7
-      magic-string: 0.30.11
-      pathe: 1.1.2
-      std-env: 3.7.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.1
-      tinypool: 1.0.1
-      tinyrainbow: 1.2.0
-      vite: 5.4.10
-      vite-node: 2.1.3
-      why-is-node-running: 2.3.0
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
     dev: true
 
   /vitest@2.1.3(@types/node@20.10.5):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,10 +19,10 @@ importers:
         version: 2.3.3
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.3.3)
+        version: 4.3.2
       vitest:
         specifier: ^2.1.3
-        version: 2.1.3(@types/node@20.10.5)
+        version: 2.1.3
 
   apis/cloudflare:
     dependencies:
@@ -227,6 +227,9 @@ importers:
       cache-control-parser:
         specifier: ^2.0.6
         version: 2.0.6
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       eventsource-parser:
         specifier: ^1.1.1
         version: 1.1.2
@@ -3395,7 +3398,7 @@ packages:
       '@vitest/spy': 2.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.11
-      vite: 5.4.10(@types/node@20.10.5)
+      vite: 5.4.10
     dev: true
 
   /@vitest/pretty-format@2.1.3:
@@ -4364,6 +4367,10 @@ packages:
   /data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
     dev: true
+
+  /date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+    dev: false
 
   /debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -7972,6 +7979,17 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
+  /tsconfck@3.1.4:
+    resolution: {integrity: sha512-kdqWFGVJqe+KGYvlSO9NIaWn9jT1Ny4oKVzAJsKii5eoE9snzTJzL4+MMVOMn+fikWGFmKEylcXL710V/kIPJQ==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dev: true
+
   /tsconfck@3.1.4(typescript@5.3.3):
     resolution: {integrity: sha512-kdqWFGVJqe+KGYvlSO9NIaWn9jT1Ny4oKVzAJsKii5eoE9snzTJzL4+MMVOMn+fikWGFmKEylcXL710V/kIPJQ==}
     engines: {node: ^18 || >=20}
@@ -8363,6 +8381,27 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
+  /vite-node@2.1.3:
+    resolution: {integrity: sha512-I1JadzO+xYX887S39Do+paRePCKoiDrWRRjp9kkG5he0t7RXNvPAJPCQSJqbGN4uCrFFeS3Kj3sLqY8NMYBEdA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.7
+      pathe: 1.1.2
+      vite: 5.4.10
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
   /vite-node@2.1.3(@types/node@20.10.5):
     resolution: {integrity: sha512-I1JadzO+xYX887S39Do+paRePCKoiDrWRRjp9kkG5he0t7RXNvPAJPCQSJqbGN4uCrFFeS3Kj3sLqY8NMYBEdA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -8384,6 +8423,22 @@ packages:
       - terser
     dev: true
 
+  /vite-tsconfig-paths@4.3.2:
+    resolution: {integrity: sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dependencies:
+      debug: 4.3.7
+      globrex: 0.1.2
+      tsconfck: 3.1.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /vite-tsconfig-paths@4.3.2(typescript@5.3.3):
     resolution: {integrity: sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==}
     peerDependencies:
@@ -8398,6 +8453,44 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+    dev: true
+
+  /vite@5.4.10:
+    resolution: {integrity: sha512-1hvaPshuPUtxeQ0hsVH3Mud0ZanOLwVTneA1EgbAM5LhaZEqyPWGRQ7BtaMvUrTDeEaC8pxtj6a6jku3x4z6SQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.4.47
+      rollup: 4.24.0
+    optionalDependencies:
+      fsevents: 2.3.3
     dev: true
 
   /vite@5.4.10(@types/node@20.10.5):
@@ -8437,6 +8530,62 @@ packages:
       rollup: 4.24.0
     optionalDependencies:
       fsevents: 2.3.3
+    dev: true
+
+  /vitest@2.1.3:
+    resolution: {integrity: sha512-Zrxbg/WiIvUP2uEzelDNTXmEMJXuzJ1kCpbDvaKByFA9MNeO95V+7r/3ti0qzJzrxdyuUw5VduN7k+D3VmVOSA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.3
+      '@vitest/ui': 2.1.3
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@vitest/expect': 2.1.3
+      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(vite@5.4.10)
+      '@vitest/pretty-format': 2.1.3
+      '@vitest/runner': 2.1.3
+      '@vitest/snapshot': 2.1.3
+      '@vitest/spy': 2.1.3
+      '@vitest/utils': 2.1.3
+      chai: 5.1.2
+      debug: 4.3.7
+      magic-string: 0.30.11
+      pathe: 1.1.2
+      std-env: 3.7.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.1
+      tinypool: 1.0.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.10
+      vite-node: 2.1.3
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
     dev: true
 
   /vitest@2.1.3(@types/node@20.10.5):


### PR DESCRIPTION
## Requests
Requests can specify cache behavior and TTL using a limited set of [Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) directives. The following request directives are implemented:
* `no-cache`,`no-store` (these are treated as equivalent)
* `max-age` (up to 90 days)

The `x-bt-cache-ttl` header is also added to request a specific TTL (between 1 second and 90 days)

Note that setting the Cache-Control header will override the behavior of the `x-bt-use-cache` header.  

### Examples:
* Request with `x-bt-cache-ttl: 604800` is equivalent to `x-bt-use-cache: auto`
* Request with `Cache-control: no-cache` is equivalent to `x-bt-use-cache: never`
* Request with `Cache-control: no-store` is equivalent to `x-bt-use-cache: never`
* Request with `Cache-control: max-age=0` is equivalent to `x-bt-use-cache: never`
* Request with `x-bt-cache-ttl: 77600` will cache requests on supported paths where temperature is 0 or a seed is set for 90 days
* Request with `x-bt-cache-ttl: 77600`, `Cache-control: max-age=60` will cache all requests on supported paths for 90 days but will only use already cached results <= 60 seconds old
* Request with `x-bt-cache-ttl: 77600`, `x-bt-use-cache: always` will cache all requests on supported paths for 90 days

### Unimplemented request directives
  - `max-stale`, `stale-if-error`: Might be useful to implement if the origin API is down
  - `min-fresh`, `no-transform`, `only-if-cached`: Not relevant for a caching proxy

## Responses
The proxy will respond with basic information about the age of cached data using the `max-age` directive and the [Age](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Age) header. If the request was not placed into the cache, these values will not be in the response.

### Examples:
* Response with `x-bt-cached: MISS`, `Cache-control: max-age=776000`, and `Age: 0` missed the cache and was just retrieved from the provider and cached for 90 days
* Response with `x-bt-cached: MISS` missed the cache and was not cached
* Response with `x-bt-cached: HIT`, `Cache-control: max-age=60`, and `Age: 15` was retrieved from the cache and will be cached for another 45 seconds

### Unimplemented response directives
  - `no-cache`, `no-store`, `must-revalidate`, `proxy-revalidate`, `must-understand`, `private`, `public`, `stale-while-revalidate`, `stale-if-error`: Proxy is agnostic to how consumers handle data
  - `s-maxage`: Ignored since proxy doesn't support shared caching
  - `immutable`: Maybe respond with this directive if the proxy keeps the always/auto/never cache semantics
  
- [ ] Followup PR to refactor `timestamp` into non-optional property of cached data once cache is cycled