### PR TITLE
add glm-5 to model_list.json

### DIFF
--- a/packages/proxy/schema/index.ts
+++ b/packages/proxy/schema/index.ts
@@ -467,6 +467,7 @@ export const AvailableEndpointTypes: { [name: string]: ModelEndpointType[] } = {
   "fireworks_ai/accounts/fireworks/models/deepseek-v3p1": ["fireworks"],
   "fireworks_ai/accounts/fireworks/models/firefunction-v2": ["fireworks"],
   "fireworks_ai/accounts/fireworks/models/glm-4p5": ["fireworks"],
+  "fireworks_ai/accounts/fireworks/models/glm-5": ["fireworks"],
   "fireworks_ai/accounts/fireworks/models/glm-4p5-air": ["fireworks"],
   "fireworks_ai/accounts/fireworks/models/gpt-oss-120b": ["fireworks"],
   "fireworks_ai/accounts/fireworks/models/gpt-oss-20b": ["fireworks"],

--- a/packages/proxy/schema/model_list.json
+++ b/packages/proxy/schema/model_list.json
@@ -5879,6 +5879,18 @@
       "fireworks"
     ]
   },
+  "fireworks_ai/accounts/fireworks/models/glm-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 3.2,
+    "max_input_tokens": 202752,
+    "max_output_tokens": 128000,
+    "reasoning": true,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
   "accounts/fireworks/models/kimi-k2p5": {
     "format": "openai",
     "flavor": "chat",


### PR DESCRIPTION
User would like to add the glm-5 model to the proxy list for Fireworks.

Pulled cost and max_input_tokens from:
[https://fireworks.ai/models/fireworks/glm-5 https://docs.z.ai/guides/llm/glm-5 ](https://fireworks.ai/models/fireworks/glm-5%E2%80%A8https://docs.z.ai/guides/llm/glm-5%E2%80%A8)

Pulled max_output_tokens from:
https://docs.z.ai/guides/llm/glm-5