### PR TITLE
Auto test proxy models

### DIFF
--- a/.github/workflows/verify-deployed-models-on-vercel-comment.yaml
+++ b/.github/workflows/verify-deployed-models-on-vercel-comment.yaml
@@ -1,0 +1,66 @@
+name: Verify deployed models on Vercel comment
+
+on:
+  issue_comment:
+    types:
+      - created
+      - edited
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: verify-deployed-models-pr-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    if: ${{ github.event.issue.pull_request && github.event.comment.user.login == 'vercel' }}
+    runs-on: ubuntu-latest
+    outputs:
+      base_sha: ${{ steps.context.outputs.base_sha }}
+      head_sha: ${{ steps.context.outputs.head_sha }}
+      proxy_base_url: ${{ steps.context.outputs.proxy_base_url }}
+      should_run: ${{ steps.context.outputs.should_run }}
+    steps:
+      - name: Resolve PR context from Vercel comment
+        id: context
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const body = context.payload.comment.body || "";
+            const previewMatch =
+              body.match(/https:\/\/[^\s)]+preview\.braintrust\.dev[^\s)]*/i) ||
+              body.match(/https:\/\/[^\s)]+vercel\.app[^\s)]*/i);
+
+            if (!previewMatch) {
+              core.setOutput("should_run", "false");
+              return;
+            }
+
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number,
+            });
+
+            core.setOutput("base_sha", pullRequest.base.sha);
+            core.setOutput("head_sha", pullRequest.head.sha);
+            core.setOutput(
+              "proxy_base_url",
+              `${previewMatch[0].replace(/\/$/, "")}/api/v1`,
+            );
+            core.setOutput("should_run", "true");
+
+  verify:
+    needs: prepare
+    if: needs.prepare.outputs.should_run == 'true'
+    uses: ./.github/workflows/verify-deployed-models.yaml
+    with:
+      base_ref: ${{ needs.prepare.outputs.base_sha }}
+      head_ref: ${{ needs.prepare.outputs.head_sha }}
+      proxy_base_url: ${{ needs.prepare.outputs.proxy_base_url }}
+    secrets:
+      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+      VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}

--- a/.github/workflows/verify-deployed-models-on-vercel-comment.yaml
+++ b/.github/workflows/verify-deployed-models-on-vercel-comment.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  issues: read
   pull-requests: read
 
 concurrency:
@@ -29,29 +30,130 @@ jobs:
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
-            const body = context.payload.comment.body || "";
-            const previewMatch =
-              body.match(/https:\/\/[^\s)]+preview\.braintrust\.dev[^\s)]*/i) ||
-              body.match(/https:\/\/[^\s)]+vercel\.app[^\s)]*/i);
+            const readyStatuses = new Set(["DEPLOYED", "READY"]);
+            const failedStatuses = new Set([
+              "CANCELED",
+              "ERROR",
+              "FAILED",
+              "REMOVED",
+            ]);
+            const pollDelayMs = 15000;
+            const maxAttempts = 20;
 
-            if (!previewMatch) {
+            function sleep(ms) {
+              return new Promise((resolve) => setTimeout(resolve, ms));
+            }
+
+            function isRecord(value) {
+              return typeof value === "object" && value !== null && !Array.isArray(value);
+            }
+
+            function parseComment(body) {
+              const metadataMatch = body.match(/^\[vc\]:\s*#[^:]+:([A-Za-z0-9+/=]+)\s*$/m);
+              if (!metadataMatch) {
+                return null;
+              }
+
+              let decoded;
+              try {
+                decoded = JSON.parse(Buffer.from(metadataMatch[1], "base64").toString("utf8"));
+              } catch (_error) {
+                return null;
+              }
+
+              if (!isRecord(decoded) || !Array.isArray(decoded.projects)) {
+                return null;
+              }
+
+              const project = decoded.projects.find((value) => {
+                if (!isRecord(value)) {
+                  return false;
+                }
+
+                return (
+                  value.name === "ai-proxy" &&
+                  value.rootDirectory === "apis/vercel"
+                );
+              });
+
+              if (!isRecord(project)) {
+                return null;
+              }
+
+              const previewUrl =
+                typeof project.previewUrl === "string" && project.previewUrl.length > 0
+                  ? `https://${project.previewUrl.replace(/^https?:\/\//, "").replace(/\/$/, "")}`
+                  : null;
+              const status =
+                typeof project.nextCommitStatus === "string"
+                  ? project.nextCommitStatus.toUpperCase()
+                  : "";
+
+              return {
+                previewUrl,
+                status,
+              };
+            }
+
+            async function loadComment(commentId) {
+              const { data } = await github.rest.issues.getComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: commentId,
+              });
+
+              return parseComment(data.body || "");
+            }
+
+            const commentId = context.payload.comment.id;
+            let parsed = parseComment(context.payload.comment.body || "");
+
+            if (!parsed) {
               core.setOutput("should_run", "false");
               return;
             }
 
-            const { data: pullRequest } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.issue.number,
-            });
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              if (failedStatuses.has(parsed.status)) {
+                core.setFailed(
+                  `Vercel preview deployment for ai-proxy finished with status ${parsed.status}.`,
+                );
+                return;
+              }
 
-            core.setOutput("base_sha", pullRequest.base.sha);
-            core.setOutput("head_sha", pullRequest.head.sha);
-            core.setOutput(
-              "proxy_base_url",
-              `${previewMatch[0].replace(/\/$/, "")}/api/v1`,
-            );
-            core.setOutput("should_run", "true");
+              if (readyStatuses.has(parsed.status)) {
+                if (!parsed.previewUrl) {
+                  core.setFailed("Vercel preview deployment is ready, but no preview URL was found.");
+                  return;
+                }
+
+                const { data: pullRequest } = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.payload.issue.number,
+                });
+
+                core.setOutput("base_sha", pullRequest.base.sha);
+                core.setOutput("head_sha", pullRequest.head.sha);
+                core.setOutput("proxy_base_url", `${parsed.previewUrl}/api/v1`);
+                core.setOutput("should_run", "true");
+                return;
+              }
+
+              if (attempt === maxAttempts) {
+                core.setFailed(
+                  `Timed out waiting for ai-proxy preview deployment to become ready. Last status: ${parsed.status || "unknown"}.`,
+                );
+                return;
+              }
+
+              await sleep(pollDelayMs);
+              parsed = await loadComment(commentId);
+              if (!parsed) {
+                core.setFailed("Unable to parse the updated Vercel deployment comment.");
+                return;
+              }
+            }
 
   verify:
     needs: prepare

