### PR TITLE
Revert a small setStatusCode change

### DIFF
--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -569,8 +569,8 @@ export async function proxyV1({
     );
     stream = proxyStream;
 
-    setStatusCode(proxyResponse.status);
     if (!proxyResponse.ok) {
+      setStatusCode(proxyResponse.status);
       responseFailed = true;
     }
 


### PR DESCRIPTION
I did this [during testing](https://github.com/braintrustdata/braintrust-proxy/pull/302/files#diff-f9467ab4882d85829b5ae101d098958cb1f6dafcb726ed6baee1dc26a5e34e9bR572-L573), but I didn't add coverage to test what would be difference. Because it's on the critical path but not for the changes https://github.com/braintrustdata/braintrust-proxy/pull/302 I'd like to revert this change and come back to it later. 

With the revert the tests could see an undefined status code (for the 200 response case), but that's the previous behavior before my change.