### PR TITLE
Eliminate dependency on `@braintrust/core`.

### DIFF
--- a/packages/proxy/generated_types.json
+++ b/packages/proxy/generated_types.json
@@ -403,6 +403,128 @@
           "preview_name"
         ]
       },
+      "AsyncScoringControl": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "score_update"
+                ]
+              },
+              "token": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "token"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "state_override"
+                ]
+              },
+              "state": {
+                "$ref": "#/components/schemas/AsyncScoringState"
+              }
+            },
+            "required": [
+              "kind",
+              "state"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "state_force_reselect"
+                ]
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "state_enabled_force_rescore"
+                ]
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          }
+        ]
+      },
+      "AsyncScoringState": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "enabled"
+                ]
+              },
+              "token": {
+                "type": "string"
+              },
+              "function_ids": {
+                "type": "array",
+                "items": {},
+                "minItems": 1
+              },
+              "skip_logging": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "status",
+              "token",
+              "function_ids"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "disabled"
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          {
+            "type": "null"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
       "AttachmentReference": {
         "oneOf": [
           {
@@ -1624,7 +1746,7 @@
             "description": "Whether this span is a root span"
           },
           "origin": {
-            "$ref": "#/components/schemas/ObjectReference"
+            "$ref": "#/components/schemas/ObjectReferenceNullish"
           }
         },
         "required": [
@@ -2001,7 +2123,7 @@
             "description": "Whether this span is a root span"
           },
           "origin": {
-            "$ref": "#/components/schemas/ObjectReference"
+            "$ref": "#/components/schemas/ObjectReferenceNullish"
           }
         },
         "required": [
@@ -3565,6 +3687,52 @@
         ]
       },
       "ObjectReference": {
+        "type": "object",
+        "properties": {
+          "object_type": {
+            "type": "string",
+            "enum": [
+              "project_logs",
+              "experiment",
+              "dataset",
+              "prompt",
+              "function",
+              "prompt_session"
+            ],
+            "description": "Type of the object the event is originating from."
+          },
+          "object_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the object the event is originating from."
+          },
+          "id": {
+            "type": "string",
+            "description": "ID of the original event."
+          },
+          "_xact_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Transaction ID of the original event."
+          },
+          "created": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Created timestamp of the original event. Used to help sort in the UI"
+          }
+        },
+        "required": [
+          "object_type",
+          "object_id",
+          "id"
+        ],
+        "description": "Reference to the original object and event this was copied from."
+      },
+      "ObjectReferenceNullish": {
         "type": [
           "object",
           "null"
@@ -4250,7 +4418,7 @@
             "$ref": "#/components/schemas/SpanAttributes"
           },
           "origin": {
-            "$ref": "#/components/schemas/ObjectReference"
+            "$ref": "#/components/schemas/ObjectReferenceNullish"
           }
         },
         "required": [
@@ -5532,6 +5700,66 @@
           }
         ]
       },
+      "ServiceToken": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for the service token"
+          },
+          "created": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "Date of service token creation"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the service token"
+          },
+          "preview_name": {
+            "type": "string"
+          },
+          "service_account_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Unique identifier for the service token"
+          },
+          "service_account_email": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The service account email (not routable)"
+          },
+          "service_account_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The service account name"
+          },
+          "org_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Unique identifier for the organization"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "preview_name"
+        ]
+      },
       "SpanAttributes": {
         "type": [
           "object",
@@ -5666,7 +5894,7 @@
           "origin": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/ObjectReference"
+                "$ref": "#/components/schemas/ObjectReferenceNullish"
               },
               {
                 "description": "The origin of the event"
@@ -5909,7 +6137,8 @@
         "properties": {
           "search": {
             "$ref": "#/components/schemas/ViewDataSearch"
-          }
+          },
+          "custom_charts": {}
         },
         "description": "The view definition"
       },
@@ -6269,7 +6498,7 @@
     "license": {
       "name": "Apache 2.0"
     },
-    "x-internal-git-sha": "4306890cf9601749445df7e191651aae5a6d9242"
+    "x-internal-git-sha": "be4abfadd22d7196ff6356c7f3fb655aac3fc933"
   },
   "paths": {},
   "webhooks": {}

--- a/packages/proxy/schema/models.ts
+++ b/packages/proxy/schema/models.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { _urljoin } from "@braintrust/core";
+import { _urljoin } from "../src/util";
 
 export const PromptInputs = ["chat", "completion"] as const;
 export type PromptInputType = (typeof PromptInputs)[number];

