### PR TITLE
Native Inference Billing

### DIFF
--- a/apis/cloudflare/src/billing.ts
+++ b/apis/cloudflare/src/billing.ts
@@ -1,0 +1,86 @@
+import { type BillingEvent } from "@braintrust/proxy";
+
+const DEFAULT_BILLING_TELEMETRY_URL =
+  "https://api.braintrust.dev/billing/telemetry/ingest";
+
+function buildPayloadEvent(event: BillingEvent) {
+  if (!event.model) {
+    console.warn("billing event skipped: missing model");
+    return null;
+  }
+  if (!event.isNativeInference) {
+    return null;
+  }
+
+  if (!event.org_id) {
+    console.warn("billing event skipped: missing org_id");
+    return null;
+  }
+  if (!event.resolved_model) {
+    console.warn("billing event skipped: missing resolved_model");
+    return null;
+  }
+  const hasTokenUsageData =
+    event.input_tokens !== undefined ||
+    event.output_tokens !== undefined ||
+    event.cached_input_tokens !== undefined ||
+    event.cache_write_input_tokens !== undefined;
+  if (!hasTokenUsageData) {
+    console.warn("billing event skipped: missing token usage");
+    return null;
+  }
+  const requestId = crypto.randomUUID();
+  const timestamp = new Date().toISOString();
+
+  return {
+    event_name: "NativeInferenceTokenUsageEvent",
+    external_customer_id: event.org_id,
+    timestamp,
+    idempotency_key: requestId,
+    properties: {
+      model: event.model,
+      resolved_model: event.resolved_model,
+      org_id: event.org_id,
+      input_tokens: event.input_tokens,
+      output_tokens: event.output_tokens,
+      cached_input_tokens: event.cached_input_tokens,
+      cache_write_input_tokens: event.cache_write_input_tokens,
+    },
+  };
+}
+
+export async function sendBillingTelemetryEvent({
+  telemetryUrl,
+  event,
+}: {
+  telemetryUrl?: string;
+  event: BillingEvent;
+}): Promise<void> {
+  try {
+    const payloadEvent = buildPayloadEvent(event);
+    if (!payloadEvent) {
+      return;
+    }
+
+    const destination = telemetryUrl || DEFAULT_BILLING_TELEMETRY_URL;
+    const response = await fetch(destination, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${event.auth_token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        events: [payloadEvent],
+      }),
+    });
+
+    if (!response.ok) {
+      const responseBody = await response.text();
+      console.warn(
+        `billing event failed: ${response.status} ${response.statusText} ${responseBody}`,
+      );
+    }
+  } catch (error) {
+    console.warn("billing event threw an error", error);
+  }
+}

--- a/apis/cloudflare/src/env.ts
+++ b/apis/cloudflare/src/env.ts
@@ -4,6 +4,7 @@ declare global {
     BRAINTRUST_APP_URL: string;
     WHITELISTED_ORIGINS?: string;
     METRICS_LICENSE_KEY?: string;
+    BILLING_TELEMETRY_URL?: string;
     NATIVE_INFERENCE_SECRET_KEY?: string;
   }
 }

--- a/apis/cloudflare/src/proxy.ts
+++ b/apis/cloudflare/src/proxy.ts
@@ -19,6 +19,7 @@ import { BT_PARENT, resolveParentHeader } from "braintrust/util";
 import { cachedLogin, makeProxySpanLogger } from "./tracing";
 import { MeterProvider } from "@opentelemetry/sdk-metrics";
 import { Meter, Attributes, Histogram } from "@opentelemetry/api";
