### PR TITLE
use baseUrl instead of hard coding openai url for responses endpoints

### DIFF
--- a/packages/proxy/src/providers/openai.test.ts
+++ b/packages/proxy/src/providers/openai.test.ts
@@ -310,6 +310,75 @@ it("falls back to provider base URL when metadata.api_base is not a string", asy
   expect(requests[0].url).toBe("https://api.openai.com/v1/chat/completions");
 });
 
+it("uses custom api base when routing appropriate models through responses", async () => {
+  const { fetch, requests } = createCapturingFetch({ captureOnly: true });
+
+  await callProxyV1<OpenAIChatCompletionCreateParams, OpenAIChatCompletion>({
+    body: {
+      model: "gpt-5.5",
+      messages: [{ role: "user", content: "hello" }],
+      stream: false,
+    },
+    fetch,
+    getApiSecrets: async () => [
+      {
+        type: "openai",
+        name: "litellm",
+        secret: "sk-fake-key",
+        metadata: {
+          api_base: "http://test.com/v1",
+        },
+      },
+    ],
+  });
+
+  expect(requests.length).toBe(1);
+  expect(requests[0].url).toBe("http://test.com/v1/responses");
+  expect(requests[0].headers.authorization).toBe("Bearer sk-fake-key");
+  expect(requests[0].body).toMatchObject({
+    model: "gpt-5.5",
+    input: [
+      {
+        content: "hello",
+        role: "user",
+        type: "message",
+      },
+    ],
+  });
+});
+
+it("handles /responses as endpoint_path", async () => {
+  const { fetch, requests } = createCapturingFetch({ captureOnly: true });
+
+  await callProxyV1<Record<string, unknown>, Record<string, unknown>>({
+    url: "/responses",
+    body: {
+      model: "gpt-5.5",
+      input: "hello",
+    },
+    fetch,
+    getApiSecrets: async () => [
+      {
+        type: "openai",
+        name: "litellm",
+        secret: "sk-fake-key",
+        metadata: {
+          api_base: "http://test.com/v1",
+          endpoint_path: "/responses",
+        },
+      },
+    ],
+  });
+
+  expect(requests.length).toBe(1);
+  expect(requests[0].url).toBe("http://test.com/v1/responses");
+  expect(requests[0].headers.authorization).toBe("Bearer sk-fake-key");
+  expect(requests[0].body).toMatchObject({
+    model: "gpt-5.5",
+    input: "hello",
+  });
+});
+
 it("uses model path for azure when metadata.deployment is non-string", async () => {
   const { fetch, requests } = createCapturingFetch({ captureOnly: true });
 

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -1973,15 +1973,19 @@ async function collectStream(stream: ReadableStream<Uint8Array>): Promise<any> {
 }
 
 async function fetchOpenAIResponsesTranslate({
+  baseURL,
   headers,
   body,
   signal,
+  fetch,
 }: {
+  baseURL: string;
   headers: Record<string, string>;
   body: ChatCompletionCreateParams;
   signal: AbortSignal | undefined;
+  fetch: FetchFn;
 }): Promise<ModelResponse> {
-  const response = await fetch("https://api.openai.com/v1/responses", {
+  const response = await fetch(new URL(_urljoin(baseURL, "responses")), {
     method: "POST",
     headers,
     body: JSON.stringify(responsesRequestFromChatCompletionsRequest(body)),
@@ -2016,20 +2020,24 @@ async function fetchOpenAIResponsesTranslate({
 }
 
 async function fetchOpenAIResponses({
+  url,
   headers,
   body,
   signal,
+  fetch,
 }: {
+  url: URL;
   headers: Record<string, string>;
   body: ResponseCreateParams;
   signal: AbortSignal | undefined;
+  fetch: FetchFn;
 }): Promise<ModelResponse> {
   // We allow users to set a seed, to enable caching, but Responses API itself does not.
   if ("seed" in body && body.seed !== undefined) {
     delete body.seed;
   }
 
-  const response = await fetch("https://api.openai.com/v1/responses", {
+  const response = await fetch(url, {
     method: "POST",
     headers,
     body: JSON.stringify(body),
@@ -2070,6 +2078,7 @@ async function fetchOpenAI(
   }
 
   let fullURL: URL | null | undefined = undefined;
+  let baseURL: string | null = null;
   let bearerToken: string | null | undefined = undefined;
 
   if (secret.type === "vertex") {
@@ -2093,7 +2102,7 @@ async function fetchOpenAI(
       modelSpec,
       defaultLocation: "us-central1",
     });
-    const baseURL = getVertexBaseUrl(api_base, resolvedLocation);
+    baseURL = getVertexBaseUrl(api_base, resolvedLocation);
 
     if (
       bodyData?.model?.startsWith("publishers/meta") ||
@@ -2133,7 +2142,7 @@ async function fetchOpenAI(
       typeof secret.metadata.api_base === "string"
         ? secret.metadata.api_base
         : undefined;
-    let baseURL = metadataApiBase || EndpointProviderToBaseURL[secret.type];
+    baseURL = metadataApiBase || EndpointProviderToBaseURL[secret.type];
     if (baseURL === null) {
       throw new ProxyBadRequestError(
         `Unsupported provider ${secret.name} (${secret.type}) (must specify base url)`,
@@ -2269,9 +2278,11 @@ async function fetchOpenAI(
 
   if (url === "/responses") {
     return fetchOpenAIResponses({
+      url: fullURL,
       headers,
       body: bodyData,
       signal,
+      fetch,
     });
   }
 
@@ -2341,9 +2352,11 @@ async function fetchOpenAI(
 
   if (shouldRouteChatToResponses) {
     return fetchOpenAIResponsesTranslate({
+      baseURL,
       headers,
       body: bodyData,
       signal,
+      fetch,
     });
   }
 


### PR DESCRIPTION
### Summary
When the proxy is called with /responses or with an OpenAI model that is greater than or equal to 5.3 it uses the OpenAI standard url (https://api.openai.com/v1/responses) instead of trying to use the custom provider base url if it exists.

### Description

#### Reproduction
1. In a terminal run the following command to setup a mock server that can handle the /responses and /chat/completions endpoints.
```
node -e 'const http=require("http");const send=(res,obj)=>res.write(`data: ${JSON.stringify(obj)}\n\n`);const server=http.createServer((req,res)=>{let body="";req.on("data",c=>body+=c);req.on("end",()=>{let parsed={};try{parsed=body?JSON.parse(body):{};}catch{}const path=new URL(req.url,"http://localhost").pathname;console.log(req.method,path,req.headers.authorization,body);if(req.method==="POST"&&path==="/v1/responses"){res.setHeader("content-type","application/json");res.end(JSON.stringify({id:"resp_mock",object:"response",created_at:Math.floor(Date.now()/1000),model:parsed.model||"gpt-5.5",output:[{type:"message",role:"assistant",content:[{type:"output_text",text:"Mock gpt-5.5 response through /v1/responses."}]}],usage:{input_tokens:5,output_tokens:9,total_tokens:14,input_tokens_details:{cached_tokens:0},output_tokens_details:{reasoning_tokens:0}}}));return;}if(req.method==="POST"&&path==="/v1/chat/completions"){const created=Math.floor(Date.now()/1000),model=parsed.model||"gpt-5.2";if(parsed.stream){res.writeHead(200,{"content-type":"text/event-stream; charset=utf-8","cache-control":"no-cache","connection":"keep-alive"});send(res,{id:"chatcmpl_mock",object:"chat.completion.chunk",created,model,choices:[{index:0,delta:{role:"assistant"},finish_reason:null}],usage:null});send(res,{id:"chatcmpl_mock",object:"chat.completion.chunk",created,model,choices:[{index:0,delta:{content:"Mock gpt-5.2 streamed response. "},finish_reason:null}],usage:null});send(res,{id:"chatcmpl_mock",object:"chat.completion.chunk",created,model,choices:[{index:0,delta:{content:"Here is a short story."},finish_reason:null}],usage:null});send(res,{id:"chatcmpl_mock",object:"chat.completion.chunk",created,model,choices:[{index:0,delta:{},finish_reason:"stop"}],usage:null});send(res,{id:"chatcmpl_mock",object:"chat.completion.chunk",created,model,choices:[],usage:{prompt_tokens:5,completion_tokens:10,total_tokens:15,prompt_tokens_details:{cached_tokens:0},completion_tokens_details:{reasoning_tokens:0}}});res.end("data: [DONE]\n\n");return;}res.setHeader("content-type","application/json");res.end(JSON.stringify({id:"chatcmpl_mock",object:"chat.completion",created,model,choices:[{index:0,message:{role:"assistant",content:"Mock gpt-5.2 non-stream response."},finish_reason:"stop"}],usage:{prompt_tokens:5,completion_tokens:8,total_tokens:13,prompt_tokens_details:{cached_tokens:0},completion_tokens_details:{reasoning_tokens:0}}}));return;}res.writeHead(404,{"content-type":"application/json"});res.end(JSON.stringify({error:{message:"Unhandled "+req.method+" "+path}}));});});server.listen(8011,()=>console.log("mock listening on http://localhost:8011/v1"));'
```
2. In a local Braintrust environment, navigate to Settings > AI Providers.
3. Click Create under Custom Providers.
4. Enter the following values:
  - API Token: sk-fake-key
  - API Base Url: http://localhost:8011/v1
  - Auth Format: bearer
  - Models:
     gpt-5.5
     openai/gpt-5.5
5. Click Update.
6. Navigate to Playgrounds.
7. Create a new Playground.
8. Choose your custom provider's gpt-5.5 as the model and enter "Tell me a story" as the User message.
9. Click Run.

**Expected:** 
The mock should handle the request since it should leverage the base url should be used.

**Actual:**
The proxy uses the hard coded url and tries to send a request directly to OpenAI's API which causes an authentication error because the custom provider API key is used.

https://github.com/user-attachments/assets/34596c53-9eac-47d7-b3d3-9291c2155d07

#### Fix
- Used existing baseUrl in fetchOpenAIResponsesTranslate to build the full responses url which is called when the model meets our condition of being >= gpt 5.3
- For fetchOpenAIResponses which is hit when the url from the proxy call is `/responses` used existing fullUrl (baseUrl + endpointPath which is either custom provider endpoint_path or url from proxy call) 

### Testing
- Used the mock above to test that it resolves to the baseUrl correctly.
- Added unit tests for:
  - handles /responses as endpoint_path
  - uses custom api base when routing appropriate models through responses