### PR TITLE
proxy: strip "fireworks_ai/" prefix from model ids before forwarding

### DIFF
--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -2233,6 +2233,13 @@ async function fetchOpenAI(
     delete bodyData["stream_options"];
   }
 
+  if (secret.type === "fireworks" && typeof bodyData.model === "string") {
+    // Strip LiteLLM-style "fireworks_ai/" prefix before forwarding; Fireworks'
+    // native API only recognizes ids like "accounts/fireworks/models/glm-5".
+    // Catalog entries sourced from LiteLLM keep the prefix (see sync_models.ts).
+    bodyData.model = bodyData.model.replace(/^fireworks_ai\//, "");
+  }
+
   if (
     secret.type === "mistral" ||
     secret.type === "databricks" ||


### PR DESCRIPTION
Catalog entries sourced from LiteLLM (via sync_models.ts) use the "fireworks_ai/accounts/fireworks/models/X" naming convention, but Fireworks' native API only accepts "accounts/fireworks/models/X". The proxy was forwarding bodyData.model verbatim, so every prefixed entry 404'd end-to-end upstream.

This mirrors the existing publishers/<x>/models/ rewrite for Vertex in the same file, scoped to the fireworks provider only.

Impact:

- Unblocks 33 fireworks_ai/* entries in model_list.json. 19 of them have no unprefixed sibling, so this is the only way to reach those models (e.g. glm-5, glm-4p7, qwen3-vl-30b-a3b-instruct, deepseek-v3p1).
- Remaining 14 entries have unprefixed siblings and become truly redundant; can be marked deprecated in a follow-up.

Verified locally: calls to
  fireworks_ai/accounts/fireworks/models/glm-5 return 404 before the patch and 200 after, hitting the same upstream as accounts/fireworks/models/glm-5.

Made-with: Cursor