--- a/.github/workflows/verify-deployed-models-on-vercel-comment.yaml
+++ b/.github/workflows/verify-deployed-models-on-vercel-comment.yaml
@@ -62,6 +62,18 @@ jobs:
               return typeof value === "object" && value !== null && !Array.isArray(value);
             }
 
+            function isTrustedPullRequest(pullRequest) {
+              const trustedAssociations = new Set(["COLLABORATOR", "MEMBER", "OWNER"]);
+              const authorAssociation =
+                typeof pullRequest.author_association === "string"
+                  ? pullRequest.author_association.toUpperCase()
+                  : "";
+              const sameRepository =
+                pullRequest.head?.repo?.full_name === `${context.repo.owner}/${context.repo.repo}`;
+
+              return sameRepository || trustedAssociations.has(authorAssociation);
+            }
+
             function parseComment(body) {
               const metadataMatch = body.match(/^\[vc\]:\s*#[^:]+:([A-Za-z0-9+/=]+)\s*$/m);
               if (!metadataMatch) {
@@ -154,6 +166,21 @@ jobs:
               return;
             }
 
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequestNumber,
+            });
+
+            if (!isTrustedPullRequest(pullRequest)) {
+              core.notice(
+                `Skipping verification for untrusted PR #${pullRequestNumber} (author_association=${pullRequest.author_association}).`,
+              );
+              core.setOutput("pull_request_number", String(pullRequestNumber));
+              core.setOutput("should_run", "false");
+              return;
+            }
+
             for (let attempt = 1; attempt <= maxAttempts; attempt++) {
               if (failedStatuses.has(parsed.status)) {
                 core.setFailed(
@@ -167,12 +194,6 @@ jobs:
                   core.setFailed("Vercel preview deployment is ready, but no preview URL was found.");
                   return;
                 }
-
-                const { data: pullRequest } = await github.rest.pulls.get({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: pullRequestNumber,
-                });
 
                 core.setOutput("base_sha", pullRequest.base.sha);
                 core.setOutput("head_sha", pullRequest.head.sha);
@@ -204,6 +225,7 @@ jobs:
     uses: ./.github/workflows/verify-deployed-models.yaml
     with:
       base_ref: ${{ needs.prepare.outputs.base_sha }}
+      head_sha: ${{ needs.prepare.outputs.head_sha }}
       pull_request_number: ${{ needs.prepare.outputs.pull_request_number }}
       proxy_base_url: ${{ needs.prepare.outputs.proxy_base_url }}
     secrets:

--- a/.github/workflows/verify-deployed-models-on-vercel-comment.yaml
+++ b/.github/workflows/verify-deployed-models-on-vercel-comment.yaml
@@ -204,7 +204,7 @@ jobs:
     uses: ./.github/workflows/verify-deployed-models.yaml
     with:
       base_ref: ${{ needs.prepare.outputs.base_sha }}
-      head_ref: ${{ needs.prepare.outputs.head_sha }}
+      pull_request_number: ${{ needs.prepare.outputs.pull_request_number }}
       proxy_base_url: ${{ needs.prepare.outputs.proxy_base_url }}
     secrets:
       BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}

--- a/.github/workflows/verify-deployed-models-on-vercel-comment.yaml
+++ b/.github/workflows/verify-deployed-models-on-vercel-comment.yaml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: read
-  issues: read
+  issues: write
   pull-requests: read
 
 concurrency:
@@ -166,3 +166,105 @@ jobs:
     secrets:
       BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
       VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+
+  comment:
+    needs:
+      - prepare
+      - verify
+    if: always() && needs.prepare.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post verification summary to PR
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        env:
+          FAILED_COUNT: ${{ needs.verify.outputs.failed_count }}
+          FAILED_MODELS_JSON: ${{ needs.verify.outputs.failed_models_json }}
+          PASSED_COUNT: ${{ needs.verify.outputs.passed_count }}
+          PASSED_MODELS_JSON: ${{ needs.verify.outputs.passed_models_json }}
+          TESTED_MODELS_JSON: ${{ needs.verify.outputs.tested_models_json }}
+          VERIFY_RESULT: ${{ needs.verify.result }}
+        with:
+          script: |
+            const marker = "<!-- proxy-model-verification -->";
+
+            function parseJsonArray(raw) {
+              if (!raw) {
+                return [];
+              }
+
+              try {
+                const parsed = JSON.parse(raw);
+                return Array.isArray(parsed) ? parsed.filter((value) => typeof value === "string") : [];
+              } catch (_error) {
+                return [];
+              }
+            }
+
+            function formatModels(models) {
+              if (models.length === 0) {
+                return "- None";
+              }
+
+              return models.map((model) => `- \`${model}\``).join("\n");
+            }
+
+            const testedModels = parseJsonArray(process.env.TESTED_MODELS_JSON);
+            const passedModels = parseJsonArray(process.env.PASSED_MODELS_JSON);
+            const failedModels = parseJsonArray(process.env.FAILED_MODELS_JSON);
+            const failedCount = Number(process.env.FAILED_COUNT || "0");
+            const passedCount = Number(process.env.PASSED_COUNT || "0");
+            const verifyResult = process.env.VERIFY_RESULT || "unknown";
+
+            let statusLine = "Verification completed successfully.";
+            if (verifyResult === "failure" || failedCount > 0) {
+              statusLine = "Verification failed for one or more models.";
+            } else if (testedModels.length === 0) {
+              statusLine = "No changed models required verification.";
+            }
+
+            const body = [
+              marker,
+              "## Proxy model verification",
+              "",
+              statusLine,
+              "",
+              `Passed: ${passedCount}`,
+              `Failed: ${failedCount}`,
+              "",
+              "Tested models",
+              formatModels(testedModels),
+              "",
+              "Passed models",
+              formatModels(passedModels),
+              "",
+              "Failed models",
+              formatModels(failedModels),
+            ].join("\n");
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) =>
+              typeof comment.body === "string" && comment.body.includes(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body,
+            });

