### PR TITLE
[chore] Add Gemini 2.5 Pro Preview to list of models

### DIFF
--- a/packages/proxy/schema/models.ts
+++ b/packages/proxy/schema/models.ts
@@ -1830,16 +1830,6 @@ export const AvailableModels: { [name: string]: ModelSpec } = {
     multimodal: true,
     parent: "gemini-1.5-pro",
   },
-  // Gemini experimental.
-  "gemini-2.5-pro-exp-03-25": {
-    format: "google",
-    flavor: "chat",
-    input_cost_per_mil_tokens: 0,
-    output_cost_per_mil_tokens: 0,
-    multimodal: true,
-    experimental: true,
-    displayName: "Gemini 2.5 Pro Experimental",
-  },
   "gemini-2.5-pro-preview-03-25": {
     format: "google",
     flavor: "chat",
@@ -1848,6 +1838,15 @@ export const AvailableModels: { [name: string]: ModelSpec } = {
     multimodal: true,
     experimental: false,
     displayName: "Gemini 2.5 Pro Preview",
+  },
+  "gemini-2.5-pro-exp-03-25": {
+    format: "google",
+    flavor: "chat",
+    input_cost_per_mil_tokens: 0,
+    output_cost_per_mil_tokens: 0,
+    multimodal: true,
+    experimental: true,
+    displayName: "Gemini 2.5 Pro Experimental",
   },
   "gemini-2.0-flash-exp": {
     format: "google",

--- a/packages/proxy/schema/models.ts
+++ b/packages/proxy/schema/models.ts
@@ -1840,6 +1840,15 @@ export const AvailableModels: { [name: string]: ModelSpec } = {
     experimental: true,
     displayName: "Gemini 2.5 Pro Experimental",
   },
+  "gemini-2.5-pro-preview-03-25": {
+    format: "google",
+    flavor: "chat",
+    input_cost_per_mil_tokens: 1.25,
+    output_cost_per_mil_tokens: 10,
+    multimodal: true,
+    experimental: false,
+    displayName: "Gemini 2.5 Pro Preview",
+  },
   "gemini-2.0-flash-exp": {
     format: "google",
     flavor: "chat",


### PR DESCRIPTION
This PR adds Gemini 2.5 Pro Preview (which has higher rate limits than the experimental version) to the Braintrust AI proxy.