--- a/packages/proxy/src/generated_types.ts
+++ b/packages/proxy/src/generated_types.ts
@@ -1,4 +1,4 @@
-// Auto-generated file (internal git SHA 4306890cf9601749445df7e191651aae5a6d9242) -- do not modify
+// Auto-generated file (internal git SHA be4abfadd22d7196ff6356c7f3fb655aac3fc933) -- do not modify
 
 import { z } from "zod";
 
@@ -128,6 +128,25 @@ export const ApiKey = z.object({
   org_id: z.union([z.string(), z.null()]).optional(),
 });
 export type ApiKeyType = z.infer<typeof ApiKey>;
+export const AsyncScoringState = z.union([
+  z.object({
+    status: z.literal("enabled"),
+    token: z.string(),
+    function_ids: z.array(z.unknown()).min(1),
+    skip_logging: z.union([z.boolean(), z.null()]).optional(),
+  }),
+  z.object({ status: z.literal("disabled") }),
+  z.null(),
+  z.null(),
+]);
+export type AsyncScoringStateType = z.infer<typeof AsyncScoringState>;
+export const AsyncScoringControl = z.union([
+  z.object({ kind: z.literal("score_update"), token: z.string() }),
+  z.object({ kind: z.literal("state_override"), state: AsyncScoringState }),
+  z.object({ kind: z.literal("state_force_reselect") }),
+  z.object({ kind: z.literal("state_enabled_force_rescore") }),
+]);
+export type AsyncScoringControlType = z.infer<typeof AsyncScoringControl>;
 export const BraintrustAttachmentReference = z.object({
   type: z.literal("braintrust_attachment"),
   filename: z.string().min(1),
@@ -384,7 +403,7 @@ export const Dataset = z.object({
     .optional(),
 });
 export type DatasetType = z.infer<typeof Dataset>;
-export const ObjectReference = z.union([
+export const ObjectReferenceNullish = z.union([
   z.object({
     object_type: z.enum([
       "project_logs",
@@ -401,7 +420,7 @@ export const ObjectReference = z.union([
   }),
   z.null(),
 ]);
-export type ObjectReferenceType = z.infer<typeof ObjectReference>;
+export type ObjectReferenceNullishType = z.infer<typeof ObjectReferenceNullish>;
 export const DatasetEvent = z.object({
   id: z.string(),
   _xact_id: z.string(),
@@ -424,7 +443,7 @@ export const DatasetEvent = z.object({
   span_id: z.string(),
   root_span_id: z.string(),
   is_root: z.union([z.boolean(), z.null()]).optional(),
-  origin: ObjectReference.optional(),
+  origin: ObjectReferenceNullish.optional(),
 });
 export type DatasetEventType = z.infer<typeof DatasetEvent>;
 export const EnvVar = z.object({
@@ -529,7 +548,7 @@ export const ExperimentEvent = z.object({
   root_span_id: z.string(),
   span_attributes: SpanAttributes.optional(),
   is_root: z.union([z.boolean(), z.null()]).optional(),
-  origin: ObjectReference.optional(),
+  origin: ObjectReferenceNullish.optional(),
 });
 export type ExperimentEventType = z.infer<typeof ExperimentEvent>;
 export const ExtendedSavedFunctionId = z.union([
@@ -965,6 +984,21 @@ export const MessageRole = z.enum([
   "developer",
 ]);
 export type MessageRoleType = z.infer<typeof MessageRole>;
+export const ObjectReference = z.object({
+  object_type: z.enum([
+    "project_logs",
+    "experiment",
+    "dataset",
+    "prompt",
+    "function",
+    "prompt_session",
+  ]),
+  object_id: z.string().uuid(),
+  id: z.string(),
+  _xact_id: z.union([z.string(), z.null()]).optional(),
+  created: z.union([z.string(), z.null()]).optional(),
+});
+export type ObjectReferenceType = z.infer<typeof ObjectReference>;
 export const OnlineScoreConfig = z.union([
   z.object({
     sampling_rate: z.number().gte(0).lte(1),
@@ -1119,7 +1153,7 @@ export const ProjectLogsEvent = z.object({
   root_span_id: z.string(),
   is_root: z.union([z.boolean(), z.null()]).optional(),
   span_attributes: SpanAttributes.optional(),
-  origin: ObjectReference.optional(),
+  origin: ObjectReferenceNullish.optional(),
 });
 export type ProjectLogsEventType = z.infer<typeof ProjectLogsEvent>;
 export const ProjectScoreType = z.enum([
@@ -1288,6 +1322,17 @@ export const RunEval = z.object({
   tags: z.array(z.string()).optional(),
 });
 export type RunEvalType = z.infer<typeof RunEval>;
+export const ServiceToken = z.object({
+  id: z.string().uuid(),
+  created: z.union([z.string(), z.null()]).optional(),
+  name: z.string(),
+  preview_name: z.string(),
+  service_account_id: z.union([z.string(), z.null()]).optional(),
+  service_account_email: z.union([z.string(), z.null()]).optional(),
+  service_account_name: z.union([z.string(), z.null()]).optional(),
+  org_id: z.union([z.string(), z.null()]).optional(),
+});
+export type ServiceTokenType = z.infer<typeof ServiceToken>;
 export const SpanIFrame = z.object({
   id: z.string().uuid(),
   project_id: z.string().uuid(),
@@ -1308,7 +1353,7 @@ export type SSEConsoleEventDataType = z.infer<typeof SSEConsoleEventData>;
 export const SSEProgressEventData = z.object({
   id: z.string(),
   object_type: FunctionObjectType,
-  origin: ObjectReference.and(z.unknown()).optional(),
+  origin: ObjectReferenceNullish.and(z.unknown()).optional(),
   format: FunctionFormat,
   output_type: FunctionOutputType,
   name: z.string(),
@@ -1357,7 +1402,7 @@ export const ViewDataSearch = z.union([
 ]);
 export type ViewDataSearchType = z.infer<typeof ViewDataSearch>;
 export const ViewData = z.union([
-  z.object({ search: ViewDataSearch }).partial(),
+  z.object({ search: ViewDataSearch, custom_charts: z.unknown() }).partial(),
   z.null(),
 ]);
 export type ViewDataType = z.infer<typeof ViewData>;

--- a/packages/proxy/src/util.test.ts
+++ b/packages/proxy/src/util.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { parseFileMetadataFromUrl } from "./util";
+import { parseFileMetadataFromUrl, _urljoin } from "./util";
 
 describe("parseFileMetadataFromUrl", () => {
   test("handles basic URLs", () => {
@@ -203,4 +203,22 @@ describe("parseFileMetadataFromUrl", () => {
       url: expect.any(URL),
     });
   });
+});
+
+test("_urljoin", () => {
+  expect(_urljoin("/a", "/b", "/c")).toBe("a/b/c");
+  expect(_urljoin("a", "b", "c")).toBe("a/b/c");
+  expect(_urljoin("/a/", "/b/", "/c/")).toBe("a/b/c/");
+  expect(_urljoin("a/", "b/", "c/")).toBe("a/b/c/");
+  expect(_urljoin("", "a", "b", "c")).toBe("a/b/c");
+  expect(_urljoin("a", "", "c")).toBe("a/c");
+  expect(_urljoin("/", "a", "b", "c")).toBe("a/b/c");
+  expect(_urljoin("http://example.com", "api", "v1")).toBe(
+    "http://example.com/api/v1",
+  );
+  expect(_urljoin("http://example.com/", "/api/", "/v1/")).toBe(
+    "http://example.com/api/v1/",
+  );
+  expect(_urljoin()).toBe("");
+  expect(_urljoin("a")).toBe("a");
 });

--- a/packages/proxy/src/util.ts
+++ b/packages/proxy/src/util.ts
@@ -167,3 +167,15 @@ export function _urljoin(...parts: string[]): string {
     .filter((x) => x.trim() !== "")
     .join("/");
 }
+
+export type ExperimentLogPartialArgs = Partial<{
+  output: unknown;
+  expected: unknown;
+  error: unknown;
+  tags: string[];
+  scores: Record<string, number | null>;
+  metadata: Record<string, unknown>;
+  metrics: Record<string, unknown>;
+  datasetRecordId: string;
+  span_attributes: Record<string, unknown>;
+}>;

--- a/packages/proxy/src/util.ts
+++ b/packages/proxy/src/util.ts
@@ -158,3 +158,12 @@ export const writeToReadable = (response: string) => {
     },
   });
 };
+
+export function _urljoin(...parts: string[]): string {
+  return parts
+    .map((x, i) =>
+      x.replace(/^\//, "").replace(i < parts.length - 1 ? /\/$/ : "", ""),
+    )
+    .filter((x) => x.trim() !== "")
+    .join("/");
+}

--- a/packages/proxy/src/util.ts
+++ b/packages/proxy/src/util.ts
@@ -167,15 +167,3 @@ export function _urljoin(...parts: string[]): string {
     .filter((x) => x.trim() !== "")
     .join("/");
 }
-
-export type ExperimentLogPartialArgs = Partial<{
-  output: unknown;
-  expected: unknown;
-  error: unknown;
-  tags: string[];
-  scores: Record<string, number | null>;
-  metadata: Record<string, unknown>;
-  metrics: Record<string, unknown>;
-  datasetRecordId: string;
-  span_attributes: Record<string, unknown>;
-}>;


### PR DESCRIPTION
We really only need the `_urljoin` function, which is simple enough to just copy-paste over.