### PR TITLE
Filter out Mistral thinking chunks in streaming responses

### DIFF
--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -2008,6 +2008,36 @@ async function fetchOpenAI(
     }
   }
 
+  if (secret.type === "mistral" && stream && bodyData?.stream) {
+    // Mistral would return a lot of thinking chunks, in a specific format not compatible with OpenAI's streaming format
+    // e.g. {"id":"426a1c8c62704d959621a94c1ff0cffb","object":"chat.completion.chunk","created":1759752086,"model":"magistral-medium-latest","choices":[{"index":0,"delta":{"content":[{"type":"thinking","thinking":[{"type":"text","text":" by 2 is"}]}]},"finish_reason":null}]}
+    // We need to discard these chunks
+    stream = stream.pipeThrough(
+      createEventStreamTransformer((data) => {
+        const chunk: ChatCompletionChunk = JSON.parse(data);
+        if (
+          chunk.choices?.some((choice) => {
+            const content = choice.delta?.content;
+            if (Array.isArray(content)) {
+              return content.some((item: any) => item.type === "thinking");
+            }
+            return false;
+          })
+        ) {
+          return {
+            data: null,
+            finished: false,
+          };
+        }
+
+        return {
+          data: data,
+          finished: false,
+        };
+      }),
+    );
+  }
+
   return {
     stream,
     response: proxyResponse,


### PR DESCRIPTION
### What?
Discard chunks with type: "thinking" from Mistral streaming responses to prevent internal reasoning content from being returned to users.

### Why
Fix this bug: https://braintrustdata.slack.com/archives/C05EHT9421Y/p1758725439305639 
<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/68862db9-852f-46cd-8f18-9054434fa0df" />

### Comments

- We should likely refactor the whole fetchOpenAI function as it has lots of if / switch statements making it really hard to navigate all the branches
- I didn't find tests that tests those code paths
- The new gateway proxy will be the opportunity to do so
