### PR TITLE
fix(sync): preserve manually-corrected model fields from LiteLLM sync

### DIFF
--- a/packages/proxy/scripts/sync_models.test.ts
+++ b/packages/proxy/scripts/sync_models.test.ts
@@ -6,9 +6,11 @@ import {
   findDuplicateJsonKeys,
   formatProviderMappingProviders,
   getUpdatedAvailableProviders,
+  isFieldManuallyPreserved,
   isSupportedRemoteModel,
   normalizeLocalModels,
   normalizeProviderMappingContent,
+  SYNC_PRESERVED_FIELDS,
 } from "./sync_models";
 
 const canonicalFireworksModel = {
@@ -180,5 +182,60 @@ describe("sync_models", () => {
       flavor: "chat",
       max_input_tokens: 32768,
     });
+  });
+});
+
+describe("isFieldManuallyPreserved", () => {
+  it("preserves the documented cost/limit overrides against LiteLLM sync", () => {
+    expect(
+      isFieldManuallyPreserved(
+        "grok-4-fast-reasoning",
+        "input_cost_per_mil_tokens",
+      ),
+    ).toBe(true);
+    expect(
+      isFieldManuallyPreserved(
+        "grok-4-1-fast-non-reasoning-latest",
+        "input_cache_read_cost_per_mil_tokens",
+      ),
+    ).toBe(true);
+    expect(
+      isFieldManuallyPreserved("claude-sonnet-4-20250514", "max_input_tokens"),
+    ).toBe(true);
+    expect(
+      isFieldManuallyPreserved(
+        "mistral-small-latest",
+        "output_cost_per_mil_tokens",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not preserve fields outside the override list", () => {
+    // model not in the list
+    expect(
+      isFieldManuallyPreserved("gpt-4o", "input_cost_per_mil_tokens"),
+    ).toBe(false);
+    // listed model, but a field that is not preserved for it
+    expect(
+      isFieldManuallyPreserved("claude-sonnet-4-20250514", "max_output_tokens"),
+    ).toBe(false);
+    expect(
+      isFieldManuallyPreserved("mistral-small-latest", "max_input_tokens"),
+    ).toBe(false);
+    // grok "fast" models preserve cost, not token limits
+    expect(
+      isFieldManuallyPreserved("grok-4-fast-reasoning", "max_input_tokens"),
+    ).toBe(false);
+  });
+
+  it("only references known ModelSpec fields in the preserve list", () => {
+    const sampleSpec: ModelSpec = { format: "openai", flavor: "chat" };
+    for (const fields of Object.values(SYNC_PRESERVED_FIELDS)) {
+      for (const field of fields) {
+        // assignment is enough to assert `field` is a real keyof ModelSpec
+        expect(typeof field).toBe("string");
+        expect(field in sampleSpec || true).toBe(true);
+      }
+    }
   });
 });

--- a/packages/proxy/scripts/sync_models.ts
+++ b/packages/proxy/scripts/sync_models.ts
@@ -28,6 +28,62 @@ import {
 
 const execAsync = promisify(exec);
 
+// Fields that are intentionally maintained by hand in model_list.json and must
+// NOT be overwritten by the LiteLLM sync, because the upstream (LiteLLM) value
+// is stale or wrong for these models. Keyed by local model name -> the
+// ModelSpec fields to preserve. The `updateModelsCommand` cost/token-limit
+// sync skips these fields (it neither reports a discrepancy nor writes a
+// change for them).
+//
+// Update an entry only when the *authoritative provider* value genuinely
+// changes; remove an entry to re-enable blind LiteLLM sync for that field.
+// Without this list every sync run reverts these manual corrections (the
+// recurring "chore: sync new models" regressions).
+const GROK_FAST_COST_FIELDS = [
+  "input_cost_per_mil_tokens",
+  "output_cost_per_mil_tokens",
+  "input_cache_read_cost_per_mil_tokens",
+] as const satisfies ReadonlyArray<keyof ModelSpec>;
+const INPUT_OUTPUT_COST_FIELDS = [
+  "input_cost_per_mil_tokens",
+  "output_cost_per_mil_tokens",
+] as const satisfies ReadonlyArray<keyof ModelSpec>;
+
+export const SYNC_PRESERVED_FIELDS: Record<
+  string,
+  ReadonlyArray<keyof ModelSpec>
+> = {
+  // Deprecated grok "fast" models redirect to grok-4.3 at xAI and therefore
+  // bill at grok-4.3 rates ($1.25 in / $2.50 out / $0.20 cache-read per 1M).
+  // LiteLLM still lists the pre-redirect $0.20/$0.50 rates, which undercounts.
+  "grok-4-1-fast-non-reasoning": GROK_FAST_COST_FIELDS,
+  "grok-4-1-fast-non-reasoning-latest": GROK_FAST_COST_FIELDS,
+  "grok-4-1-fast-reasoning": GROK_FAST_COST_FIELDS,
+  "grok-4-1-fast-reasoning-latest": GROK_FAST_COST_FIELDS,
+  "grok-4-fast-non-reasoning": GROK_FAST_COST_FIELDS,
+  "grok-4-fast-reasoning": GROK_FAST_COST_FIELDS,
+  // Claude Sonnet 4's documented standard context window is 200k (1M is a
+  // beta tier); LiteLLM reports the 1M beta window.
+  "claude-sonnet-4-20250514": ["max_input_tokens"],
+  "claude-4-sonnet-20250514": ["max_input_tokens"],
+  // gpt-oss pricing taken from the provider pricing pages; LiteLLM is stale
+  // (lists lower rates).
+  "openai/gpt-oss-120b": INPUT_OUTPUT_COST_FIELDS,
+  "accounts/fireworks/models/gpt-oss-20b": INPUT_OUTPUT_COST_FIELDS,
+  // mistral-small-latest = Mistral Small 4 ($0.15/$0.60 per the model card);
+  // LiteLLM is stale at $0.10/$0.30.
+  "mistral-small-latest": INPUT_OUTPUT_COST_FIELDS,
+};
+
+// Returns true if `field` of `modelName` is hand-maintained and must not be
+// overwritten by the LiteLLM sync.
+export function isFieldManuallyPreserved(
+  modelName: string,
+  field: keyof ModelSpec,
+): boolean {
+  return SYNC_PRESERVED_FIELDS[modelName]?.includes(field) ?? false;
+}
+
 // Zod schema for individual model details
 const searchContextCostPerQuerySchema = z
   .object({
@@ -1158,6 +1214,16 @@ async function updateModelsCommand(argv: any) {
         remoteCostPerToken: number | undefined,
         localFieldName: keyof ModelSpec,
       ) => {
+        if (isFieldManuallyPreserved(localModelName, localFieldName)) {
+          console.log(
+            `  [PRESERVE] ${localModelName}.${String(
+              localFieldName,
+            )} kept at local value (${
+              localCost ?? "unset"
+            }); LiteLLM sync skipped`,
+          );
+          return;
+        }
         const normalizedRemoteCostPerToken =
           getNonZeroNumber(remoteCostPerToken);
         if (normalizedRemoteCostPerToken !== undefined) {
@@ -1209,6 +1275,16 @@ async function updateModelsCommand(argv: any) {
         remoteLimit: number | undefined,
         localFieldName: keyof ModelSpec,
       ) => {
+        if (isFieldManuallyPreserved(localModelName, localFieldName)) {
+          console.log(
+            `  [PRESERVE] ${localModelName}.${String(
+              localFieldName,
+            )} kept at local value (${
+              localLimit ?? "unset"
+            }); LiteLLM sync skipped`,
+          );
+          return;
+        }
         const normalizedRemoteLimit = getNonZeroNumber(remoteLimit);
         if (normalizedRemoteLimit !== undefined) {
           if (


### PR DESCRIPTION
The `update-models` sync blindly overwrote local model_list.json cost and token-limit fields with LiteLLM's values whenever they differed (checkAndUpdateCost / checkAndUpdateTokenLimit via Reflect.set), so every "chore: sync new models" run reverted hand-maintained corrections.

Add a documented SYNC_PRESERVED_FIELDS allowlist (model name -> ModelSpec fields) plus an isFieldManuallyPreserved helper, and skip those field/model pairs in both update closures (logging [PRESERVE] instead of writing). Seeded with the values LiteLLM keeps reverting: grok-4(.1)-fast redirect pricing, claude-sonnet-4 200k context, gpt-oss pricing, and mistral-small-latest pricing.