### PR TITLE
feat: expose api_base on Ollama provider metadata schema

### DIFF
--- a/packages/proxy/schema/index.test.ts
+++ b/packages/proxy/schema/index.test.ts
@@ -331,4 +331,29 @@ describe("APISecretSchema compatibility", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it("preserves passthrough behavior for legacy Ollama api_base values", () => {
+    const cases: Array<{ name: string; api_base: unknown }> = [
+      { name: "invalid url string", api_base: "not a url" },
+      { name: "bare hostname", api_base: "localhost" },
+      { name: "number", api_base: 12345 },
+      { name: "boolean", api_base: true },
+      { name: "object", api_base: { nested: 1 } },
+    ];
+
+    for (const { name, api_base } of cases) {
+      const parsed = APISecretSchema.parse({
+        secret: "ollama-secret",
+        type: "ollama",
+        metadata: { api_base },
+      });
+      if (parsed.type !== "ollama") {
+        throw new Error(`Expected ollama secret for case '${name}'`);
+      }
+      expect(
+        parsed.metadata?.api_base,
+        `case '${name}' should coerce to undefined to preserve runtime fallback`,
+      ).toBeUndefined();
+    }
+  });
 });

--- a/packages/proxy/schema/secrets.ts
+++ b/packages/proxy/schema/secrets.ts
@@ -131,7 +131,10 @@ export const MistralMetadataSchema = BaseMetadataSchema.merge(
 
 export const OllamaMetadataSchema = BaseMetadataSchema.merge(
   z.object({
-    api_base: z.union([z.string().url(), z.string().length(0)]).nullish(),
+    api_base: z
+      .union([z.string().url(), z.string().length(0)])
+      .nullish()
+      .catch(undefined),
   }),
 ).passthrough();
 

--- a/packages/proxy/schema/secrets.ts
+++ b/packages/proxy/schema/secrets.ts
@@ -129,6 +129,12 @@ export const MistralMetadataSchema = BaseMetadataSchema.merge(
   }),
 ).passthrough();
 
+export const OllamaMetadataSchema = BaseMetadataSchema.merge(
+  z.object({
+    api_base: z.union([z.string().url(), z.string().length(0)]).nullish(),
+  }),
+).passthrough();
+
 export const BraintrustMetadataSchema = BaseMetadataSchema.merge(
   z.object({
     api_base: z.union([z.string().url(), z.string().length(0)]).nullish(),
@@ -155,7 +161,6 @@ export const APISecretSchema = z.union([
         "replicate",
         "together",
         "baseten",
-        "ollama",
         "groq",
         "lepton",
         "fireworks",
@@ -206,6 +211,12 @@ export const APISecretSchema = z.union([
     z.object({
       type: z.literal("mistral"),
       metadata: MistralMetadataSchema.nullish(),
+    }),
+  ).passthrough(),
+  APISecretBaseSchema.merge(
+    z.object({
+      type: z.literal("ollama"),
+      metadata: OllamaMetadataSchema.nullish(),
     }),
   ).passthrough(),
 ]);


### PR DESCRIPTION
Add a typed `api_base` field to the Ollama provider's metadata so it can be customized in the AI providers form (e.g. to point at a self-hosted or tunnelled Ollama instance instead of the default `http://127.0.0.1:11434/v1`).

The proxy already honors `secret.metadata.api_base` generically at runtime, so this is a schema-only change. It mirrors the existing `MistralMetadataSchema` shape:

- Promote `ollama` from the bulk `z.enum` to its own discriminated union arm with `OllamaMetadataSchema` metadata.
- `OllamaMetadataSchema` is `BaseMetadataSchema` plus an optional `api_base` (allows valid URL, empty string, null, or undefined to preserve the default).

Existing Ollama secrets continue to validate (the new schema is a strict superset), so no migration is required.