### PR TITLE
Add Wafer as a model provider

### DIFF
--- a/packages/proxy/schema/index.ts
+++ b/packages/proxy/schema/index.ts
@@ -1098,6 +1098,7 @@ export const AISecretTypes: { [keyName: string]: ModelEndpointType } = {
   CEREBRAS_API_KEY: "cerebras",
   REPLICATE_API_KEY: "replicate",
   BASETEN_API_KEY: "baseten",
+  WAFER_API_KEY: "wafer",
 };
 
 export const CloudSecretTypes: { [keyName: string]: ModelEndpointType } = {
@@ -1125,6 +1126,7 @@ export const EndpointProviderToBaseURL: {
   baseten: "https://inference.baseten.co/v1",
   cerebras: "https://api.cerebras.ai/v1",
   xAI: "https://api.x.ai/v1",
+  wafer: "https://pass.wafer.ai/v1",
   bedrock: null,
   vertex: null,
   azure: null,

--- a/packages/proxy/schema/model_list.json
+++ b/packages/proxy/schema/model_list.json
@@ -12692,5 +12692,94 @@
     "available_providers": [
       "bedrock"
     ]
+  },
+  "GLM-5.1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 3.6,
+    "input_cache_read_cost_per_mil_tokens": 0.12,
+    "displayName": "GLM-5.1",
+    "reasoning": true,
+    "max_input_tokens": 202752,
+    "available_providers": [
+      "wafer"
+    ]
+  },
+  "Kimi-K2.6": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.88,
+    "output_cost_per_mil_tokens": 3.84,
+    "input_cache_read_cost_per_mil_tokens": 0.09,
+    "displayName": "Kimi K2.6",
+    "reasoning": true,
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "wafer"
+    ]
+  },
+  "Qwen3.5-397B-A17B": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.48,
+    "output_cost_per_mil_tokens": 2.88,
+    "input_cache_read_cost_per_mil_tokens": 0.05,
+    "displayName": "Qwen3.5 397B A17B",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "wafer"
+    ]
+  },
+  "Qwen3.6-35B-A3B": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 1.0,
+    "input_cache_read_cost_per_mil_tokens": 0.02,
+    "displayName": "Qwen3.6 35B A3B",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "wafer"
+    ]
+  },
+  "qwen3.7-max": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 5.0,
+    "output_cost_per_mil_tokens": 15.0,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "Qwen3.7 Max",
+    "max_input_tokens": 256000,
+    "available_providers": [
+      "wafer"
+    ]
+  },
+  "deepseek-v4-flash": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.14,
+    "output_cost_per_mil_tokens": 0.28,
+    "input_cache_read_cost_per_mil_tokens": 0.01,
+    "displayName": "DeepSeek V4 Flash",
+    "max_input_tokens": 1000000,
+    "available_providers": [
+      "wafer"
+    ]
+  },
+  "deepseek-v4-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.74,
+    "output_cost_per_mil_tokens": 3.48,
+    "input_cache_read_cost_per_mil_tokens": 0.02,
+    "displayName": "DeepSeek V4 Pro",
+    "max_input_tokens": 1000000,
+    "available_providers": [
+      "wafer"
+    ]
   }
 }

--- a/packages/proxy/schema/models.ts
+++ b/packages/proxy/schema/models.ts
@@ -37,6 +37,7 @@ export const ModelEndpointType = [
   "cerebras",
   "ollama",
   "replicate",
+  "wafer",
   "js",
 ] as const;
 export type ModelEndpointType = (typeof ModelEndpointType)[number];

--- a/packages/proxy/schema/secrets.ts
+++ b/packages/proxy/schema/secrets.ts
@@ -212,6 +212,7 @@ export const APISecretSchema = z.union([
         "fireworks",
         "cerebras",
         "xAI",
+        "wafer",
         "js",
       ]),
       metadata: BaseMetadataSchema.nullish(),

--- a/packages/proxy/scripts/verify_proxy_models.ts
+++ b/packages/proxy/scripts/verify_proxy_models.ts
@@ -23,6 +23,7 @@ type ModelEndpointType =
   | "cerebras"
   | "ollama"
   | "replicate"
+  | "wafer"
   | "js";
 
 type ModelFormat =


### PR DESCRIPTION
## Summary
- Adds Wafer (https://wafer.ai) as a new endpoint type alongside `cerebras`, `groq`, `together`, etc.
- Wafer's serverless catalog is exposed at `https://pass.wafer.ai/v1` and is OpenAI-compatible (chat completions, streaming, tools, `/v1/models`), so it slots into the existing OpenAI-format passthrough — **no new request/response translator is needed**.
- Registers the 7 publicly-listed Wafer models with `available_providers: ["wafer"]`. Pricing and context lengths come straight from `https://pass.wafer.ai/v1/models` on 2026-05-27.

## Changes
- `packages/proxy/schema/models.ts` — add `"wafer"` to `ModelEndpointType`.
- `packages/proxy/schema/secrets.ts` — add `"wafer"` to the simple-types enum in `APISecretSchema`.
- `packages/proxy/schema/index.ts` — register `WAFER_API_KEY` → `wafer` in `AISecretTypes` and `EndpointProviderToBaseURL.wafer = "https://pass.wafer.ai/v1"`.
- `packages/proxy/schema/model_list.json` — add the 7 Wafer-served public models:
  - `GLM-5.1` ($1.20 / $3.60 per Mtok, 203K ctx)
  - `Kimi-K2.6` ($0.88 / $3.84, 262K ctx, multimodal)
  - `Qwen3.5-397B-A17B` ($0.48 / $2.88, 262K ctx, multimodal)
  - `Qwen3.6-35B-A3B` ($0.15 / $1.00, 262K ctx, multimodal)
  - `qwen3.7-max` ($5.00 / $15.00, 256K ctx)
  - `deepseek-v4-flash` ($0.14 / $0.28, 1M ctx)
  - `deepseek-v4-pro` ($1.74 / $3.48, 1M ctx)
- `packages/proxy/scripts/verify_proxy_models.ts` — keep the local `ModelEndpointType` mirror in sync.

## How it works at request time
A secret of `type: "wafer"` with `secret: <WAFER_API_KEY>` is routed through `fetchOpenAI` exactly like cerebras/groq/together: `EndpointProviderToBaseURL.wafer` supplies the base URL, the `Authorization: Bearer <key>` header is set by the shared code path, and the chat-completions body is forwarded unchanged. End users can call any of the model IDs above through the proxy and get OpenAI-formatted responses back.

## Test plan
- [x] `pnpm install && pnpm --filter @braintrust/proxy build` — clean (TS build succeeds, including the schema d.ts regeneration).
- [x] `pnpm test` — same 89 pre-existing failures as `main` (all "No API keys found" against live providers; no new failures introduced).
- [x] `python3 -c 'import json; json.load(open("packages/proxy/schema/model_list.json"))'` — model list still parses.
- [ ] Smoke-test end-to-end through a deployed proxy with a real `WAFER_API_KEY` against e.g. `GLM-5.1`. Happy to do this once a maintainer points me at the right staging entry point — or it can be done at review time.

## Notes
- I'm posting this as a draft so you can shape the wiring (naming, where to register, whether you want an `"available_regions"` value, etc.) before I clean it up.
- Happy to add a `WaferMetadataSchema` later (e.g. for an `api_base` override so on-prem / EU edges can be pointed at directly), but didn't include one in this PR to keep the diff minimal — Wafer customers on the default region don't need any metadata.