### PR TITLE
sync-models: add --major-only heuristic

### DIFF
--- a/packages/proxy/schema/index.ts
+++ b/packages/proxy/schema/index.ts
@@ -447,6 +447,19 @@ export const AvailableEndpointTypes: { [name: string]: ModelEndpointType[] } = {
   "grok-2-1212": ["xAI"],
   "grok-vision-beta": ["xAI"],
   "grok-beta": ["xAI"],
+  "gemini-flash-latest": ["google"],
+  "gemini-flash-lite-latest": ["google"],
+  "gemini-pro-latest": ["google"],
+  "gpt-5.2-pro-2025-12-11": ["openai", "azure"],
+  "gpt-5.4-pro-2026-03-05": ["openai", "azure"],
+  "vertex_ai/gemini-3-flash-preview": ["vertex"],
+  "vertex_ai/gemini-3-pro-preview": ["vertex"],
+  "vertex_ai/gemini-3.1-pro-preview": ["vertex"],
+  "vertex_ai/gemini-3.1-pro-preview-customtools": ["vertex"],
+  "vertex_ai/gemini-2.5-flash-image": ["vertex"],
+  "vertex_ai/gemini-3-pro-image-preview": ["vertex"],
+  "vertex_ai/gemini-3.1-flash-image-preview": ["vertex"],
+  "vertex_ai/gemini-3.1-flash-lite-preview": ["vertex"],
   "fireworks-ai-4.1b-to-16b": ["fireworks"],
   "fireworks-ai-56b-to-176b": ["fireworks"],
   "fireworks-ai-above-16b": ["fireworks"],
@@ -607,7 +620,9 @@ export const AvailableEndpointTypes: { [name: string]: ModelEndpointType[] } = {
   "deepseek-ai/DeepSeek-V3-0324": ["baseten"],
   "publishers/moonshotai/models/kimi-k2.5": ["azure"],
   "fireworks_ai/accounts/fireworks/models/glm-4p7": ["fireworks"],
-  "fireworks_ai/accounts/fireworks/models/qwen3-vl-30b-a3b-instruct": ["fireworks"]
+  "fireworks_ai/accounts/fireworks/models/qwen3-vl-30b-a3b-instruct": [
+    "fireworks",
+  ],
 };
 
 export function getModelEndpointTypes(model: string): ModelEndpointType[] {

--- a/packages/proxy/schema/model_list.json
+++ b/packages/proxy/schema/model_list.json
@@ -6654,5 +6654,212 @@
     "available_providers": [
       "fireworks"
     ]
+  },
+  "gemini-flash-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 2.5,
+    "input_cache_read_cost_per_mil_tokens": 0.03,
+    "reasoning": true,
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "google"
+    ]
+  },
+  "gemini-flash-lite-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "input_cache_read_cost_per_mil_tokens": 0.01,
+    "reasoning": true,
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "google"
+    ]
+  },
+  "gemini-pro-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "reasoning": true,
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "google"
+    ]
+  },
+  "gpt-5.2-pro-2025-12-11": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 21,
+    "output_cost_per_mil_tokens": 168,
+    "reasoning": true,
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.4-pro-2026-03-05": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 30,
+    "output_cost_per_mil_tokens": 180,
+    "input_cache_read_cost_per_mil_tokens": 3,
+    "reasoning": true,
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "vertex_ai/gemini-2.5-flash-image": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 2.5,
+    "input_cache_read_cost_per_mil_tokens": 0.03,
+    "supported_regions": [
+      "global",
+      "europe-central2",
+      "europe-north1",
+      "europe-southwest1",
+      "europe-west1",
+      "europe-west4",
+      "europe-west8",
+      "us-central1",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-south1",
+      "us-west1",
+      "us-west4"
+    ],
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "vertex_ai/gemini-3-flash-preview": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 3,
+    "input_cache_read_cost_per_mil_tokens": 0.05,
+    "reasoning": true,
+    "supported_regions": [
+      "global"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "vertex_ai/gemini-3-pro-image-preview": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 12,
+    "supported_regions": [
+      "global"
+    ],
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "vertex_ai/gemini-3-pro-preview": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 12,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "reasoning": true,
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "vertex_ai/gemini-3.1-flash-image-preview": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 3,
+    "supported_regions": [
+      "global"
+    ],
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "vertex_ai/gemini-3.1-flash-lite-preview": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 1.5,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "reasoning": true,
+    "supported_regions": [
+      "global"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "vertex_ai/gemini-3.1-pro-preview": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 12,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "reasoning": true,
+    "supported_regions": [
+      "global"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "vertex_ai/gemini-3.1-pro-preview-customtools": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 12,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "reasoning": true,
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "vertex"
+    ]
   }
 }

