### PR TITLE
increase req max tokens

### DIFF
--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -2082,7 +2082,7 @@ async function fetchAnthropicChatCompletions({
 
   messages = flattenAnthropicMessages(messages);
   const params: Record<string, unknown> = {
-    max_tokens: 1024, // Required param
+    max_tokens: 4096, // Required param
     ...translateParams("anthropic", oaiParams),
   };
 


### PR DESCRIPTION
The minimum an anthropic model can produce now is 4096, so let's increase this default.