+import { sendBillingTelemetryEvent } from "./billing";
 
 export type LogHistogramFn = (args: {
   name: string;
@@ -117,6 +118,30 @@ export async function handleProxyV1(
   let span: Span | undefined;
   let spanId: string | undefined;
   let spanExport: string | undefined;
+  let billingOrgId: string | undefined;
+  const orgName = request.headers.get(ORG_NAME_HEADER) ?? undefined;
+  const apiKey =
+    parseAuthHeader({
+      authorization: request.headers.get("authorization") ?? undefined,
+    }) ?? undefined;
+
+  const getLoginState = async () =>
+    cachedLogin({
+      appUrl: braintrustAppUrl(env).toString(),
+      apiKey,
+      orgName,
+      cache: credentialsCache,
+    });
+
+  if (apiKey) {
+    try {
+      const loginState = await getLoginState();
+      billingOrgId = loginState.orgId ?? undefined;
+    } catch (error) {
+      console.warn("Failed to resolve billing org id", error);
+    }
+  }
+
   const parentHeader = request.headers.get(BT_PARENT);
   if (parentHeader) {
     let parent;
@@ -131,19 +156,11 @@ export async function handleProxyV1(
       );
     }
 
-    const orgName = request.headers.get(ORG_NAME_HEADER) ?? undefined;
-    const apiKey =
-      parseAuthHeader({
-        authorization: request.headers.get("authorization") ?? undefined,
-      }) ?? undefined;
+    const loginState = await getLoginState();
+    billingOrgId = loginState.orgId ?? undefined;
 
     span = startSpan({
-      state: await cachedLogin({
-        appUrl: braintrustAppUrl(env).toString(),
-        apiKey,
-        orgName,
-        cache: credentialsCache,
-      }),
+      state: loginState,
       type: "llm",
       name: "LLM",
       parent: parent.toStr(),
@@ -199,6 +216,17 @@ export async function handleProxyV1(
     spanLogger,
     spanId,
     spanExport,
+    billingOrgId,
+    onBillingEvent: (event) => {
+      ctx.waitUntil(
+        sendBillingTelemetryEvent({
+          telemetryUrl: env.BILLING_TELEMETRY_URL,
+          event,
+        }).catch((error) => {
+          console.warn("billing waitUntil task failed", error);
+        }),
+      );
+    },
     nativeInferenceSecretKey: env.NATIVE_INFERENCE_SECRET_KEY,
   };
 

--- a/apis/cloudflare/wrangler-template.toml
+++ b/apis/cloudflare/wrangler-template.toml
@@ -28,10 +28,12 @@ head_sampling_rate = 0.2
 # You should not need to edit this
 BRAINTRUST_APP_URL = "https://www.braintrust.dev"
 METRICS_LICENSE_KEY="<YOUR_METRICS_LICENSE_KEY>"
+BILLING_TELEMETRY_URL="https://api.braintrust.dev/billing/telemetry/ingest"
 
 [env.staging.vars]
 BRAINTRUST_APP_URL = "https://www.braintrust.dev"
 METRICS_LICENSE_KEY="<YOUR_METRICS_LICENSE_KEY>"
+BILLING_TELEMETRY_URL="https://api.braintrust.dev/billing/telemetry/ingest"
 
 [env.staging]
 kv_namespaces = [

--- a/packages/proxy/edge/index.ts
+++ b/packages/proxy/edge/index.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_BRAINTRUST_APP_URL } from "@lib/constants";
 import { flushMetrics } from "@lib/metrics";
-import { proxyV1, SpanLogger, LogHistogramFn } from "@lib/proxy";
+import { proxyV1, SpanLogger, LogHistogramFn, BillingEvent } from "@lib/proxy";
 import { isEmpty } from "@lib/util";
 import { MeterProvider } from "@opentelemetry/sdk-metrics";
 
@@ -36,6 +36,8 @@ export interface ProxyOpts {
   logHistogram?: LogHistogramFn;
   whitelist?: (string | RegExp)[];
   spanLogger?: SpanLogger;
+  billingOrgId?: string;
+  onBillingEvent?: (event: BillingEvent) => void;
   spanId?: string;
   spanExport?: string;
   nativeInferenceSecretKey?: string;
@@ -398,6 +400,8 @@ export function EdgeProxyV1(opts: ProxyOpts) {
         digest: digestMessage,
         logHistogram: opts.logHistogram,
         spanLogger: opts.spanLogger,
+        billingOrgId: opts.billingOrgId,
+        onBillingEvent: opts.onBillingEvent,
       });
     } catch (e) {
       return new Response(`${e}`, {

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -102,6 +102,7 @@ import {
   flattenChunksArray,
   getRandomInt,
   isEmpty,
+  isNativeInferenceSecret,
   isObject,
   ModelResponse,
   parseAuthHeader,
@@ -190,6 +191,20 @@ export interface SpanLogger {
   reportProgress: (progress: string) => void;
 }
 
+export type BillingEvent = {
+  event_name: "NativeInferenceTokenUsageEvent";
+  auth_token: string;
+  org_id?: string;
+  isNativeInference?: boolean;
+  model?: string | null;
+  resolved_model?: string | null;
+  org_name?: string;
+  input_tokens?: number;
+  output_tokens?: number;
+  cached_input_tokens?: number;
+  cache_write_input_tokens?: number;
+};
+
 // This is an isomorphic implementation of proxyV1, which is used by both edge functions
 // in CloudFlare and by the node proxy (locally and in lambda).
 export async function proxyV1({
@@ -208,6 +223,8 @@ export async function proxyV1({
   cacheKeyOptions = {},
   decompressFetch = false,
   spanLogger,
+  billingOrgId,
+  onBillingEvent,
   signal,
   fetch = globalThis.fetch,
 }: {
@@ -237,6 +254,8 @@ export async function proxyV1({
   cacheKeyOptions?: CacheKeyOptions;
   decompressFetch?: boolean;
   spanLogger?: SpanLogger;
+  billingOrgId?: string;
+  onBillingEvent?: (event: BillingEvent) => void;
   signal?: AbortSignal;
   fetch?: FetchFn;
 }): Promise<void> {
@@ -299,6 +318,7 @@ export async function proxyV1({
   );
 
   let orgName: string | undefined = proxyHeaders[ORG_NAME_HEADER] ?? undefined;
+  let resolvedOrgName: string | undefined = orgName;
   const projectId: string | undefined =
     proxyHeaders[PROJECT_ID_HEADER] ?? undefined;
 
@@ -568,6 +588,10 @@ export async function proxyV1({
   }
 
   let responseFailed = false;
+  let isNativeInference = false;
+  let secretName: string | null | undefined = undefined;
+  let proxyResponse: Response | undefined = undefined;
+  let proxyStream: ReadableStream<Uint8Array> | null = null;
 
   const overridenHeaders: string[] = [];
   const setOverriddenHeader = (name: string, value: string) => {
@@ -592,10 +616,7 @@ export async function proxyV1({
       );
     }
 
-    const {
-      modelResponse: { response: proxyResponse, stream: proxyStream },
-      secretName,
-    } = await fetchModelLoop(
+    const fetchResult = await fetchModelLoop(
       logHistogram,
       method,
       url,
@@ -649,6 +670,7 @@ export async function proxyV1({
 
         if (secrets.length > 0 && !orgName && secrets[0].org_name) {
           baseAttributes.org_name = secrets[0].org_name;
+          resolvedOrgName = secrets[0].org_name;
         }
         logRequest();
 
@@ -669,6 +691,10 @@ export async function proxyV1({
       signal,
       fetch,
     );
+    proxyResponse = fetchResult.modelResponse.response;
+    proxyStream = fetchResult.modelResponse.stream;
+    secretName = fetchResult.secretName;
+    isNativeInference = fetchResult.isNativeInference;
     stream = proxyStream;
 
     if (!proxyResponse.ok) {
@@ -759,6 +785,11 @@ export async function proxyV1({
   if (stream) {
     let first = true;
     const allChunks: Uint8Array[] = [];
+    let resolvedModel: string | undefined = undefined;
+    let inputTokens: number | undefined = undefined;
+    let outputTokens: number | undefined = undefined;
+    let cachedInputTokens: number | undefined = undefined;
+    let cacheWriteInputTokens: number | undefined = undefined;
 
     // These parameters are for the streaming case
     let reasoning: OpenAIReasoning[] | undefined = undefined;
@@ -787,10 +818,20 @@ export async function proxyV1({
                 | OpenAIChatCompletionChunk
                 | undefined;
               if (result) {
+                if (typeof result.model === "string" && result.model) {
+                  resolvedModel = result.model;
+                }
                 const extendedUsage = completionUsageSchema.safeParse(
                   result.usage,
                 );
                 if (extendedUsage.success) {
+                  inputTokens = extendedUsage.data.prompt_tokens;
+                  outputTokens = extendedUsage.data.completion_tokens;
+                  cachedInputTokens =
+                    extendedUsage.data.prompt_tokens_details?.cached_tokens;
+                  cacheWriteInputTokens =
+                    extendedUsage.data.prompt_tokens_details
+                      ?.cache_creation_tokens;
                   spanLogger?.log({
                     metrics: {
                       tokens: extendedUsage.data.total_tokens,
@@ -978,10 +1019,20 @@ export async function proxyV1({
               case "chat":
               case "completion": {
                 const data = dataRaw as ChatCompletion;
+                if (typeof data.model === "string" && data.model) {
+                  resolvedModel = data.model;
+                }
                 const extendedUsage = completionUsageSchema.safeParse(
                   data.usage,
                 );
                 if (extendedUsage.success) {
+                  inputTokens = extendedUsage.data.prompt_tokens;
+                  outputTokens = extendedUsage.data.completion_tokens;
+                  cachedInputTokens =
+                    extendedUsage.data.prompt_tokens_details?.cached_tokens;
+                  cacheWriteInputTokens =
+                    extendedUsage.data.prompt_tokens_details
+                      ?.cache_creation_tokens;
                   spanLogger?.log({
                     output: data.choices,
                     metrics: {
@@ -1041,6 +1092,15 @@ export async function proxyV1({
               }
               case "response": {
                 const data = dataRaw as OpenAIResponse;
+                if (typeof data.model === "string" && data.model) {
+                  resolvedModel = data.model;
+                }
+                if (data.usage) {
+                  inputTokens = data.usage.input_tokens;
+                  outputTokens = data.usage.output_tokens;
+                  cachedInputTokens =
+                    data.usage.input_tokens_details?.cached_tokens;
+                }
                 spanLogger?.log({
                   output: data.output,
                   metrics: {
@@ -1089,6 +1149,28 @@ export async function proxyV1({
         });
 
         spanLogger?.end();
+        if (!responseFailed) {
+          try {
+            if (typeof onBillingEvent !== "function") {
+              return;
+            }
+            onBillingEvent({
+              event_name: "NativeInferenceTokenUsageEvent",
+              auth_token: authToken,
+              org_id: billingOrgId,
+              isNativeInference,
+              model,
+              resolved_model: resolvedModel,
+              org_name: resolvedOrgName,
+              input_tokens: inputTokens,
+              output_tokens: outputTokens,
+              cached_input_tokens: cachedInputTokens,
+              cache_write_input_tokens: cacheWriteInputTokens,
+            });
+          } catch (error) {
+            console.warn("billing callback failed", error);
+          }
+        }
         controller.terminate();
       },
     });
@@ -1202,7 +1284,11 @@ async function fetchModelLoop(
   model: string | null,
   signal: AbortSignal | undefined,
   fetch: FetchFn,
-): Promise<{ modelResponse: ModelResponse; secretName?: string | null }> {
+): Promise<{
+  modelResponse: ModelResponse;
+  secretName?: string | null;
+  isNativeInference: boolean;
+}> {
   // model is now passed as a parameter
 
   // TODO: Make this smarter. For now, just pick a random one.
@@ -1256,6 +1342,10 @@ async function fetchModelLoop(
   }
 
   const initialIdx = getRandomInt(secrets.length);
+  const nativeInferenceSecret =
+    model === null || model === undefined
+      ? undefined
+      : secrets.find((secret) => isNativeInferenceSecret(secret, model));
   let proxyResponse: ModelResponse | null = null;
   let secretName: string | null | undefined = null;
   let lastException = null;
@@ -1553,6 +1643,7 @@ async function fetchModelLoop(
       response: proxyResponse.response,
     },
     secretName,
+    isNativeInference: nativeInferenceSecret !== undefined,
   };
 }
 

--- a/packages/proxy/src/util.test.ts
+++ b/packages/proxy/src/util.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest";
-import { parseFileMetadataFromUrl, _urljoin } from "./util";
+import { type APISecret } from "@schema";
+import {
+  isNativeInferenceSecret,
+  parseFileMetadataFromUrl,
+  _urljoin,
+} from "./util";
 
 describe("parseFileMetadataFromUrl", () => {
   test("handles basic URLs", () => {
@@ -221,4 +226,59 @@ test("_urljoin", () => {
   );
   expect(_urljoin()).toBe("");
   expect(_urljoin("a")).toBe("a");
+});
+
+describe("isNativeInferenceSecret", () => {
+  test("treats braintrust secrets without custom models as native inference", () => {
+    const secret: APISecret = {
+      type: "braintrust",
+      secret: "test-secret",
+      metadata: {
+        api_base: "http://localhost:8001/native-inference-test",
+      },
+    };
+
+    expect(isNativeInferenceSecret(secret, "brain-test-native-1")).toBe(true);
+  });
+
+  test("treats custom model secrets as native inference only for matching models", () => {
+    const secret: APISecret = {
+      type: "openai",
+      secret: "test-secret",
+      metadata: {
+        customModels: {
+          "brain-test-native-1": {
+            format: "openai",
+            flavor: "chat",
+          },
+        },
+      },
+    };
+
+    expect(isNativeInferenceSecret(secret, "brain-test-native-1")).toBe(true);
+    expect(isNativeInferenceSecret(secret, "brain-test-native-2")).toBe(false);
+  });
+
+  test("treats non-braintrust secrets without matching custom models as non-native", () => {
+    const secret: APISecret = {
+      type: "openai",
+      secret: "test-secret",
+      metadata: {
+        api_base: "https://api.openai.com/v1",
+      },
+    };
+
+    expect(isNativeInferenceSecret(secret, "brain-test-native-1")).toBe(false);
+  });
+
+  test("returns false when the model is missing", () => {
+    const secret: APISecret = {
+      type: "braintrust",
+      secret: "test-secret",
+      metadata: null,
+    };
+
+    expect(isNativeInferenceSecret(secret, null)).toBe(false);
+    expect(isNativeInferenceSecret(secret, undefined)).toBe(false);
+  });
 });

--- a/packages/proxy/src/util.test.ts
+++ b/packages/proxy/src/util.test.ts
@@ -229,7 +229,7 @@ test("_urljoin", () => {
 });
 
 describe("isNativeInferenceSecret", () => {
-  test("treats braintrust secrets without custom models as native inference", () => {
+  test("treats braintrust secrets without custom models as non-native", () => {
     const secret: APISecret = {
       type: "braintrust",
       secret: "test-secret",
@@ -238,10 +238,10 @@ describe("isNativeInferenceSecret", () => {
       },
     };
 
-    expect(isNativeInferenceSecret(secret, "brain-test-native-1")).toBe(true);
+    expect(isNativeInferenceSecret(secret, "brain-test-native-1")).toBe(false);
   });
 
-  test("treats custom model secrets as native inference only for matching models", () => {
+  test("treats custom model secrets as native inference only for matching models with braintrust endpoint_type", () => {
     const secret: APISecret = {
       type: "openai",
       secret: "test-secret",
@@ -250,6 +250,7 @@ describe("isNativeInferenceSecret", () => {
           "brain-test-native-1": {
             format: "openai",
             flavor: "chat",
+            endpoint_types: ["braintrust"],
           },
         },
       },
@@ -257,6 +258,23 @@ describe("isNativeInferenceSecret", () => {
 
     expect(isNativeInferenceSecret(secret, "brain-test-native-1")).toBe(true);
     expect(isNativeInferenceSecret(secret, "brain-test-native-2")).toBe(false);
+  });
+
+  test("treats custom model secrets without braintrust endpoint_type as non-native", () => {
+    const secret: APISecret = {
+      type: "openai",
+      secret: "test-secret",
+      metadata: {
+        customModels: {
+          "custom-model": {
+            format: "openai",
+            flavor: "chat",
+          },
+        },
+      },
+    };
+
+    expect(isNativeInferenceSecret(secret, "custom-model")).toBe(false);
   });
 
   test("treats non-braintrust secrets without matching custom models as non-native", () => {

--- a/packages/proxy/src/util.ts
+++ b/packages/proxy/src/util.ts
@@ -80,6 +80,8 @@ export function isEmpty(a: any): a is null | undefined {
   return a === undefined || a === null;
 }
 
+export const NATIVE_INFERENCE_ENDPOINT = "braintrust";
+
 export function isNativeInferenceSecret(
   secret: APISecret,
   model: string | null | undefined,
@@ -93,12 +95,21 @@ export function isNativeInferenceSecret(
     customModels === null ||
     customModels === undefined ||
     typeof customModels !== "object" ||
-    Array.isArray(customModels)
+    Array.isArray(customModels) ||
+    !(model in customModels)
   ) {
-    return secret.type === "braintrust";
+    return false;
   }
 
-  return Object.prototype.hasOwnProperty.call(customModels, model);
+  const spec = customModels[model];
+  return (
+    spec !== null &&
+    typeof spec === "object" &&
+    !Array.isArray(spec) &&
+    "endpoint_types" in spec &&
+    Array.isArray(spec.endpoint_types) &&
+    spec.endpoint_types.includes(NATIVE_INFERENCE_ENDPOINT)
+  );
 }
 
 export function getRandomInt(max: number) {

--- a/packages/proxy/src/util.ts
+++ b/packages/proxy/src/util.ts
@@ -1,4 +1,5 @@
 import contentDisposition from "content-disposition";
+import { type APISecret } from "@schema";
 export interface ModelResponse {
   stream: ReadableStream<Uint8Array> | null;
   response: Response;
@@ -77,6 +78,27 @@ export function flattenChunks(allChunks: Uint8Array[]) {
 
 export function isEmpty(a: any): a is null | undefined {
   return a === undefined || a === null;
+}
+
+export function isNativeInferenceSecret(
+  secret: APISecret,
+  model: string | null | undefined,
+): boolean {
+  if (model === null || model === undefined) {
+    return false;
+  }
+
+  const customModels = secret.metadata?.customModels;
+  if (
+    customModels === null ||
+    customModels === undefined ||
+    typeof customModels !== "object" ||
+    Array.isArray(customModels)
+  ) {
+    return secret.type === "braintrust";
+  }
+
+  return Object.prototype.hasOwnProperty.call(customModels, model);
 }
 
 export function getRandomInt(max: number) {


### PR DESCRIPTION
Reapply native inference billing to the proxy.

Properly ensure only models with endpoint type braintrust are treated as native inference.

Refer to second commit: https://github.com/braintrustdata/braintrust-proxy/pull/442/changes/7038729a71a9ff295f5146bf4620f6a86ee4d118