### PR TITLE
Fix Cloudflare Worker remote media conversion

### DIFF
--- a/.github/workflows/js.yaml
+++ b/.github/workflows/js.yaml
@@ -76,3 +76,62 @@ jobs:
           AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
           AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
           AZURE_OPENAI_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION }}
+
+  cloudflare-worker-media:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Check Cloudflare credentials
+        id: cloudflare
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ] && [ "$HEAD_REPOSITORY" != "$REPOSITORY" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping remote Cloudflare Worker media test for fork pull request"
+            exit 0
+          fi
+          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ] || [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping remote Cloudflare Worker media test because Cloudflare secrets are unavailable"
+            exit 0
+          fi
+          echo "run=true" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        if: steps.cloudflare.outputs.run == 'true'
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        if: steps.cloudflare.outputs.run == 'true'
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+      - name: Setup pnpm
+        if: steps.cloudflare.outputs.run == 'true'
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+        with:
+          version: 10.33.0
+          cache: true
+      - name: Get pnpm store directory
+        if: steps.cloudflare.outputs.run == 'true'
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        if: steps.cloudflare.outputs.run == 'true'
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - name: Install dependencies
+        if: steps.cloudflare.outputs.run == 'true'
+        run: pnpm install --frozen-lockfile
+      - name: Run remote Cloudflare Worker media test
+        if: steps.cloudflare.outputs.run == 'true'
+        working-directory: packages/proxy
+        run: pnpm run test:cloudflare-worker
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/js.yaml
+++ b/.github/workflows/js.yaml
@@ -84,8 +84,8 @@ jobs:
       - name: Check Cloudflare credentials
         id: cloudflare
         env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          TEST_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
+          TEST_CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
           HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
           REPOSITORY: ${{ github.repository }}
@@ -95,7 +95,7 @@ jobs:
             echo "::notice::Skipping remote Cloudflare Worker media test for fork pull request"
             exit 0
           fi
-          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ] || [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
+          if [ -z "${TEST_CLOUDFLARE_API_TOKEN:-}" ] || [ -z "${TEST_CLOUDFLARE_ACCOUNT_ID:-}" ]; then
             echo "run=false" >> "$GITHUB_OUTPUT"
             echo "::notice::Skipping remote Cloudflare Worker media test because Cloudflare secrets are unavailable"
             exit 0
@@ -133,5 +133,5 @@ jobs:
         working-directory: packages/proxy
         run: pnpm run test:cloudflare-worker
         env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          TEST_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
+          TEST_CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -9,7 +9,8 @@
     "build": "tsup",
     "watch": "tsup --watch",
     "clean": "rm -r dist/*",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:cloudflare-worker": "tsx scripts/cloudflare_worker_media_test.ts"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -100,6 +100,7 @@
     "msw": "^2.8.2",
     "openapi-zod-client": "^1.18.3",
     "tsup": "^8.5.1",
+    "tsx": "^4.8.1",
     "typescript": "5.5.4",
     "vite": "7.3.2",
     "vite-tsconfig-paths": "^6.1.1",

--- a/packages/proxy/scripts/cloudflare_worker_media_test.ts
+++ b/packages/proxy/scripts/cloudflare_worker_media_test.ts
@@ -1,0 +1,362 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const mediaUrl =
+  process.env.CLOUDFLARE_REMOTE_MEDIA_TEST_URL ??
+  "https://httpbin.org/image/png";
+const privateMediaUrl = "https://169.254.169.254/latest/meta-data";
+const compatibilityDate = "2025-08-15";
+const maxOutputLength = 20_000;
+
+interface WranglerProcess {
+  process: ChildProcessWithoutNullStreams;
+  output: () => string;
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function stringProperty(value: unknown, key: string): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const property = value[key];
+  return typeof property === "string" ? property : undefined;
+}
+
+function nestedStringProperty(
+  value: unknown,
+  key: string,
+  nestedKey: string,
+): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  return stringProperty(value[key], nestedKey);
+}
+
+function truncateOutput(output: string): string {
+  if (output.length <= maxOutputLength) {
+    return output;
+  }
+  return output.slice(output.length - maxOutputLength);
+}
+
+function workerSource(utilPath: string): string {
+  return `import { convertMediaToBase64 } from ${JSON.stringify(utilPath)};
+
+function serializeError(error: unknown) {
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message };
+  }
+  return { name: typeof error, message: String(error) };
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+    status,
+  });
+}
+
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname === "/health") {
+      return json({ ok: true, userAgent: navigator.userAgent });
+    }
+
+    if (url.pathname !== "/convert") {
+      return json({ ok: false, error: "unknown path" }, 404);
+    }
+
+    const media = url.searchParams.get("url") ?? ${JSON.stringify(mediaUrl)};
+    try {
+      const result = await convertMediaToBase64({
+        media,
+        allowedMediaTypes: null,
+        maxMediaBytes: 1024 * 1024,
+      });
+      return json({
+        ok: true,
+        userAgent: navigator.userAgent,
+        media_type: result.media_type,
+        data_prefix: result.data.slice(0, 16),
+        data_length: result.data.length,
+      });
+    } catch (error) {
+      return json(
+        { ok: false, userAgent: navigator.userAgent, error: serializeError(error) },
+        500,
+      );
+    }
+  },
+};
+`;
+}
+
+async function writeWorkerProject({
+  accountId,
+  proxyPackageRoot,
+  tempDir,
+  workerName,
+}: {
+  accountId: string;
+  proxyPackageRoot: string;
+  tempDir: string;
+  workerName: string;
+}) {
+  await mkdir(join(tempDir, "src"), { recursive: true });
+  await mkdir(join(tempDir, "home"), { recursive: true });
+  await mkdir(join(tempDir, "xdg-config"), { recursive: true });
+
+  await writeFile(
+    join(tempDir, "wrangler.toml"),
+    `name = ${JSON.stringify(workerName)}
+main = "src/index.ts"
+compatibility_date = ${JSON.stringify(compatibilityDate)}
+compatibility_flags = ["nodejs_compat"]
+account_id = ${JSON.stringify(accountId)}
+`,
+  );
+  await writeFile(
+    join(tempDir, "src/index.ts"),
+    workerSource(join(proxyPackageRoot, "src/providers/util.ts")),
+  );
+}
+
+function startWrangler({
+  cloudflarePackageRoot,
+  port,
+  proxyPackageRoot,
+  tempDir,
+}: {
+  cloudflarePackageRoot: string;
+  port: number;
+  proxyPackageRoot: string;
+  tempDir: string;
+}): WranglerProcess {
+  const command = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+  const child = spawn(
+    command,
+    [
+      "--dir",
+      cloudflarePackageRoot,
+      "exec",
+      "wrangler",
+      "dev",
+      "--remote",
+      "--config",
+      join(tempDir, "wrangler.toml"),
+      "--cwd",
+      tempDir,
+      "--tsconfig",
+      join(proxyPackageRoot, "tsconfig.json"),
+      "--ip",
+      "127.0.0.1",
+      "--port",
+      String(port),
+      "--log-level",
+      "error",
+      "--show-interactive-dev-session=false",
+    ],
+    {
+      env: {
+        ...process.env,
+        HOME: join(tempDir, "home"),
+        XDG_CONFIG_HOME: join(tempDir, "xdg-config"),
+      },
+    },
+  );
+
+  let output = "";
+  child.stdout.on("data", (chunk: Buffer) => {
+    output += chunk.toString();
+  });
+  child.stderr.on("data", (chunk: Buffer) => {
+    output += chunk.toString();
+  });
+
+  return {
+    process: child,
+    output: () => truncateOutput(output),
+  };
+}
+
+async function stopWrangler(child: ChildProcessWithoutNullStreams) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+
+  child.kill("SIGTERM");
+  await new Promise<void>((resolvePromise) => {
+    const timeout = setTimeout(() => {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGKILL");
+      }
+      resolvePromise();
+    }, 2_000);
+    child.once("exit", () => {
+      clearTimeout(timeout);
+      resolvePromise();
+    });
+  });
+}
+
+async function fetchJson(
+  url: string,
+): Promise<{ body: unknown; status: number }> {
+  const response = await fetch(url);
+  const text = await response.text();
+  const body: unknown = JSON.parse(text);
+  return { body, status: response.status };
+}
+
+async function waitForWorker(baseUrl: string, wrangler: WranglerProcess) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 120_000) {
+    if (
+      wrangler.process.exitCode !== null ||
+      wrangler.process.signalCode !== null
+    ) {
+      throw new Error(`Wrangler exited before startup:\n${wrangler.output()}`);
+    }
+
+    try {
+      const { body, status } = await fetchJson(`${baseUrl}/health`);
+      if (
+        status === 200 &&
+        isRecord(body) &&
+        body.ok === true &&
+        body.userAgent === "Cloudflare-Workers"
+      ) {
+        return;
+      }
+    } catch {
+      // Retry until Wrangler finishes uploading the remote development Worker.
+    }
+
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 1_000));
+  }
+
+  throw new Error(
+    `Timed out waiting for Wrangler remote Worker:\n${wrangler.output()}`,
+  );
+}
+
+function expectSuccessfulMediaResponse(body: unknown) {
+  if (!isRecord(body) || body.ok !== true) {
+    throw new Error(
+      `Expected successful media response, got ${JSON.stringify(body)}`,
+    );
+  }
+
+  if (body.userAgent !== "Cloudflare-Workers") {
+    throw new Error(
+      `Expected Cloudflare Worker runtime, got ${JSON.stringify(body)}`,
+    );
+  }
+
+  const mediaType = stringProperty(body, "media_type");
+  if (!mediaType || !mediaType.startsWith("image/")) {
+    throw new Error(`Expected image media type, got ${JSON.stringify(body)}`);
+  }
+
+  const dataPrefix = stringProperty(body, "data_prefix");
+  if (!dataPrefix) {
+    throw new Error(`Expected base64 data prefix, got ${JSON.stringify(body)}`);
+  }
+
+  const dataLength = isRecord(body) ? body.data_length : undefined;
+  if (typeof dataLength !== "number" || dataLength <= dataPrefix.length) {
+    throw new Error(
+      `Expected non-empty base64 payload, got ${JSON.stringify(body)}`,
+    );
+  }
+}
+
+function expectBlockedPrivateResponse(body: unknown, status: number) {
+  if (status !== 500) {
+    throw new Error(`Expected private media request to fail, got ${status}`);
+  }
+
+  const message = nestedStringProperty(body, "error", "message");
+  if (message !== "Media URL resolves to a blocked address") {
+    throw new Error(
+      `Expected private media rejection, got ${JSON.stringify(body)}`,
+    );
+  }
+}
+
+async function main() {
+  requireEnv("CLOUDFLARE_API_TOKEN");
+  const accountId = requireEnv("CLOUDFLARE_ACCOUNT_ID");
+
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  const proxyPackageRoot = resolve(scriptDir, "..");
+  const proxyRepoRoot = resolve(proxyPackageRoot, "../..");
+  const cloudflarePackageRoot = join(proxyRepoRoot, "apis/cloudflare");
+  const tempDir = await mkdtemp(join(tmpdir(), "bt-proxy-cloudflare-media-"));
+  const workerName = `bt-proxy-media-ci-${Date.now().toString(36)}-${process.pid.toString(36)}`;
+  const port = 18_000 + Math.floor(Math.random() * 1_000);
+  let wrangler: WranglerProcess | undefined;
+
+  try {
+    await writeWorkerProject({
+      accountId,
+      proxyPackageRoot,
+      tempDir,
+      workerName,
+    });
+    wrangler = startWrangler({
+      cloudflarePackageRoot,
+      port,
+      proxyPackageRoot,
+      tempDir,
+    });
+
+    const baseUrl = `http://127.0.0.1:${port}`;
+    await waitForWorker(baseUrl, wrangler);
+
+    const mediaResponse = await fetchJson(
+      `${baseUrl}/convert?url=${encodeURIComponent(mediaUrl)}`,
+    );
+    expectSuccessfulMediaResponse(mediaResponse.body);
+
+    const privateResponse = await fetchJson(
+      `${baseUrl}/convert?url=${encodeURIComponent(privateMediaUrl)}`,
+    );
+    expectBlockedPrivateResponse(privateResponse.body, privateResponse.status);
+
+    console.log(
+      `Cloudflare remote Worker media test passed for ${mediaUrl} and private literal rejection`,
+    );
+  } catch (error) {
+    if (wrangler) {
+      console.error(wrangler.output());
+    }
+    throw error;
+  } finally {
+    if (wrangler) {
+      await stopWrangler(wrangler.process);
+    }
+    await rm(tempDir, { force: true, recursive: true });
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/packages/proxy/scripts/cloudflare_worker_media_test.ts
+++ b/packages/proxy/scripts/cloudflare_worker_media_test.ts
@@ -138,11 +138,13 @@ account_id = ${JSON.stringify(accountId)}
 }
 
 function startWrangler({
+  cloudflareApiToken,
   cloudflarePackageRoot,
   port,
   proxyPackageRoot,
   tempDir,
 }: {
+  cloudflareApiToken: string;
   cloudflarePackageRoot: string;
   port: number;
   proxyPackageRoot: string;
@@ -175,6 +177,7 @@ function startWrangler({
     {
       env: {
         ...process.env,
+        CLOUDFLARE_API_TOKEN: cloudflareApiToken,
         HOME: join(tempDir, "home"),
         XDG_CONFIG_HOME: join(tempDir, "xdg-config"),
       },
@@ -301,8 +304,8 @@ function expectBlockedPrivateResponse(body: unknown, status: number) {
 }
 
 async function main() {
-  requireEnv("CLOUDFLARE_API_TOKEN");
-  const accountId = requireEnv("CLOUDFLARE_ACCOUNT_ID");
+  const cloudflareApiToken = requireEnv("TEST_CLOUDFLARE_API_TOKEN");
+  const accountId = requireEnv("TEST_CLOUDFLARE_ACCOUNT_ID");
 
   const scriptDir = dirname(fileURLToPath(import.meta.url));
   const proxyPackageRoot = resolve(scriptDir, "..");
@@ -321,6 +324,7 @@ async function main() {
       workerName,
     });
     wrangler = startWrangler({
+      cloudflareApiToken,
       cloudflarePackageRoot,
       port,
       proxyPackageRoot,

--- a/packages/proxy/src/providers/util.test.ts
+++ b/packages/proxy/src/providers/util.test.ts
@@ -1,12 +1,30 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { lookup } from "node:dns/promises";
 import { convertMediaToBase64 } from "./util";
 
-vi.mock("node:dns/promises", () => ({
-  lookup: vi.fn(async () => [{ address: "93.184.216.34", family: 4 }]),
-}));
+const dnsMocks = vi.hoisted(() => {
+  const resolve4 = vi.fn(async (): Promise<string[]> => ["93.184.216.34"]);
+  const resolve6 = vi.fn(async (): Promise<string[]> => []);
 
-const publicImageUrl = "https://93.184.216.34/image.png";
+  class MockResolver {
+    resolve4(hostname: string) {
+      return resolve4(hostname);
+    }
+
+    resolve6(hostname: string) {
+      return resolve6(hostname);
+    }
+  }
+
+  return {
+    Resolver: MockResolver,
+    resolve4,
+    resolve6,
+  };
+});
+
+vi.mock("node:dns/promises", () => ({
+  Resolver: dnsMocks.Resolver,
+}));
 
 function mockFetch(response: Response) {
   const fetchMock = vi.fn(async () => response);
@@ -17,6 +35,8 @@ function mockFetch(response: Response) {
 describe("convertMediaToBase64", () => {
   afterEach(() => {
     vi.clearAllMocks();
+    dnsMocks.resolve4.mockResolvedValue(["93.184.216.34"]);
+    dnsMocks.resolve6.mockResolvedValue([]);
     vi.unstubAllGlobals();
   });
 
@@ -80,8 +100,48 @@ describe("convertMediaToBase64", () => {
   });
 
   it("rejects hostnames that resolve to private addresses before fetching", async () => {
-    const lookupMock = vi.mocked(lookup);
-    lookupMock.mockResolvedValueOnce([{ address: "10.0.0.5", family: 4 }]);
+    dnsMocks.resolve4.mockResolvedValueOnce(["10.0.0.5"]);
+    const fetchMock = mockFetch(new Response());
+
+    await expect(
+      convertMediaToBase64({
+        media: "https://example.com/image.png",
+        allowedMediaTypes: null,
+        maxMediaBytes: null,
+      }),
+    ).rejects.toThrow("Media URL resolves to a blocked address");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches public hostname media with Cloudflare Worker fetch", async () => {
+    vi.stubGlobal("navigator", { userAgent: "Cloudflare-Workers" });
+    const fetchMock = mockFetch(
+      new Response(new Uint8Array([1, 2, 3]), {
+        headers: { "content-type": "image/png" },
+      }),
+    );
+
+    await expect(
+      convertMediaToBase64({
+        media: "https://example.com/image.png",
+        allowedMediaTypes: ["image/png"],
+        maxMediaBytes: 3,
+      }),
+    ).resolves.toEqual({
+      media_type: "image/png",
+      data: "AQID",
+    });
+    expect(dnsMocks.resolve4).toHaveBeenCalledWith("example.com");
+    expect(fetchMock).toHaveBeenCalledWith("https://example.com/image.png", {
+      method: "GET",
+      redirect: "manual",
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("rejects private hostname resolutions before Cloudflare Worker fetch", async () => {
+    vi.stubGlobal("navigator", { userAgent: "Cloudflare-Workers" });
+    dnsMocks.resolve4.mockResolvedValueOnce(["10.0.0.5"]);
     const fetchMock = mockFetch(new Response());
 
     await expect(

--- a/packages/proxy/src/providers/util.ts
+++ b/packages/proxy/src/providers/util.ts
@@ -1,4 +1,4 @@
-import { lookup } from "node:dns/promises";
+import { Resolver } from "node:dns/promises";
 import { type IncomingHttpHeaders } from "node:http";
 import { request as httpRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
@@ -17,6 +17,7 @@ export interface MediaBlock {
 
 interface ValidatedMediaUrl {
   address: string;
+  transport: "fetch" | "node";
   url: URL;
 }
 
@@ -165,6 +166,55 @@ function isBlockedIPAddress(address: string): boolean {
   return isBlockedIPv4Address(address) || isBlockedIPv6Address(address);
 }
 
+function shouldUseFetchTransport(): boolean {
+  return (
+    typeof navigator !== "undefined" &&
+    navigator.userAgent === "Cloudflare-Workers"
+  );
+}
+
+function dnsErrorCode(error: unknown): string | undefined {
+  const code =
+    error !== null && typeof error === "object"
+      ? Object.getOwnPropertyDescriptor(error, "code")?.value
+      : undefined;
+  return typeof code === "string" ? code : undefined;
+}
+
+function dnsRecordNotFound(error: unknown): boolean {
+  const code = dnsErrorCode(error);
+  return code === "ENODATA" || code === "ENOTFOUND";
+}
+
+async function resolveHostnameAddresses(hostname: string): Promise<string[]> {
+  const resolver = new Resolver();
+  const results = await Promise.allSettled([
+    resolver.resolve4(hostname),
+    resolver.resolve6(hostname),
+  ]);
+  const addresses: string[] = [];
+  const errors: unknown[] = [];
+
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      addresses.push(...result.value);
+      continue;
+    }
+
+    if (!dnsRecordNotFound(result.reason)) {
+      errors.push(result.reason);
+    }
+  }
+
+  if (addresses.length > 0) {
+    return addresses;
+  }
+  if (errors.length > 0) {
+    throw errors[0];
+  }
+  return [];
+}
+
 function nodeHeadersToHeaders(headers: IncomingHttpHeaders): Headers {
   const result = new Headers();
   for (const [name, value] of Object.entries(headers)) {
@@ -192,19 +242,26 @@ async function validateMediaUrl(url: URL): Promise<ValidatedMediaUrl> {
     throw new Error("Media URL resolves to a blocked address");
   }
 
+  // Cloudflare Workers reject media requests sent through the Node transport
+  // even after DNS validation succeeds, while their native fetch path works.
+  const transport = shouldUseFetchTransport() ? "fetch" : "node";
   if (parseIPv4Address(hostname) !== null || hostname.includes(":")) {
-    return { address: hostname, url };
+    return { address: hostname, transport, url };
   }
 
-  const addresses = await lookup(hostname, { all: true, verbatim: true });
+  const addresses = await resolveHostnameAddresses(hostname);
   if (
     addresses.length === 0 ||
-    addresses.some(({ address }) => isBlockedIPAddress(address))
+    addresses.some((address) => isBlockedIPAddress(address))
   ) {
     throw new Error("Media URL resolves to a blocked address");
   }
 
-  return { address: addresses[0].address, url };
+  return {
+    address: transport === "node" ? addresses[0] : hostname,
+    transport,
+    url,
+  };
 }
 
 async function readResponseBytes(
@@ -273,9 +330,17 @@ async function fetchMediaUrl(
 }
 
 async function fetchValidatedMediaUrl(
-  { address, url }: ValidatedMediaUrl,
+  { address, transport, url }: ValidatedMediaUrl,
   signal: AbortSignal,
 ): Promise<Response> {
+  if (transport === "fetch") {
+    return await fetch(url.toString(), {
+      method: "GET",
+      redirect: "manual",
+      signal,
+    });
+  }
+
   return await new Promise((resolve, reject) => {
     const hostname = normalizeHostname(url.hostname);
     const servername =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,13 +34,13 @@ importers:
         version: 2.9.14
       vite:
         specifier: 7.3.2
-        version: 7.3.2(@types/node@20.19.40)(jiti@1.21.7)(yaml@2.9.0)
+        version: 7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.3)(yaml@2.9.0)
       vite-tsconfig-paths:
         specifier: ^6.1.1
-        version: 6.1.1(typescript@5.5.4)(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(yaml@2.9.0))
+        version: 6.1.1(typescript@5.5.4)(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.3)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(msw@2.8.4(@types/node@20.19.40)(typescript@5.5.4))(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(msw@2.8.4(@types/node@20.19.40)(typescript@5.5.4))(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.3)(yaml@2.9.0))
 
   apis/cloudflare:
     dependencies:
@@ -80,7 +80,7 @@ importers:
         version: 3.0.12
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@1.21.7)(postcss@8.5.14)(typescript@5.3.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.22.3)(typescript@5.3.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.0.4
         version: 5.3.3
@@ -196,7 +196,7 @@ importers:
         version: 8.5.14
       tailwindcss:
         specifier: ^3.4.19
-        version: 3.4.19(yaml@2.9.0)
+        version: 3.4.19(tsx@4.22.3)(yaml@2.9.0)
       turbo:
         specifier: ^2.9.14
         version: 2.9.14
@@ -299,7 +299,7 @@ importers:
         version: 1.18.3(react@19.2.6)
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@1.21.7)(postcss@8.5.14)(typescript@5.5.4)(yaml@2.9.0)
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.22.3)(typescript@5.5.4)(yaml@2.9.0)
       tsx:
         specifier: ^4.8.1
         version: 4.22.3
@@ -308,13 +308,13 @@ importers:
         version: 5.5.4
       vite:
         specifier: 7.3.2
-        version: 7.3.2(@types/node@20.19.40)(jiti@1.21.7)(yaml@2.9.0)
+        version: 7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.3)(yaml@2.9.0)
       vite-tsconfig-paths:
         specifier: ^6.1.1
-        version: 6.1.1(typescript@5.5.4)(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(yaml@2.9.0))
+        version: 6.1.1(typescript@5.5.4)(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.3)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(msw@2.8.4(@types/node@20.19.40)(typescript@5.5.4))(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(msw@2.8.4(@types/node@20.19.40)(typescript@5.5.4))(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.3)(yaml@2.9.0))
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -693,6 +693,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.27.0':
     resolution: {integrity: sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==}
     engines: {node: '>=18'}
@@ -701,6 +707,12 @@ packages:
 
   '@esbuild/android-arm64@0.27.3':
     resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -717,6 +729,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.27.0':
     resolution: {integrity: sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==}
     engines: {node: '>=18'}
@@ -725,6 +743,12 @@ packages:
 
   '@esbuild/android-x64@0.27.3':
     resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -741,6 +765,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.27.0':
     resolution: {integrity: sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==}
     engines: {node: '>=18'}
@@ -749,6 +779,12 @@ packages:
 
   '@esbuild/darwin-x64@0.27.3':
     resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -765,6 +801,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.27.0':
     resolution: {integrity: sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==}
     engines: {node: '>=18'}
@@ -773,6 +815,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.3':
     resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -789,6 +837,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.27.0':
     resolution: {integrity: sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==}
     engines: {node: '>=18'}
@@ -797,6 +851,12 @@ packages:
 
   '@esbuild/linux-arm@0.27.3':
     resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -813,6 +873,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.27.0':
     resolution: {integrity: sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==}
     engines: {node: '>=18'}
@@ -821,6 +887,12 @@ packages:
 
   '@esbuild/linux-loong64@0.27.3':
     resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -837,6 +909,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.27.0':
     resolution: {integrity: sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==}
     engines: {node: '>=18'}
@@ -845,6 +923,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.3':
     resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -861,6 +945,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.0':
     resolution: {integrity: sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==}
     engines: {node: '>=18'}
@@ -869,6 +959,12 @@ packages:
 
   '@esbuild/linux-s390x@0.27.3':
     resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -885,6 +981,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.0':
     resolution: {integrity: sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==}
     engines: {node: '>=18'}
@@ -893,6 +995,12 @@ packages:
 
   '@esbuild/netbsd-arm64@0.27.3':
     resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -909,6 +1017,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.0':
     resolution: {integrity: sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==}
     engines: {node: '>=18'}
@@ -917,6 +1031,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.27.3':
     resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -933,6 +1053,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.0':
     resolution: {integrity: sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==}
     engines: {node: '>=18'}
@@ -941,6 +1067,12 @@ packages:
 
   '@esbuild/openharmony-arm64@0.27.3':
     resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -957,6 +1089,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.27.0':
     resolution: {integrity: sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==}
     engines: {node: '>=18'}
@@ -965,6 +1103,12 @@ packages:
 
   '@esbuild/win32-arm64@0.27.3':
     resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -981,6 +1125,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.0':
     resolution: {integrity: sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==}
     engines: {node: '>=18'}
@@ -989,6 +1139,12 @@ packages:
 
   '@esbuild/win32-x64@0.27.3':
     resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2772,6 +2928,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
@@ -4402,6 +4563,11 @@ packages:
       typescript:
         optional: true
 
+  tsx@4.22.3:
+    resolution: {integrity: sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   turbo@2.9.14:
     resolution: {integrity: sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==}
     hasBin: true
@@ -5460,10 +5626,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.27.0':
     optional: true
 
   '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.27.0':
@@ -5472,10 +5644,16 @@ snapshots:
   '@esbuild/android-arm@0.27.3':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.27.0':
     optional: true
 
   '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.0':
@@ -5484,10 +5662,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.3':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.0':
     optional: true
 
   '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.0':
@@ -5496,10 +5680,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.3':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.0':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.27.0':
@@ -5508,10 +5698,16 @@ snapshots:
   '@esbuild/linux-arm64@0.27.3':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.27.0':
     optional: true
 
   '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.27.0':
@@ -5520,10 +5716,16 @@ snapshots:
   '@esbuild/linux-ia32@0.27.3':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.0':
     optional: true
 
   '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.0':
@@ -5532,10 +5734,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.3':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.0':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.0':
@@ -5544,10 +5752,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.3':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.0':
     optional: true
 
   '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.27.0':
@@ -5556,10 +5770,16 @@ snapshots:
   '@esbuild/linux-x64@0.27.3':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.0':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.0':
@@ -5568,10 +5788,16 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.0':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.0':
@@ -5580,10 +5806,16 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.0':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.27.0':
@@ -5592,10 +5824,16 @@ snapshots:
   '@esbuild/sunos-x64@0.27.3':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.0':
     optional: true
 
   '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.27.0':
@@ -5604,10 +5842,16 @@ snapshots:
   '@esbuild/win32-ia32@0.27.3':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.27.0':
     optional: true
 
   '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@1.21.7))':
@@ -6808,14 +7052,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(msw@2.8.4(@types/node@20.19.40)(typescript@5.5.4))(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.5(msw@2.8.4(@types/node@20.19.40)(typescript@5.5.4))(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.8.4(@types/node@20.19.40)(typescript@5.5.4)
-      vite: 7.3.2(@types/node@20.19.40)(jiti@1.21.7)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.3)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -7575,6 +7819,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
 
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
   escalade@3.1.1: {}
 
   escalade@3.2.0: {}
@@ -7589,7 +7862,7 @@ snapshots:
       eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@1.21.7))
@@ -7622,7 +7895,7 @@ snapshots:
       enhanced-resolve: 5.15.0
       eslint: 9.39.4(jiti@1.21.7)
       eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.4(jiti@1.21.7))
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.16.1
@@ -7644,7 +7917,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -8816,12 +9089,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.14
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.14)(yaml@2.9.0):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.14
+      tsx: 4.22.3
       yaml: 2.9.0
 
   postcss-nested@6.2.0(postcss@8.5.14):
@@ -9344,7 +9618,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  tailwindcss@3.4.19(yaml@2.9.0):
+  tailwindcss@3.4.19(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -9363,7 +9637,7 @@ snapshots:
       postcss: 8.5.14
       postcss-import: 15.1.0(postcss@8.5.14)
       postcss-js: 4.0.1(postcss@8.5.14)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.14)(yaml@2.9.0)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.22.3)(yaml@2.9.0)
       postcss-nested: 6.2.0(postcss@8.5.14)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.8
@@ -9453,7 +9727,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@1.21.7)(postcss@8.5.14)(typescript@5.3.3)(yaml@2.9.0):
+  tsup@8.5.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.22.3)(typescript@5.3.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.0)
       cac: 6.7.14
@@ -9464,7 +9738,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.14)(yaml@2.9.0)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.22.3)(yaml@2.9.0)
       resolve-from: 5.0.0
       rollup: 4.60.3
       source-map: 0.7.6
@@ -9481,7 +9755,7 @@ snapshots:
       - tsx
       - yaml
 
-  tsup@8.5.1(jiti@1.21.7)(postcss@8.5.14)(typescript@5.5.4)(yaml@2.9.0):
+  tsup@8.5.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.22.3)(typescript@5.5.4)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.0)
       cac: 6.7.14
@@ -9492,7 +9766,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.14)(yaml@2.9.0)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.22.3)(yaml@2.9.0)
       resolve-from: 5.0.0
       rollup: 4.60.3
       source-map: 0.7.6
@@ -9508,6 +9782,12 @@ snapshots:
       - supports-color
       - tsx
       - yaml
+
+  tsx@4.22.3:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   turbo@2.9.14:
     optionalDependencies:
@@ -9660,17 +9940,17 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-tsconfig-paths@6.1.1(typescript@5.5.4)(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(yaml@2.9.0)):
+  vite-tsconfig-paths@6.1.1(typescript@5.5.4)(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.4(typescript@5.5.4)
-      vite: 7.3.2(@types/node@20.19.40)(jiti@1.21.7)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(yaml@2.9.0):
+  vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.4)
@@ -9682,12 +9962,13 @@ snapshots:
       '@types/node': 20.19.40
       fsevents: 2.3.3
       jiti: 1.21.7
+      tsx: 4.22.3
       yaml: 2.9.0
 
-  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(msw@2.8.4(@types/node@20.19.40)(typescript@5.5.4))(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(yaml@2.9.0)):
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(msw@2.8.4(@types/node@20.19.40)(typescript@5.5.4))(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(msw@2.8.4(@types/node@20.19.40)(typescript@5.5.4))(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.5(msw@2.8.4(@types/node@20.19.40)(typescript@5.5.4))(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.3)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -9704,7 +9985,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@20.19.40)(jiti@1.21.7)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,9 @@ importers:
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.14)(typescript@5.5.4)(yaml@2.9.0)
+      tsx:
+        specifier: ^4.8.1
+        version: 4.22.3
       typescript:
         specifier: 5.5.4
         version: 5.5.4


### PR DESCRIPTION
### Context

Remote media normalization runs inside the Cloudflare Worker proxy for multimodal provider requests. The previous hostname validation/fetch path depended on Node DNS lookup plus the Node HTTP transport; remote Worker testing showed public media URLs can fail through that transport even though the same URLs work through Worker-native `fetch`.

### Description

- Resolve media hostnames with `Resolver.resolve4()` / `resolve6()` instead of `dns.promises.lookup()`.
- Keep rejecting unsafe literal IPs and hostnames that resolve to private/reserved addresses before fetching.
- Use Worker-native `fetch` for Cloudflare Workers while preserving the DNS-pinned Node `http`/`https` transport for Node runtimes.
- Add focused provider util coverage for the Worker fetch path and private-resolution rejection.
- Add `pnpm run test:cloudflare-worker` plus a gated CI job that runs a remote Wrangler Worker media conversion check when `TEST_CLOUDFLARE_API_TOKEN` and `TEST_CLOUDFLARE_ACCOUNT_ID` secrets are available.


