### PR TITLE
limit the customFetch to non-Request objects. simplifies implementations and clearer boundary

### DIFF
--- a/packages/proxy/src/providers/databricks.ts
+++ b/packages/proxy/src/providers/databricks.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { DatabricksOAuthSecretSchema } from "@braintrust/proxy/schema";
+import { type FetchFn } from "../proxy";
 
 const databricksOAuthResponseSchema = z.union([
   z.object({
@@ -30,7 +31,7 @@ export async function getDatabricksOAuthAccessToken({
     value: string,
     ttl_seconds?: number,
   ) => Promise<void>;
-  fetch?: typeof globalThis.fetch;
+  fetch?: FetchFn;
 }): Promise<string> {
   const { client_id, client_secret } = secret;
   const tokenUrl = `${apiBase}/oidc/v1/token`;

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -122,9 +122,20 @@ export type LogHistogramFn = (args: {
 }) => void;
 
 export type ProviderFetchInput = string | URL;
-export type ProviderFetchInit = NonNullable<
-  Parameters<typeof globalThis.fetch>[1]
->;
+export type ProviderFetchHeaders = Record<string, string> | [string, string][];
+export type ProviderFetchBody =
+  | string
+  | URLSearchParams
+  | ArrayBuffer
+  | Uint8Array
+  | ReadableStream<Uint8Array>;
+export type ProviderFetchInit = {
+  method?: string;
+  headers?: ProviderFetchHeaders;
+  body?: ProviderFetchBody;
+  signal?: AbortSignal;
+  keepalive?: boolean;
+};
 export type CustomFetchFn = (
   input: ProviderFetchInput,
   init?: ProviderFetchInit,

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -121,7 +121,15 @@ export type LogHistogramFn = (args: {
   attributes?: Attributes;
 }) => void;
 
-export type FetchFn = typeof globalThis.fetch;
+export type ProviderFetchInput = string | URL;
+export type ProviderFetchInit = NonNullable<
+  Parameters<typeof globalThis.fetch>[1]
+>;
+export type CustomFetchFn = (
+  input: ProviderFetchInput,
+  init?: ProviderFetchInit,
+) => Promise<Response>;
+export type FetchFn = CustomFetchFn;
 
 type CachedMetadata = {
   cached_at: Date;
@@ -251,7 +259,7 @@ export async function proxyV1({
   billingOrgId,
   onBillingEvent,
   signal,
-  fetch = globalThis.fetch,
+  customFetch = globalThis.fetch,
 }: {
   method: "GET" | "POST";
   url: string;
@@ -282,8 +290,10 @@ export async function proxyV1({
   billingOrgId?: string;
   onBillingEvent?: (event: BillingEvent) => void;
   signal?: AbortSignal;
-  fetch?: FetchFn;
+  customFetch?: FetchFn;
 }): Promise<void> {
+  const fetch = customFetch;
+
   // totalCalls will be updated with model attributes after model extraction
 
   proxyHeaders = Object.fromEntries(

--- a/packages/proxy/utils/tests.ts
+++ b/packages/proxy/utils/tests.ts
@@ -32,11 +32,7 @@ export function createCapturingFetch(options?: { captureOnly?: boolean }): {
     const headers: Record<string, string> = {};
 
     if (init?.headers) {
-      if (init.headers instanceof Headers) {
-        init.headers.forEach((value, key) => {
-          headers[key] = value;
-        });
-      } else if (Array.isArray(init.headers)) {
+      if (Array.isArray(init.headers)) {
         init.headers.forEach(([key, value]) => {
           headers[key] = value;
         });

--- a/packages/proxy/utils/tests.ts
+++ b/packages/proxy/utils/tests.ts
@@ -27,7 +27,7 @@ export function createCapturingFetch(options?: { captureOnly?: boolean }): {
   const requests: CapturedRequest[] = [];
 
   const fetch: FetchFn = async (input, init) => {
-    const url = input instanceof Request ? input.url : input.toString();
+    const url = input.toString();
     const method = init?.method || "GET";
     const headers: Record<string, string> = {};
 
@@ -189,11 +189,13 @@ export const getKnownApiSecrets: Parameters<
 export async function callProxyV1<Input extends object, Output extends object>({
   body,
   proxyHeaders,
+  customFetch,
   fetch,
   ...request
 }: Partial<Omit<Parameters<typeof proxyV1>, "body" | "proxyHeaders">> & {
   body: Input;
   proxyHeaders?: Record<string, string>;
+  customFetch?: FetchFn;
   fetch?: FetchFn;
 }): Promise<
   ReturnType<typeof createHeaderHandlers> & {
@@ -232,7 +234,7 @@ export async function callProxyV1<Input extends object, Output extends object>({
       cachePut: async () => {},
       digest: async (message: string) =>
         Buffer.from(message).toString("base64"),
-      fetch: fetch ?? globalThis.fetch,
+      customFetch: customFetch ?? fetch ?? globalThis.fetch,
       ...request,
       body: requestBody,
     });


### PR DESCRIPTION


slight change from: https://github.com/braintrustdata/braintrust-proxy/pull/558