--- a/.github/workflows/verify-deployed-models-on-vercel-comment.yaml
+++ b/.github/workflows/verify-deployed-models-on-vercel-comment.yaml
@@ -5,6 +5,16 @@ on:
     types:
       - created
       - edited
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: "Pull request number to verify"
+        required: true
+        type: string
+      vercel_comment_id:
+        description: "Issue comment ID for the Vercel deployment comment"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -12,22 +22,26 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: verify-deployed-models-pr-${{ github.event.issue.number }}
+  group: verify-deployed-models-pr-${{ github.event.issue.number || github.event.inputs.pull_request_number }}
   cancel-in-progress: true
 
 jobs:
   prepare:
-    if: ${{ github.event.issue.pull_request && github.event.comment.user.login == 'vercel' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.issue.pull_request && github.event.comment.user.login == 'vercel') }}
     runs-on: ubuntu-latest
     outputs:
       base_sha: ${{ steps.context.outputs.base_sha }}
       head_sha: ${{ steps.context.outputs.head_sha }}
+      pull_request_number: ${{ steps.context.outputs.pull_request_number }}
       proxy_base_url: ${{ steps.context.outputs.proxy_base_url }}
       should_run: ${{ steps.context.outputs.should_run }}
     steps:
       - name: Resolve PR context from Vercel comment
         id: context
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        env:
+          MANUAL_PULL_REQUEST_NUMBER: ${{ github.event.inputs.pull_request_number || '' }}
+          MANUAL_VERCEL_COMMENT_ID: ${{ github.event.inputs.vercel_comment_id || '' }}
         with:
           script: |
             const readyStatuses = new Set(["DEPLOYED", "READY"]);
@@ -102,11 +116,38 @@ jobs:
                 comment_id: commentId,
               });
 
-              return parseComment(data.body || "");
+              return data;
             }
 
-            const commentId = context.payload.comment.id;
-            let parsed = parseComment(context.payload.comment.body || "");
+            const commentId =
+              context.eventName === "workflow_dispatch"
+                ? Number(process.env.MANUAL_VERCEL_COMMENT_ID)
+                : context.payload.comment.id;
+            const pullRequestNumber =
+              context.eventName === "workflow_dispatch"
+                ? Number(process.env.MANUAL_PULL_REQUEST_NUMBER)
+                : context.payload.issue.number;
+            const initialComment =
+              context.eventName === "workflow_dispatch"
+                ? await loadComment(commentId)
+                : context.payload.comment;
+
+            if (!Number.isInteger(commentId) || commentId <= 0) {
+              core.setFailed("A valid Vercel comment ID is required.");
+              return;
+            }
+
+            if (!Number.isInteger(pullRequestNumber) || pullRequestNumber <= 0) {
+              core.setFailed("A valid pull request number is required.");
+              return;
+            }
+
+            if (initialComment.user?.login !== "vercel") {
+              core.setFailed("The selected comment is not authored by the Vercel bot.");
+              return;
+            }
+
+            let parsed = parseComment(initialComment.body || "");
 
             if (!parsed) {
               core.setOutput("should_run", "false");
@@ -130,11 +171,12 @@ jobs:
                 const { data: pullRequest } = await github.rest.pulls.get({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  pull_number: context.payload.issue.number,
+                  pull_number: pullRequestNumber,
                 });
 
                 core.setOutput("base_sha", pullRequest.base.sha);
                 core.setOutput("head_sha", pullRequest.head.sha);
+                core.setOutput("pull_request_number", String(pullRequestNumber));
                 core.setOutput("proxy_base_url", `${parsed.previewUrl}/api/v1`);
                 core.setOutput("should_run", "true");
                 return;
@@ -148,7 +190,8 @@ jobs:
               }
 
               await sleep(pollDelayMs);
-              parsed = await loadComment(commentId);
+              const refreshedComment = await loadComment(commentId);
+              parsed = parseComment(refreshedComment.body || "");
               if (!parsed) {
                 core.setFailed("Unable to parse the updated Vercel deployment comment.");
                 return;
@@ -181,6 +224,7 @@ jobs:
           FAILED_MODELS_JSON: ${{ needs.verify.outputs.failed_models_json }}
           PASSED_COUNT: ${{ needs.verify.outputs.passed_count }}
           PASSED_MODELS_JSON: ${{ needs.verify.outputs.passed_models_json }}
+          PULL_REQUEST_NUMBER: ${{ needs.prepare.outputs.pull_request_number }}
           TESTED_MODELS_JSON: ${{ needs.verify.outputs.tested_models_json }}
           VERIFY_RESULT: ${{ needs.verify.result }}
         with:
@@ -213,7 +257,13 @@ jobs:
             const failedModels = parseJsonArray(process.env.FAILED_MODELS_JSON);
             const failedCount = Number(process.env.FAILED_COUNT || "0");
             const passedCount = Number(process.env.PASSED_COUNT || "0");
+            const pullRequestNumber = Number(process.env.PULL_REQUEST_NUMBER || "0");
             const verifyResult = process.env.VERIFY_RESULT || "unknown";
+
+            if (!Number.isInteger(pullRequestNumber) || pullRequestNumber <= 0) {
+              core.setFailed("Missing pull request number for verification comment.");
+              return;
+            }
 
             let statusLine = "Verification completed successfully.";
             if (verifyResult === "failure" || failedCount > 0) {
@@ -244,7 +294,7 @@ jobs:
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.issue.number,
+              issue_number: pullRequestNumber,
               per_page: 100,
             });
 
@@ -265,6 +315,6 @@ jobs:
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.issue.number,
+              issue_number: pullRequestNumber,
               body,
             });

--- a/.github/workflows/verify-deployed-models.yaml
+++ b/.github/workflows/verify-deployed-models.yaml
@@ -18,6 +18,25 @@ on:
       proxy_base_url:
         required: true
         type: string
+    outputs:
+      failed_count:
+        description: "How many models failed verification"
+        value: ${{ jobs.verify.outputs.failed_count }}
+      failed_models_json:
+        description: "JSON array of failed model ids"
+        value: ${{ jobs.verify.outputs.failed_models_json }}
+      passed_count:
+        description: "How many models passed verification"
+        value: ${{ jobs.verify.outputs.passed_count }}
+      passed_models_json:
+        description: "JSON array of passed model ids"
+        value: ${{ jobs.verify.outputs.passed_models_json }}
+      results_json:
+        description: "Full verification results JSON array"
+        value: ${{ jobs.verify.outputs.results_json }}
+      tested_models_json:
+        description: "JSON array of tested model ids"
+        value: ${{ jobs.verify.outputs.tested_models_json }}
     secrets:
       BRAINTRUST_API_KEY:
         required: true