--- a/packages/proxy/scripts/model_sync_filters.ts
+++ b/packages/proxy/scripts/model_sync_filters.ts
@@ -1,0 +1,311 @@
+type SupportedProvider = "openai" | "anthropic" | "google" | "vertex";
+
+type ModelSyncFilterOptions = {
+  provider?: string;
+  remoteProvider?: string;
+  filterRegex?: RegExp | null;
+  majorOnly?: boolean;
+  translatedModelName: string;
+  remoteModelName: string;
+};
+
+type ExplicitExcludeList = {
+  exact?: string[];
+  prefixes?: string[];
+  suffixes?: string[];
+  contains?: string[];
+};
+
+// These are a bunch of old models that we haven't included yet. Let's continue
+// to exclude them unless we have a reason not to.
+const MAJOR_ONLY_EXCLUDE_LISTS: Record<SupportedProvider, ExplicitExcludeList> =
+  {
+    openai: {
+      exact: [
+        "babbage-002",
+        "chatgpt-image-latest",
+        "dall-e-3",
+        "davinci-002",
+        "dall-e-2",
+        "whisper-1",
+        "text-embedding-ada-002",
+        "text-embedding-ada-002-v2",
+        "gpt-5.1-codex-max",
+        "gpt-5.2-pro",
+      ],
+      prefixes: [
+        "ft:",
+        "chatgpt-",
+        "codex-mini-",
+        "gpt-3.5-",
+        "gpt-4-",
+        "gpt-4o-",
+        "gpt-4-turbo",
+        "gpt-5-search-api",
+        "gpt-audio",
+        "gpt-image",
+        "gpt-realtime",
+        "o3-deep-research",
+        "o4-mini-deep-research",
+        "omni-moderation-",
+        "openai/",
+        "sora-2",
+        "text-embedding-",
+        "text-moderation-",
+        "tts-1",
+        "1024-x-",
+        "1536-x-",
+        "256-x-",
+        "512-x-",
+        "hd/",
+        "high/",
+        "low/",
+        "medium/",
+        "standard/",
+      ],
+    },
+    anthropic: {
+      exact: [
+        "anthropic.claude-instant-v1",
+        "anthropic.claude-v1",
+        "anthropic.claude-v2:1",
+        "claude-opus-4-1",
+      ],
+      prefixes: [
+        "claude-3-",
+        "anthropic.",
+        "vertex_ai/claude-3-",
+        "vertex_ai/claude-",
+        "apac.anthropic.",
+        "au.anthropic.",
+        "eu.anthropic.",
+        "global.anthropic.",
+        "jp.anthropic.",
+        "us-gov.anthropic.",
+        "us.anthropic.",
+      ],
+      suffixes: [
+        "@default",
+        "@20240229",
+        "@20240620",
+        "@20241022",
+        "@20250219",
+        "@20250514",
+        "@20250805",
+        "@20250929",
+        "@20251001",
+        "@20251101",
+        "-20240229",
+        "-20240307",
+        "-20240620-v1:0",
+        "-20241022-v1:0",
+        "-20241022-v2:0",
+        "-20250219-v1:0",
+        "-20250514",
+        "-20250514-v1:0",
+        "-20250805",
+        "-20250805-v1:0",
+        "-20250929-v1:0",
+        "-20251001-v1:0",
+        "-20251101-v1:0",
+        "-20260205",
+        "-v1",
+      ],
+    },
+    google: {
+      prefixes: [
+        "gemini-1.",
+        "gemini-2.0",
+        "gemini-2.5-",
+        "gemini-embedding-",
+        "gemini-gemma-",
+        "gemma-",
+        "google_pse/",
+        "deep-research-",
+        "lyria-",
+        "veo-",
+      ],
+      contains: [
+        "live",
+        "tts",
+        "image",
+        "exp",
+        "native-audio",
+        "robotics",
+        "computer-use",
+      ],
+    },
+    vertex: {
+      exact: [
+        "medlm-large",
+        "medlm-medium",
+        "multimodalembedding",
+        "multimodalembedding@001",
+        "text-embedding-004",
+        "text-embedding-005",
+        "text-embedding-preview-0409",
+        "text-embedding-large-exp-03-07",
+        "text-multilingual-embedding-002",
+        "text-unicorn",
+        "text-unicorn@001",
+      ],
+      prefixes: [
+        "vertex_ai/chirp",
+        "vertex_ai/claude-",
+        "vertex_ai/codestral",
+        "vertex_ai/jamba-",
+        "vertex_ai/deepseek-",
+        "vertex_ai/gemini-embedding-",
+        "vertex_ai/imagegeneration",
+        "vertex_ai/imagen-",
+        "vertex_ai/meta/",
+        "vertex_ai/minimaxai/",
+        "vertex_ai/mistral",
+        "vertex_ai/mistralai/",
+        "vertex_ai/moonshotai/",
+        "vertex_ai/openai/",
+        "vertex_ai/qwen/",
+        "vertex_ai/search_api",
+        "vertex_ai/veo-",
+        "vertex_ai/zai-org/",
+      ],
+      contains: [
+        "experimental",
+        "robotics",
+        "computer-use",
+        "deep-research",
+        "tts",
+        "live",
+        "thinking",
+      ],
+    },
+  };
+
+function normalizeProvider(provider?: string): SupportedProvider | null {
+  const normalized = provider?.toLowerCase();
+  if (
+    normalized === "openai" ||
+    normalized === "anthropic" ||
+    normalized === "google" ||
+    normalized === "vertex"
+  ) {
+    return normalized;
+  }
+  return null;
+}
+
+function inferProvider({
+  provider,
+  remoteProvider,
+  translatedModelName,
+  remoteModelName,
+}: Pick<
+  ModelSyncFilterOptions,
+  "provider" | "remoteProvider" | "translatedModelName" | "remoteModelName"
+>): SupportedProvider | null {
+  const explicitProvider = normalizeProvider(provider);
+  if (explicitProvider) {
+    return explicitProvider;
+  }
+
+  const normalizedRemoteProvider = remoteProvider?.toLowerCase() ?? "";
+  const names = [
+    translatedModelName.toLowerCase(),
+    remoteModelName.toLowerCase(),
+  ];
+
+  if (
+    normalizedRemoteProvider.includes("vertex") ||
+    names.some((name) => name.startsWith("vertex_ai/"))
+  ) {
+    return "vertex";
+  }
+
+  if (
+    normalizedRemoteProvider.includes("anthropic") ||
+    names.some((name) => name.startsWith("claude-"))
+  ) {
+    return "anthropic";
+  }
+
+  if (
+    normalizedRemoteProvider.includes("google") ||
+    normalizedRemoteProvider.includes("gemini") ||
+    names.some((name) => name.startsWith("gemini-"))
+  ) {
+    return "google";
+  }
+
+  if (
+    normalizedRemoteProvider.includes("openai") ||
+    names.some((name) =>
+      /^(gpt-|o[34](?:-|$)|omni-moderation-|text-embedding-3-|sora-2)/i.test(
+        name,
+      ),
+    )
+  ) {
+    return "openai";
+  }
+
+  return null;
+}
+
+function matchesExplicitExclude(
+  value: string,
+  excludeList: ExplicitExcludeList,
+): boolean {
+  const normalizedValue = value.toLowerCase();
+
+  return (
+    (excludeList.exact ?? []).some(
+      (candidate) => normalizedValue === candidate,
+    ) ||
+    (excludeList.prefixes ?? []).some((candidate) =>
+      normalizedValue.startsWith(candidate),
+    ) ||
+    (excludeList.suffixes ?? []).some((candidate) =>
+      normalizedValue.endsWith(candidate),
+    ) ||
+    (excludeList.contains ?? []).some((candidate) =>
+      normalizedValue.includes(candidate),
+    )
+  );
+}
+
+export function shouldIncludeModelForSync({
+  provider,
+  remoteProvider,
+  filterRegex,
+  majorOnly,
+  translatedModelName,
+  remoteModelName,
+}: ModelSyncFilterOptions): boolean {
+  if (
+    filterRegex &&
+    !filterRegex.test(translatedModelName) &&
+    !filterRegex.test(remoteModelName)
+  ) {
+    return false;
+  }
+
+  if (!majorOnly) {
+    return true;
+  }
+
+  const normalizedProvider = inferProvider({
+    provider,
+    remoteProvider,
+    translatedModelName,
+    remoteModelName,
+  });
+  if (!normalizedProvider) {
+    return false;
+  }
+
+  const excludeList = MAJOR_ONLY_EXCLUDE_LISTS[normalizedProvider];
+  const isExcluded =
+    matchesExplicitExclude(translatedModelName, excludeList) ||
+    matchesExplicitExclude(remoteModelName, excludeList);
+
+  return !isExcluded;
+}

