### PR TITLE
Nicer errors for persistent 400-class errors

### DIFF
--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -1061,8 +1061,9 @@ async function fetchModelLoop(
         cachePut,
       );
       secretName = secret.name;
-      // If the response is ok, we can break out of the loop.
-      if (proxyResponse.response.ok) {
+      // If the response is ok or a 400 (Bad Request), we can break out of the loop and return
+      // the exact response.
+      if (proxyResponse.response.ok || proxyResponse.response.status === 400) {
         errorHttpCode = undefined;
         errorHttpHeaders = new Headers();
         break;

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -1073,7 +1073,7 @@ async function fetchModelLoop(
           !TRY_ANOTHER_ENDPOINT_ERROR_CODES.includes(
             proxyResponse.response.status,
           )) ||
-        // Or we've exhausted the set of secrets
+        // Or we have not exhausted the set of secrets
         i < secrets.length - 1
         // Then mark this as an error response, and fall through to the error handling logic.
       ) {

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -106,7 +106,6 @@ import {
   ProxyBadRequestError,
   writeToReadable,
 } from "./util";
-import { f } from "msw/lib/core/HttpResponse-DzeJL_i8";
 
 type CachedMetadata = {
   cached_at: Date;
@@ -1049,7 +1048,6 @@ async function fetchModelLoop(
     let errorHttpHeaders = new Headers();
     endpointCalls.add(1, loggableInfo);
     try {
-      console.log("fetching model", modelSpec, method, endpointUrl);
       proxyResponse = await fetchModel(
         modelSpec,
         method,
@@ -1075,9 +1073,10 @@ async function fetchModelLoop(
           !TRY_ANOTHER_ENDPOINT_ERROR_CODES.includes(
             proxyResponse.response.status,
           )) ||
+        // Or we've exhausted the set of secrets
         i < secrets.length - 1
+        // Then mark this as an error response, and fall through to the error handling logic.
       ) {
-        console.log("setting httpCode", proxyResponse.response.status);
         errorHttpCode = proxyResponse.response.status;
         errorHttpHeaders = proxyResponse.response.headers;
       }


### PR DESCRIPTION
We were previously propagating these error responses directly, but now clarify that they are from the AI provider itself.