### PR TITLE
add grok 4.2 models

### DIFF
--- a/packages/proxy/schema/index.ts
+++ b/packages/proxy/schema/index.ts
@@ -427,6 +427,8 @@ export const AvailableEndpointTypes: { [name: string]: ModelEndpointType[] } = {
   "amazon.nova-pro-v1:0": ["bedrock"],
   "amazon.nova-lite-v1:0": ["bedrock"],
   "amazon.nova-micro-v1:0": ["bedrock"],
+  "grok-4.20-0309-reasoning": ["xAI"],
+  "grok-4.20-0309-non-reasoning": ["xAI"],
   "grok-4-1-fast": ["xAI"],
   "grok-4-1-fast-reasoning": ["xAI"],
   "grok-4-1-fast-reasoning-latest": ["xAI"],

--- a/packages/proxy/schema/model_list.json
+++ b/packages/proxy/schema/model_list.json
@@ -3543,6 +3543,32 @@
       "vertex"
     ]
   },
+  "grok-4.20-0309-reasoning": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.0,
+    "output_cost_per_mil_tokens": 6.0,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 2000000,
+    "max_output_tokens": 2000000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+    "grok-4.20-0309-non-reasoning": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.0,
+    "output_cost_per_mil_tokens": 6.0,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 2000000,
+    "max_output_tokens": 2000000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
   "grok-4-1-fast-reasoning-latest": {
     "format": "openai",
     "flavor": "chat",


### PR DESCRIPTION
User would like the grok 4.2 models added:
- [grok-4.20-0309-reasoning](https://docs.x.ai/developers/models/grok-4.20-0309-reasoning?cluster=eu-west-1)
- [grok-4.20-0309-non-reasoning](https://docs.x.ai/developers/models/grok-4.20-0309-non-reasoning?cluster=eu-west-1)