### PR TITLE
docs(cloudflare): fix the syntax for the wrangler kv command

### DIFF
--- a/apis/cloudflare/README.md
+++ b/apis/cloudflare/README.md
@@ -22,7 +22,7 @@ pnpm build
 Then, you return to this directory and setup a KV namespace for the proxy:
 
 ```bash copy
-wrangler kv:namespace create ai_proxy
+wrangler kv namespace create ai_proxy
 ```
 
 Record the ID of the namespace that you just created. Then, copy `wrangler-template.toml` to


### PR DESCRIPTION
Latest wrangler requires a space between the command:
```sh
 wrangler kv                     🗂️  Manage Workers KV Namespaces
```
->
```sh
wrangler kv --help
wrangler kv

🗂️  Manage Workers KV Namespaces

COMMANDS
  wrangler kv namespace  Interact with your Workers KV Namespaces
```