### PR TITLE
Fix broken gemini test

### DIFF
--- a/packages/proxy/src/providers/google.test.ts
+++ b/packages/proxy/src/providers/google.test.ts
@@ -1571,31 +1571,31 @@ describe("googleCompletionToOpenAICompletion", () => {
     }
   });
 
-  it("should handle mixed text and image in response via callProxyV1", async () => {
-    const { json } = await callProxyV1<
-      OpenAIChatCompletionCreateParams,
-      OpenAIChatCompletion
-    >({
-      body: {
-        model: "gemini-3-pro-image-preview",
-        messages: [
-          {
-            role: "user",
-            content:
-              'First write "Here is the image:" then generate a small solid blue circle',
+  it("should handle mixed text and image in response", () => {
+    const geminiResponse: GenerateContentResponse = {
+      candidates: [
+        {
+          content: {
+            role: "model",
+            parts: [
+              { text: "Here is the image:" },
+              { inlineData: { data: "abcd", mimeType: "image/png" } },
+            ],
           },
-        ],
-        stream: false,
-        responseModalities: ["TEXT", "IMAGE"],
-      },
-    });
+          finishReason: "STOP",
+        },
+      ],
+    };
 
-    const result = json();
+    const result = googleCompletionToOpenAICompletion(
+      "gemini-3-pro-image-preview",
+      geminiResponse,
+    );
+
     expect(result.choices).toHaveLength(1);
     expect(result.choices[0].message.role).toBe("assistant");
     expect(result.choices[0].finish_reason).toBe("stop");
 
-    // Response should contain both text and image content
     const content = result.choices[0].message.content;
     expect(Array.isArray(content)).toBe(true);
     if (Array.isArray(content)) {
@@ -1606,9 +1606,7 @@ describe("googleCompletionToOpenAICompletion", () => {
       expect(textContent?.text).toBeTruthy();
 
       expect(imageContent).toBeDefined();
-      expect(imageContent?.image_url?.url).toMatch(
-        /^data:image\/(png|jpeg);base64,/,
-      );
+      expect(imageContent?.image_url?.url).toBe("data:image/png;base64,abcd");
     }
   });
 

--- a/packages/proxy/src/providers/google.test.ts
+++ b/packages/proxy/src/providers/google.test.ts
@@ -5,7 +5,10 @@ import {
   OpenAIChatCompletionChunk,
   OpenAIChatCompletionCreateParams,
 } from "@types";
-import { GenerateContentParameters } from "../../types/google";
+import {
+  GenerateContentParameters,
+  GenerateContentResponse,
+} from "../../types/google";
 import {
   geminiParamsToOpenAIParams,
   geminiParamsToOpenAIMessages,
@@ -1385,6 +1388,52 @@ describe("geminiParamsToOpenAIMessages", () => {
 });
 
 describe("googleCompletionToOpenAICompletion", () => {
+  it("should return string content for text-only responses", () => {
+    const geminiResponse: GenerateContentResponse = {
+      candidates: [
+        {
+          content: {
+            role: "model",
+            parts: [{ text: "Hello there!" }],
+          },
+          finishReason: "STOP",
+        },
+      ],
+    };
+
+    const result = googleCompletionToOpenAICompletion(
+      "gemini-2.5-flash",
+      geminiResponse,
+    );
+
+    expect(result.choices).toHaveLength(1);
+    expect(result.choices[0].message.role).toBe("assistant");
+    expect(result.choices[0].message.content).toBe("Hello there!");
+    expect(result.choices[0].finish_reason).toBe("stop");
+  });
+
+  it("should map safety finish reasons to content_filter", () => {
+    const geminiResponse: GenerateContentResponse = {
+      candidates: [
+        {
+          content: {
+            role: "model",
+            parts: [{ text: "I can't help with that." }],
+          },
+          finishReason: "SAFETY",
+        },
+      ],
+    };
+
+    const result = googleCompletionToOpenAICompletion(
+      "gemini-2.5-flash",
+      geminiResponse,
+    );
+
+    expect(result.choices).toHaveLength(1);
+    expect(result.choices[0].finish_reason).toBe("content_filter");
+  });
+
   it("should handle snake_case function_call in output", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const geminiResponse: any = {
@@ -1643,7 +1692,7 @@ describe("googleCompletionToOpenAICompletion", () => {
       OpenAIChatCompletion
     >({
       body: {
-        model: "gemini-3-pro-image-preview",
+        model: "gemini-2.5-flash",
         messages: [{ role: "user", content: "Say hello" }],
         stream: false,
       },


### PR DESCRIPTION
This test has been broken for a bit-- the model used (gemini-3-pro-image-preview) was returning a different value than expected (the image model returned content_filter when requested to use text only for some reason):
```
 FAIL  packages/proxy/src/providers/google.test.ts > googleCompletionToOpenAICompletion > should return string content for text-only responses via callProxyV1
AssertionError: expected 'content_filter' to be 'stop' // Object.is equality

Expected: "stop"
Received: "content_filter"

 ❯ packages/proxy/src/providers/google.test.ts:1655:45
    1653|     expect(result.choices).toHaveLength(1);
    1654|     expect(result.choices[0].message.role).toBe("assistant");
    1655|     expect(result.choices[0].finish_reason).toBe("stop");
       |                                             ^
    1656|

    1657|     // Text-only responses should return string for backwards compatib…

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯

 Test Files  1 failed | 22 passed (23)
      Tests  1 failed | 310 passed (311)
   Start at  15:35:27
   Duration  121.46s (transform 1.96s, setup 0ms, import 16.42s, tests 180.75s, environment 3ms)


Error: AssertionError: expected 'content_filter' to be 'stop' // Object.is equality

Expected: "stop"
Received: "content_filter"
```

 This PR adds a specific test for the content_filter stop field and updates the model used for the other test to return what we expect.