--- a/packages/proxy/scripts/sync_models.ts
+++ b/packages/proxy/scripts/sync_models.ts
@@ -7,6 +7,7 @@ import { hideBin } from "yargs/helpers";
 import { exec, spawn } from "child_process";
 import { promisify } from "util";
 import { ModelSchema, ModelSpec } from "../schema/models";
+import { shouldIncludeModelForSync } from "./model_sync_filters";
 import {
   fetchVertexSupportedRegions,
   GOOGLE_VERTEX_LOCATIONS_URL,
@@ -767,6 +768,9 @@ async function findMissingCommand(argv: any) {
     console.log(`Read ${Object.keys(localModels).length} local models.`);
 
     const localModelNames = new Set(Object.keys(localModels));
+    const filterRegex = argv.filter
+      ? new RegExp(String(argv.filter), "i")
+      : null;
     const missingInLocal: string[] = [];
     const consideredRemoteModels: LiteLLMModelList = {};
     const filteredRemoteModels: LiteLLMModelList = {};
@@ -783,6 +787,18 @@ async function findMissingCommand(argv: any) {
       translatedName,
       { remoteModelName, remoteModel },
     ] of resolvedRemote) {
+      if (
+        !shouldIncludeModelForSync({
+          provider: argv.provider,
+          remoteProvider: remoteModel.litellm_provider,
+          filterRegex,
+          majorOnly: argv.majorOnly,
+          translatedModelName: translatedName,
+          remoteModelName,
+        })
+      ) {
+        continue;
+      }
       consideredRemoteModels[remoteModelName] = remoteModel;
       if (argv.provider) {
         console.log(
@@ -1366,6 +1382,9 @@ async function addModelsCommand(argv: any) {
     console.log(`Read ${Object.keys(localModels).length} local models.`);
 
     const localModelNames = new Set(Object.keys(localModels));
+    const filterRegex = argv.filter
+      ? new RegExp(String(argv.filter), "i")
+      : null;
     const missingInLocal: Array<{
       remoteModelName: string;
       translatedName: string;
@@ -1379,14 +1398,17 @@ async function addModelsCommand(argv: any) {
       translatedModelName,
       { remoteModelName, remoteModel: modelDetail, mergedProviders },
     ] of resolvedRemote) {
-      if (argv.filter) {
-        const lowerFilter = argv.filter.toLowerCase();
-        if (
-          !translatedModelName.toLowerCase().includes(lowerFilter) &&
-          !remoteModelName.toLowerCase().includes(lowerFilter)
-        ) {
-          continue;
-        }
+      if (
+        !shouldIncludeModelForSync({
+          provider: argv.provider,
+          remoteProvider: modelDetail.litellm_provider,
+          filterRegex,
+          majorOnly: argv.majorOnly,
+          translatedModelName,
+          remoteModelName,
+        })
+      ) {
+        continue;
       }
 
       if (!localModelNames.has(translatedModelName)) {
@@ -1597,6 +1619,18 @@ async function main() {
             alias: "p",
             type: "string",
             description: "Filter models by a specific provider",
+          })
+          .option("filter", {
+            alias: "f",
+            type: "string",
+            description:
+              "Filter models by regular expression against local or remote model name (e.g., '^gpt-5$')",
+          })
+          .option("majorOnly", {
+            type: "boolean",
+            description:
+              "Apply provider-specific major-release presets for openai, anthropic, google, and vertex",
+            default: false,
           });
       },
       async (argv) => {
@@ -1637,7 +1671,14 @@ async function main() {
           .option("filter", {
             alias: "f",
             type: "string",
-            description: "Filter models by name substring (e.g., 'gpt-5')",
+            description:
+              "Filter models by regular expression against local or remote model name (e.g., '^gpt-5$')",
+          })
+          .option("majorOnly", {
+            type: "boolean",
+            description:
+              "Apply provider-specific major-release presets for openai, anthropic, google, and vertex",
+            default: false,
           })
           .option("write", {
             type: "boolean",

--- a/packages/proxy/scripts/sync_vertex_regions.ts
+++ b/packages/proxy/scripts/sync_vertex_regions.ts
@@ -40,12 +40,14 @@ function fetchText(url: string): Promise<string> {
   });
 }
 
-function stripPublisherGooglePrefix(modelName: string): string {
-  return modelName.replace(/^publishers\/google\/models\//, "");
+function normalizeVertexGoogleModelName(modelName: string): string {
+  return modelName
+    .replace(/^publishers\/google\/models\//, "")
+    .replace(/^vertex_ai\//, "");
 }
 
 function isVertexGoogleModel(modelName: string, model?: ModelSpec): boolean {
-  const normalizedName = stripPublisherGooglePrefix(modelName);
+  const normalizedName = normalizeVertexGoogleModelName(modelName);
   const isGoogleModel = normalizedName.startsWith("gemini");
   const hasVertexProvider =
     model?.available_providers?.includes("vertex") ||
@@ -160,7 +162,7 @@ export function syncVertexSupportedRegions<T extends Record<string, ModelSpec>>(
       continue;
     }
 
-    const normalizedName = stripPublisherGooglePrefix(modelName);
+    const normalizedName = normalizeVertexGoogleModelName(modelName);
     const supportedRegions = supportedRegionsByModel.get(normalizedName);
     const currentRegions = model.supported_regions;
 


### PR DESCRIPTION
Add a heuristic to add new major models from openai/anthropic/google to
model_list.json, assuming that litellm's list already contains those models.
Explicitly excludes a bunch of old models from these providers that we haven't
added yet, to avoid polluting the model list. I ran this and updated the model
list too.