@@ -46,6 +65,13 @@ on:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    outputs:
+      failed_count: ${{ steps.summary.outputs.failed_count }}
+      failed_models_json: ${{ steps.summary.outputs.failed_models_json }}
+      passed_count: ${{ steps.summary.outputs.passed_count }}
+      passed_models_json: ${{ steps.summary.outputs.passed_models_json }}
+      results_json: ${{ steps.summary.outputs.results_json }}
+      tested_models_json: ${{ steps.summary.outputs.tested_models_json }}
 
     steps:
       - name: Resolve checkout ref
@@ -134,7 +160,9 @@ jobs:
         run: echo "No models to verify."
 
       - name: Verify deployed models
+        id: verify
         if: steps.models.outputs.count != '0'
+        continue-on-error: true
         env:
           BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
@@ -144,4 +172,50 @@ jobs:
           pnpm dlx tsx packages/proxy/scripts/verify_proxy_models.ts \
             --proxy-base-url "${{ inputs.proxy_base_url }}" \
             --model-file "${{ steps.models.outputs.path }}" \
+            --output "$RUNNER_TEMP/verification-results.json" \
             --github-output "$GITHUB_OUTPUT"
+
+      - name: Summarize verification results
+        id: summary
+        if: always()
+        shell: bash
+        env:
+          MODEL_COUNT: ${{ steps.models.outputs.count }}
+        run: |
+          set -euo pipefail
+
+          if [ "${MODEL_COUNT:-0}" = "0" ]; then
+            {
+              echo "failed_count=0"
+              echo "failed_models_json=[]"
+              echo "passed_count=0"
+              echo "passed_models_json=[]"
+              echo "results_json=[]"
+              echo "tested_models_json=[]"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          node -e '
+          const fs = require("fs");
+          const path = process.argv[1];
+          const results = JSON.parse(fs.readFileSync(path, "utf8"));
+          const testedModels = results.map((result) => result.model);
+          const passedModels = results.filter((result) => result.ok).map((result) => result.model);
+          const failedModels = results.filter((result) => !result.ok).map((result) => result.model);
+          const output = process.env.GITHUB_OUTPUT;
+
+          fs.appendFileSync(output, `failed_count=${failedModels.length}\n`);
+          fs.appendFileSync(output, `failed_models_json=${JSON.stringify(failedModels)}\n`);
+          fs.appendFileSync(output, `passed_count=${passedModels.length}\n`);
+          fs.appendFileSync(output, `passed_models_json=${JSON.stringify(passedModels)}\n`);
+          fs.appendFileSync(output, `results_json=${JSON.stringify(results)}\n`);
+          fs.appendFileSync(output, `tested_models_json=${JSON.stringify(testedModels)}\n`);
+          ' "$RUNNER_TEMP/verification-results.json"
+
+      - name: Fail if verification failed
+        if: steps.verify.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "One or more models failed verification." >&2
+          exit 1

--- a/.github/workflows/verify-deployed-models.yaml
+++ b/.github/workflows/verify-deployed-models.yaml
@@ -7,6 +7,10 @@ on:
         required: false
         type: string
         default: ""
+      pull_request_number:
+        required: false
+        type: string
+        default: ""
       head_ref:
         required: false
         type: string
@@ -48,6 +52,10 @@ on:
         description: "Base git ref to diff against when model_ids_json is omitted"
         required: false
         type: string
+      pull_request_number:
+        description: "Pull request number to diff against when reading the PR head safely"
+        required: false
+        type: string
       head_ref:
         description: "Head git ref to diff from when model_ids_json is omitted"
         required: false
@@ -74,25 +82,10 @@ jobs:
       tested_models_json: ${{ steps.summary.outputs.tested_models_json }}
 
     steps:
-      - name: Resolve checkout ref
-        id: checkout-ref
-        shell: bash
-        env:
-          HEAD_REF: ${{ inputs.head_ref }}
-        run: |
-          set -euo pipefail
-
-          if [ -n "$HEAD_REF" ] && [ "$HEAD_REF" != "HEAD" ]; then
-            echo "ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
-          else
-            echo "ref=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ steps.checkout-ref.outputs.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -126,6 +119,7 @@ jobs:
           BASE_REF: ${{ inputs.base_ref }}
           EXPLICIT_MODEL_IDS_JSON: ${{ inputs.model_ids_json }}
           HEAD_REF: ${{ inputs.head_ref }}
+          PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number }}
         run: |
           set -euo pipefail
 
@@ -138,7 +132,21 @@ jobs:
             fi
 
             git show "${BASE_REF}:packages/proxy/schema/model_list.json" > "$RUNNER_TEMP/model_list.before.json"
-            git show "${HEAD_REF}:packages/proxy/schema/model_list.json" > "$RUNNER_TEMP/model_list.after.json"
+
+            if [ -n "$PULL_REQUEST_NUMBER" ]; then
+              pr_head_ref="refs/remotes/origin/pr-${PULL_REQUEST_NUMBER}-head"
+              git fetch --no-tags --depth=1 origin "refs/pull/${PULL_REQUEST_NUMBER}/head:${pr_head_ref}"
+              git show "${pr_head_ref}:packages/proxy/schema/model_list.json" > "$RUNNER_TEMP/model_list.after.json"
+            else
+              if [ -z "$HEAD_REF" ] || [ "$HEAD_REF" = "HEAD" ]; then
+                echo "Either pull_request_number or a non-HEAD head_ref must be provided" >&2
+                exit 1
+              fi
+
+              temp_head_ref="refs/remotes/origin/verify-head"
+              git fetch --no-tags --depth=1 origin "${HEAD_REF}:${temp_head_ref}"
+              git show "${temp_head_ref}:packages/proxy/schema/model_list.json" > "$RUNNER_TEMP/model_list.after.json"
+            fi
 
             pnpm dlx tsx packages/proxy/scripts/collect_changed_model_ids.ts \
               --before "$RUNNER_TEMP/model_list.before.json" \

