### PR TITLE
Update displayName for gpt 5.5

### DIFF
--- a/packages/proxy/schema/index.ts
+++ b/packages/proxy/schema/index.ts
@@ -1101,4 +1101,3 @@ const anthropicContentSchema = z.union([
 
 export type AnthropicImageBlock = z.infer<typeof anthropicImageBlockSchema>;
 export type AnthropicContent = z.infer<typeof anthropicContentSchema>;
-

--- a/packages/proxy/schema/model_list.json
+++ b/packages/proxy/schema/model_list.json
@@ -21,6 +21,7 @@
     "multimodal": true,
     "input_cost_per_mil_tokens": 5,
     "output_cost_per_mil_tokens": 30,
+    "displayName": "GPT 5.5",
     "input_cache_read_cost_per_mil_tokens": 0.5,
     "reasoning": true,
     "max_input_tokens": 272000,


### PR DESCRIPTION
Update the displayName for gpt 5.5 to "GPT 5.5"

<img width="1512" height="982" alt="Screenshot 2026-04-27 at 3 32 02 PM" src="https://github.com/user-attachments/assets/ad93521d-0ed4-4697-a663-29e6111f58bc" />
