### PR TITLE
handle o1_like model calls

### DIFF
--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -1657,8 +1657,11 @@ async function fetchOpenAI(
   // TODO: Ideally this is encapsulated as some advanced per-model config
   // or mapping, but for now, let's just map it manually.
   const isO1Like =
-    typeof bodyData.model === "string" &&
-    (bodyData.model.startsWith("o1") || bodyData.model.startsWith("o3-mini"));
+    bodyData.o1_like ||
+    (typeof bodyData.model === "string" &&
+      (bodyData.model.startsWith("o1") ||
+        bodyData.model.startsWith("o3") ||
+        bodyData.model.startsWith("o4")));
   if (isO1Like) {
     if (!isEmpty(bodyData.max_tokens)) {
       bodyData.max_completion_tokens = bodyData.max_tokens;


### PR DESCRIPTION
need to ensure `max_tokens` gets mapped to `max_completion_tokens` for the entire o* line of models