--- a/.github/workflows/verify-deployed-models.yaml
+++ b/.github/workflows/verify-deployed-models.yaml
@@ -15,6 +15,10 @@ on:
         required: false
         type: string
         default: "HEAD"
+      head_sha:
+        required: false
+        type: string
+        default: ""
       model_ids_json:
         required: false
         type: string
@@ -61,6 +65,10 @@ on:
         required: false
         type: string
         default: "HEAD"
+      head_sha:
+        description: "Pinned head commit SHA to diff from when reading a PR safely"
+        required: false
+        type: string
       model_ids_json:
         description: "Optional JSON string array of model ids to verify"
         required: false
@@ -119,6 +127,7 @@ jobs:
           BASE_REF: ${{ inputs.base_ref }}
           EXPLICIT_MODEL_IDS_JSON: ${{ inputs.model_ids_json }}
           HEAD_REF: ${{ inputs.head_ref }}
+          HEAD_SHA: ${{ inputs.head_sha }}
           PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number }}
         run: |
           set -euo pipefail
@@ -134,9 +143,14 @@ jobs:
             git show "${BASE_REF}:packages/proxy/schema/model_list.json" > "$RUNNER_TEMP/model_list.before.json"
 
             if [ -n "$PULL_REQUEST_NUMBER" ]; then
-              pr_head_ref="refs/remotes/origin/pr-${PULL_REQUEST_NUMBER}-head"
-              git fetch --no-tags --depth=1 origin "refs/pull/${PULL_REQUEST_NUMBER}/head:${pr_head_ref}"
-              git show "${pr_head_ref}:packages/proxy/schema/model_list.json" > "$RUNNER_TEMP/model_list.after.json"
+              if [ -z "$HEAD_SHA" ]; then
+                echo "head_sha is required when pull_request_number is provided" >&2
+                exit 1
+              fi
+
+              pinned_head_ref="refs/remotes/origin/verify-head"
+              git fetch --no-tags --depth=1 origin "${HEAD_SHA}:${pinned_head_ref}"
+              git show "${pinned_head_ref}:packages/proxy/schema/model_list.json" > "$RUNNER_TEMP/model_list.after.json"
             else
               if [ -z "$HEAD_REF" ] || [ "$HEAD_REF" = "HEAD" ]; then
                 echo "Either pull_request_number or a non-HEAD head_ref must be provided" >&2

