### PR TITLE
Remove Anthropic -latest models

### DIFF
--- a/packages/proxy/schema/models.ts
+++ b/packages/proxy/schema/models.ts
@@ -612,7 +612,7 @@ export const AvailableModels: { [name: string]: ModelSpec } = {
     output_cost_per_mil_tokens: 75,
     parent: "claude-3-opus-latest",
   },
-  "claude-3-sonnet-latest": {
+  "claude-3-sonnet-20240229": {
     format: "anthropic",
     flavor: "chat",
     multimodal: true,
@@ -620,29 +620,13 @@ export const AvailableModels: { [name: string]: ModelSpec } = {
     output_cost_per_mil_tokens: 15,
     displayName: "Claude 3 Sonnet",
   },
-  "claude-3-sonnet-20240229": {
-    format: "anthropic",
-    flavor: "chat",
-    multimodal: true,
-    input_cost_per_mil_tokens: 3,
-    output_cost_per_mil_tokens: 15,
-    parent: "claude-3-sonnet-latest",
-  },
-  "claude-3-haiku-latest": {
-    format: "anthropic",
-    flavor: "chat",
-    multimodal: true,
-    input_cost_per_mil_tokens: 0.25,
-    output_cost_per_mil_tokens: 1.25,
-    displayName: "Claude 3 Haiku",
-  },
   "claude-3-haiku-20240307": {
     format: "anthropic",
     flavor: "chat",
     multimodal: true,
     input_cost_per_mil_tokens: 0.25,
     output_cost_per_mil_tokens: 1.25,
-    parent: "claude-3-haiku-latest",
+    displayName: "Claude 3 Haiku",
   },
   // Anthropic deprecated.
   "claude-instant-1.2": {


### PR DESCRIPTION
Anthropic doesn't have the `-latest` aliases for these two models anymore, so we should just use the versioned names

https://docs.anthropic.com/en/docs/about-claude/models/all-models