--- a/.github/workflows/verify-deployed-models.yaml
+++ b/.github/workflows/verify-deployed-models.yaml
@@ -1,0 +1,132 @@
+name: Verify deployed models
+
+on:
+  workflow_call:
+    inputs:
+      base_ref:
+        required: false
+        type: string
+        default: ""
+      head_ref:
+        required: false
+        type: string
+        default: "HEAD"
+      model_ids_json:
+        required: false
+        type: string
+        default: ""
+      proxy_base_url:
+        required: true
+        type: string
+    secrets:
+      BRAINTRUST_API_KEY:
+        required: true
+      VERCEL_AUTOMATION_BYPASS_SECRET:
+        required: true
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: "Base git ref to diff against when model_ids_json is omitted"
+        required: false
+        type: string
+      head_ref:
+        description: "Head git ref to diff from when model_ids_json is omitted"
+        required: false
+        type: string
+        default: "HEAD"
+      model_ids_json:
+        description: "Optional JSON string array of model ids to verify"
+        required: false
+        type: string
+      proxy_base_url:
+        description: "Proxy base URL, for example https://preview.example.com/api/v1"
+        required: true
+        type: string
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 20
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+        with:
+          version: 10.33.0
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Resolve models to verify
+        id: models
+        shell: bash
+        env:
+          BASE_REF: ${{ inputs.base_ref }}
+          EXPLICIT_MODEL_IDS_JSON: ${{ inputs.model_ids_json }}
+          HEAD_REF: ${{ inputs.head_ref }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "$EXPLICIT_MODEL_IDS_JSON" ]; then
+            printf '%s' "$EXPLICIT_MODEL_IDS_JSON" > "$RUNNER_TEMP/changed-models.json"
+          else
+            if [ -z "$BASE_REF" ]; then
+              echo "Either model_ids_json or base_ref must be provided" >&2
+              exit 1
+            fi
+
+            git show "${BASE_REF}:packages/proxy/schema/model_list.json" > "$RUNNER_TEMP/model_list.before.json"
+            git show "${HEAD_REF}:packages/proxy/schema/model_list.json" > "$RUNNER_TEMP/model_list.after.json"
+
+            pnpm dlx tsx packages/proxy/scripts/collect_changed_model_ids.ts \
+              --before "$RUNNER_TEMP/model_list.before.json" \
+              --after "$RUNNER_TEMP/model_list.after.json" \
+              --output "$RUNNER_TEMP/changed-models.json"
+          fi
+
+          compact_json=$(node -e 'const fs=require("fs"); const parsed=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); process.stdout.write(JSON.stringify(parsed));' "$RUNNER_TEMP/changed-models.json")
+          count=$(node -e 'const fs=require("fs"); const parsed=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); process.stdout.write(String(parsed.length));' "$RUNNER_TEMP/changed-models.json")
+
+          {
+            echo "json=$compact_json"
+            echo "count=$count"
+            echo "path=$RUNNER_TEMP/changed-models.json"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Skip when no models changed
+        if: steps.models.outputs.count == '0'
+        run: echo "No models to verify."
+
+      - name: Verify deployed models
+        if: steps.models.outputs.count != '0'
+        env:
+          BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+        run: |
+          set -euo pipefail
+
+          pnpm dlx tsx packages/proxy/scripts/verify_proxy_models.ts \
+            --proxy-base-url "${{ inputs.proxy_base_url }}" \
+            --model-file "${{ steps.models.outputs.path }}" \
+            --github-output "$GITHUB_OUTPUT"

--- a/.github/workflows/verify-deployed-models.yaml
+++ b/.github/workflows/verify-deployed-models.yaml
@@ -48,10 +48,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Resolve checkout ref
+        id: checkout-ref
+        shell: bash
+        env:
+          HEAD_REF: ${{ inputs.head_ref }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "$HEAD_REF" ] && [ "$HEAD_REF" != "HEAD" ]; then
+            echo "ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          ref: ${{ steps.checkout-ref.outputs.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/packages/proxy/scripts/verify_proxy_models.test.ts
+++ b/packages/proxy/scripts/verify_proxy_models.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  addSlugQueryParams,
   buildVerificationRequest,
   extractErrorMessage,
   resolveBraintrustApiKey,
@@ -94,19 +93,6 @@ describe("extractErrorMessage", () => {
 
   it("falls back to raw text", () => {
     expect(extractErrorMessage("plain text error")).toBe("plain text error");
-  });
-});
-
-describe("addSlugQueryParams", () => {
-  it("adds slug query params for the endpoint path", () => {
-    const url = addSlugQueryParams(
-      new URL("https://example.com/api/v1/chat/completions"),
-      "chat/completions",
-    );
-
-    expect(url.toString()).toBe(
-      "https://example.com/api/v1/chat/completions?slug=chat&slug=completions",
-    );
   });
 });
 

--- a/packages/proxy/scripts/verify_proxy_models.test.ts
+++ b/packages/proxy/scripts/verify_proxy_models.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import {
+  addSlugQueryParams,
+  buildVerificationRequest,
+  extractErrorMessage,
+  resolveBraintrustApiKey,
+  resolveVercelProtectionBypassSecret,
+} from "./verify_proxy_models";
+
+describe("buildVerificationRequest", () => {
+  it("builds a chat completion verification request", () => {
+    expect(
+      buildVerificationRequest("gpt-4o", {
+        flavor: "chat",
+        format: "openai",
+      }),
+    ).toEqual({
+      body: {
+        messages: [
+          {
+            content: "ok",
+            role: "user",
+          },
+        ],
+        model: "gpt-4o",
+      },
+      endpoint: "chat/completions",
+    });
+  });
+
+  it("builds a completion verification request", () => {
+    expect(
+      buildVerificationRequest("gpt-3.5-turbo-instruct", {
+        flavor: "completion",
+        format: "openai",
+      }),
+    ).toEqual({
+      body: {
+        model: "gpt-3.5-turbo-instruct",
+        prompt: "ok",
+      },
+      endpoint: "completions",
+    });
+  });
+
+  it("builds an embedding verification request", () => {
+    expect(
+      buildVerificationRequest("text-embedding-3-small", {
+        flavor: "embedding",
+        format: "openai",
+      }),
+    ).toEqual({
+      body: {
+        input: "ok",
+        model: "text-embedding-3-small",
+      },
+      endpoint: "embeddings",
+    });
+  });
+});
+
+describe("extractErrorMessage", () => {
+  it("returns nested OpenAI-style error messages", () => {
+    expect(
+      extractErrorMessage(
+        JSON.stringify({
+          error: {
+            message: "Unsupported model",
+          },
+        }),
+      ),
+    ).toBe("Unsupported model");
+  });
+
+  it("returns top-level messages", () => {
+    expect(
+      extractErrorMessage(
+        JSON.stringify({
+          message: "No API keys found",
+        }),
+      ),
+    ).toBe("No API keys found");
+  });
+
+  it("falls back to raw text", () => {
+    expect(extractErrorMessage("plain text error")).toBe("plain text error");
+  });
+});
+
+describe("addSlugQueryParams", () => {
+  it("adds slug query params for the endpoint path", () => {
+    const url = addSlugQueryParams(
+      new URL("https://example.com/api/v1/chat/completions"),
+      "chat/completions",
+    );
+
+    expect(url.toString()).toBe(
+      "https://example.com/api/v1/chat/completions?slug=chat&slug=completions",
+    );
+  });
+});
+
+describe("resolveBraintrustApiKey", () => {
+  it("uses an explicit key when present", () => {
+    expect(resolveBraintrustApiKey("braintrust-key")).toBe("braintrust-key");
+  });
+
+  it("falls back to BRAINTRUST_API_KEY", () => {
+    process.env.BRAINTRUST_API_KEY = "braintrust-env-key";
+
+    expect(resolveBraintrustApiKey()).toBe("braintrust-env-key");
+
+    delete process.env.BRAINTRUST_API_KEY;
+  });
+
+  it("throws when no Braintrust key exists", () => {
+    delete process.env.BRAINTRUST_API_KEY;
+
+    expect(() => resolveBraintrustApiKey()).toThrow("Missing API key");
+  });
+});
+
+describe("resolveVercelProtectionBypassSecret", () => {
+  it("uses an explicit secret when present", () => {
+    expect(resolveVercelProtectionBypassSecret("bypass-secret")).toBe(
+      "bypass-secret",
+    );
+  });
+
+  it("falls back to VERCEL_AUTOMATION_BYPASS_SECRET", () => {
+    process.env.VERCEL_AUTOMATION_BYPASS_SECRET = "bypass-env-secret";
+
+    expect(resolveVercelProtectionBypassSecret()).toBe("bypass-env-secret");
+
+    delete process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  });
+
+  it("throws when no bypass secret exists", () => {
+    delete process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+
+    expect(() => resolveVercelProtectionBypassSecret()).toThrow(
+      "Missing preview bypass secret",
+    );
+  });
+});

--- a/packages/proxy/scripts/verify_proxy_models.test.ts
+++ b/packages/proxy/scripts/verify_proxy_models.test.ts
@@ -8,7 +8,7 @@ import {
 } from "./verify_proxy_models";
 
 describe("buildVerificationRequest", () => {
-  it("builds a chat completion verification request", () => {
+  it("builds a chat completion verification request for chat models", () => {
     expect(
       buildVerificationRequest("gpt-4o", {
         flavor: "chat",
@@ -28,7 +28,7 @@ describe("buildVerificationRequest", () => {
     });
   });
 
-  it("builds a completion verification request", () => {
+  it("uses chat completions for completion models too", () => {
     expect(
       buildVerificationRequest("gpt-3.5-turbo-instruct", {
         flavor: "completion",
@@ -36,14 +36,19 @@ describe("buildVerificationRequest", () => {
       }),
     ).toEqual({
       body: {
+        messages: [
+          {
+            content: "ok",
+            role: "user",
+          },
+        ],
         model: "gpt-3.5-turbo-instruct",
-        prompt: "ok",
       },
-      endpoint: "completions",
+      endpoint: "chat/completions",
     });
   });
 
-  it("builds an embedding verification request", () => {
+  it("uses chat completions for embedding models too", () => {
     expect(
       buildVerificationRequest("text-embedding-3-small", {
         flavor: "embedding",
@@ -51,10 +56,15 @@ describe("buildVerificationRequest", () => {
       }),
     ).toEqual({
       body: {
-        input: "ok",
+        messages: [
+          {
+            content: "ok",
+            role: "user",
+          },
+        ],
         model: "text-embedding-3-small",
       },
-      endpoint: "embeddings",
+      endpoint: "chat/completions",
     });
   });
 });

--- a/packages/proxy/scripts/verify_proxy_models.ts
+++ b/packages/proxy/scripts/verify_proxy_models.ts
@@ -1,0 +1,342 @@
+import fs from "fs";
+import { pathToFileURL } from "url";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+import { getAvailableModels, type ModelSpec } from "../schema/models";
+
+type VerificationRequest = {
+  endpoint: string;
+  body: Record<string, unknown>;
+};
+
+type VerificationResult = {
+  endpoint: string;
+  error?: string;
+  model: string;
+  ok: boolean;
+  responseBody: string;
+  status?: number;
+};
+
+function withTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value : `${value}/`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readModelIdsFromFile(path: string): string[] {
+  const parsed: unknown = JSON.parse(fs.readFileSync(path, "utf8"));
+  if (
+    !Array.isArray(parsed) ||
+    !parsed.every((value) => typeof value === "string")
+  ) {
+    throw new Error(`Model file must be a JSON array of strings: ${path}`);
+  }
+  return parsed;
+}
+
+function uniqueModelIds(modelIds: string[]): string[] {
+  return Array.from(
+    new Set(modelIds.map((modelId) => modelId.trim()).filter(Boolean)),
+  );
+}
+
+export function addSlugQueryParams(url: URL, endpoint: string): URL {
+  for (const segment of endpoint.split("/").filter(Boolean)) {
+    url.searchParams.append("slug", segment);
+  }
+  return url;
+}
+
+export function resolveBraintrustApiKey(explicitApiKey?: string): string {
+  const apiKey = explicitApiKey ?? process.env.BRAINTRUST_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "Missing API key. Pass --api-key or set BRAINTRUST_API_KEY.",
+    );
+  }
+  return apiKey;
+}
+
+export function resolveVercelProtectionBypassSecret(
+  explicitSecret?: string,
+): string {
+  const secret = explicitSecret ?? process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  if (!secret) {
+    throw new Error(
+      "Missing preview bypass secret. Pass --vercel-protection-bypass or set VERCEL_AUTOMATION_BYPASS_SECRET.",
+    );
+  }
+  return secret;
+}
+
+export function buildVerificationRequest(
+  model: string,
+  modelSpec: ModelSpec,
+): VerificationRequest {
+  switch (modelSpec.flavor) {
+    case "chat":
+      return {
+        endpoint: "chat/completions",
+        body: {
+          messages: [
+            {
+              content: "ok",
+              role: "user",
+            },
+          ],
+          model,
+        },
+      };
+    case "completion":
+      return {
+        endpoint: "completions",
+        body: {
+          model,
+          prompt: "ok",
+        },
+      };
+    case "embedding":
+      return {
+        endpoint: "embeddings",
+        body: {
+          input: "ok",
+          model,
+        },
+      };
+  }
+}
+
+export function extractErrorMessage(responseBody: string): string {
+  if (responseBody.length === 0) {
+    return "Empty response body";
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(responseBody);
+    if (isRecord(parsed) && typeof parsed.message === "string") {
+      return parsed.message;
+    }
+
+    const errorValue = isRecord(parsed) ? parsed.error : undefined;
+    if (isRecord(errorValue) && typeof errorValue.message === "string") {
+      return errorValue.message;
+    }
+  } catch (_error) {
+    return responseBody;
+  }
+
+  return responseBody;
+}
+
+async function verifyModel(args: {
+  apiKey: string;
+  model: string;
+  modelSpec: ModelSpec;
+  proxyBaseUrl: string;
+  timeoutMs: number;
+  vercelProtectionBypassSecret: string;
+}): Promise<VerificationResult> {
+  const request = buildVerificationRequest(args.model, args.modelSpec);
+  const url = addSlugQueryParams(
+    new URL(request.endpoint, withTrailingSlash(args.proxyBaseUrl)),
+    request.endpoint,
+  );
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), args.timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      body: JSON.stringify(request.body),
+      headers: {
+        authorization: `Bearer ${args.apiKey}`,
+        "content-type": "application/json",
+        "x-bt-use-cache": "never",
+        "x-bt-use-creds-cache": "never",
+        "x-vercel-protection-bypass": args.vercelProtectionBypassSecret,
+      },
+      method: "POST",
+      signal: controller.signal,
+    });
+    const responseBody = await response.text();
+
+    return {
+      endpoint: request.endpoint,
+      model: args.model,
+      ok: response.ok,
+      responseBody,
+      status: response.status,
+    };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      endpoint: request.endpoint,
+      error: message,
+      model: args.model,
+      ok: false,
+      responseBody: message,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function main(): Promise<void> {
+  const argv = await yargs(hideBin(process.argv))
+    .option("api-key", {
+      describe:
+        "Braintrust API key to send to the proxy. Defaults to BRAINTRUST_API_KEY.",
+      type: "string",
+    })
+    .option("github-output", {
+      describe: "Optional path to the GitHub Actions output file",
+      type: "string",
+    })
+    .option("max-attempts", {
+      default: 3,
+      describe: "How many attempts to make per model before failing",
+      type: "number",
+    })
+    .option("model", {
+      array: true,
+      describe: "Model id to verify. Can be passed multiple times.",
+      type: "string",
+    })
+    .option("model-file", {
+      describe: "Path to a JSON file containing a string array of model ids",
+      type: "string",
+    })
+    .option("output", {
+      describe: "Optional path to write the verification results JSON",
+      type: "string",
+    })
+    .option("proxy-base-url", {
+      demandOption: true,
+      describe:
+        "Proxy base URL, for example https://preview.example.com/api/v1",
+      type: "string",
+    })
+    .option("vercel-protection-bypass", {
+      describe:
+        "Vercel deployment protection bypass secret. Defaults to VERCEL_AUTOMATION_BYPASS_SECRET.",
+      type: "string",
+    })
+    .option("retry-delay-ms", {
+      default: 5000,
+      describe: "Delay between verification attempts for the same model",
+      type: "number",
+    })
+    .option("timeout-ms", {
+      default: 30000,
+      describe: "Timeout for each verification request",
+      type: "number",
+    })
+    .strict()
+    .help()
+    .parseAsync();
+  const apiKey = resolveBraintrustApiKey(argv["api-key"]);
+  const vercelProtectionBypassSecret = resolveVercelProtectionBypassSecret(
+    argv["vercel-protection-bypass"],
+  );
+
+  const fileModels = argv["model-file"]
+    ? readModelIdsFromFile(argv["model-file"])
+    : [];
+  const cliModels = argv.model ?? [];
+  const modelIds = uniqueModelIds([...cliModels, ...fileModels]);
+  if (modelIds.length === 0) {
+    throw new Error("No models provided. Pass --model and/or --model-file.");
+  }
+
+  const availableModels = getAvailableModels();
+  const results: VerificationResult[] = [];
+
+  for (const model of modelIds) {
+    const modelSpec = availableModels[model];
+    if (!modelSpec) {
+      results.push({
+        endpoint: "n/a",
+        error: "Model is not present in the local catalog",
+        model,
+        ok: false,
+        responseBody: "Model is not present in the local catalog",
+      });
+      continue;
+    }
+
+    let result: VerificationResult | null = null;
+    for (let attempt = 1; attempt <= argv["max-attempts"]; attempt++) {
+      result = await verifyModel({
+        apiKey,
+        model,
+        modelSpec,
+        proxyBaseUrl: argv["proxy-base-url"],
+        timeoutMs: argv["timeout-ms"],
+        vercelProtectionBypassSecret,
+      });
+      if (result.ok) {
+        break;
+      }
+
+      if (attempt < argv["max-attempts"]) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, argv["retry-delay-ms"]),
+        );
+      }
+    }
+
+    if (result) {
+      results.push(result);
+    }
+  }
+
+  if (argv.output) {
+    await fs.promises.writeFile(
+      argv.output,
+      JSON.stringify(results, null, 2) + "\n",
+    );
+  }
+
+  const failed = results.filter((result) => !result.ok);
+  const verified = results.length - failed.length;
+
+  if (argv["github-output"]) {
+    await fs.promises.appendFile(
+      argv["github-output"],
+      `verified_count=${verified}\nfailed_count=${failed.length}\n`,
+    );
+  }
+
+  for (const result of results) {
+    if (result.ok) {
+      console.log(
+        `Verified ${result.model} via ${result.endpoint} (${result.status ?? "unknown status"})`,
+      );
+      continue;
+    }
+
+    const detail = result.error ?? extractErrorMessage(result.responseBody);
+    console.error(
+      `Failed ${result.model} via ${result.endpoint} (${result.status ?? "request error"}): ${detail}`,
+    );
+  }
+
+  if (failed.length > 0) {
+    throw new Error(
+      `Failed to verify ${failed.length} model${failed.length === 1 ? "" : "s"}: ${failed
+        .map((result) => result.model)
+        .join(", ")}`,
+    );
+  }
+}
+
+const entryPointPath = process.argv[1];
+if (entryPointPath && import.meta.url === pathToFileURL(entryPointPath).href) {
+  void main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    process.exit(1);
+  });
+}

--- a/packages/proxy/scripts/verify_proxy_models.ts
+++ b/packages/proxy/scripts/verify_proxy_models.ts
@@ -74,39 +74,20 @@ export function resolveVercelProtectionBypassSecret(
 
 export function buildVerificationRequest(
   model: string,
-  modelSpec: ModelSpec,
+  _modelSpec: ModelSpec,
 ): VerificationRequest {
-  switch (modelSpec.flavor) {
-    case "chat":
-      return {
-        endpoint: "chat/completions",
-        body: {
-          messages: [
-            {
-              content: "ok",
-              role: "user",
-            },
-          ],
-          model,
+  return {
+    endpoint: "chat/completions",
+    body: {
+      messages: [
+        {
+          content: "ok",
+          role: "user",
         },
-      };
-    case "completion":
-      return {
-        endpoint: "completions",
-        body: {
-          model,
-          prompt: "ok",
-        },
-      };
-    case "embedding":
-      return {
-        endpoint: "embeddings",
-        body: {
-          input: "ok",
-          model,
-        },
-      };
-  }
+      ],
+      model,
+    },
+  };
 }
 
 export function extractErrorMessage(responseBody: string): string {

--- a/packages/proxy/scripts/verify_proxy_models.ts
+++ b/packages/proxy/scripts/verify_proxy_models.ts
@@ -43,13 +43,6 @@ function uniqueModelIds(modelIds: string[]): string[] {
   );
 }
 
-export function addSlugQueryParams(url: URL, endpoint: string): URL {
-  for (const segment of endpoint.split("/").filter(Boolean)) {
-    url.searchParams.append("slug", segment);
-  }
-  return url;
-}
-
 export function resolveBraintrustApiKey(explicitApiKey?: string): string {
   const apiKey = explicitApiKey ?? process.env.BRAINTRUST_API_KEY;
   if (!apiKey) {
@@ -121,10 +114,7 @@ async function verifyModel(args: {
   vercelProtectionBypassSecret: string;
 }): Promise<VerificationResult> {
   const request = buildVerificationRequest(args.model, args.modelSpec);
-  const url = addSlugQueryParams(
-    new URL(request.endpoint, withTrailingSlash(args.proxyBaseUrl)),
-    request.endpoint,
-  );
+  const url = new URL(request.endpoint, withTrailingSlash(args.proxyBaseUrl));
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), args.timeoutMs);
 


### PR DESCRIPTION
#### Background

I do not like that when I add a model to the model_list I don't know if it will work or not. I pray and I hope but that is not good enough. 

I would like a flow where once a model is added I roughly just test if some simple output can be returned.

#### Changes
This PR adds two jobs. One workflow reads our deployment comment, parses the preview url, kicks off a verification job and then posts a comment. The other workflow verifies the models with a request. 

Long term vision is that I would like to test the model list with the gateway as well.

