### PR TITLE
fix(ci): run model-sync scripts with pinned local tsx, not pnpm dlx

### DIFF
--- a/.github/workflows/fix-missing-model-bot-issues.yaml
+++ b/.github/workflows/fix-missing-model-bot-issues.yaml
@@ -236,7 +236,7 @@ jobs:
             body_file="$BATCH_DIR/issue-${issue_number}.body.md"
             result_file="$BATCH_DIR/results/issue-${issue_number}.initial.json"
 
-            pnpm dlx tsx packages/proxy/scripts/fix_bot_issue.ts resolve-issue \
+            pnpm exec tsx packages/proxy/scripts/fix_bot_issue.ts resolve-issue \
               --title "$issue_title" \
               --body-file "$body_file" \
               --result-path "$result_file" \
@@ -370,7 +370,7 @@ jobs:
               cp "$original_body" "$enriched_body"
             fi
 
-            pnpm dlx tsx packages/proxy/scripts/fix_bot_issue.ts resolve-issue \
+            pnpm exec tsx packages/proxy/scripts/fix_bot_issue.ts resolve-issue \
               --title "$issue_title" \
               --body-file "$enriched_body" \
               --result-path "$result_file" \
@@ -788,7 +788,7 @@ jobs:
 
       - name: Canonicalize model list after Codex response
         if: steps.codex_comments.outputs.found == 'true'
-        run: pnpm dlx tsx packages/proxy/scripts/sync_models.ts normalize-local-models --write
+        run: pnpm exec tsx packages/proxy/scripts/sync_models.ts normalize-local-models --write
 
       - name: Check Codex response changes
         id: codex_changes

--- a/.github/workflows/sync-models.yaml
+++ b/.github/workflows/sync-models.yaml
@@ -72,8 +72,8 @@ jobs:
           echo "Syncing providers: $providers"
 
           for provider in $providers; do
-            pnpm dlx tsx packages/proxy/scripts/sync_models.ts update-models --provider "$provider" --write
-            pnpm dlx tsx packages/proxy/scripts/sync_models.ts add-models --provider "$provider" --write
+            pnpm exec tsx packages/proxy/scripts/sync_models.ts update-models --provider "$provider" --write
+            pnpm exec tsx packages/proxy/scripts/sync_models.ts add-models --provider "$provider" --write
           done
 
       - name: Collect changed model ids
@@ -82,7 +82,7 @@ jobs:
           set -euo pipefail
 
           git show HEAD:packages/proxy/schema/model_list.json > "$RUNNER_TEMP/model_list.head.json"
-          pnpm dlx tsx packages/proxy/scripts/collect_changed_model_ids.ts \
+          pnpm exec tsx packages/proxy/scripts/collect_changed_model_ids.ts \
             --before "$RUNNER_TEMP/model_list.head.json" \
             --after "packages/proxy/schema/model_list.json" \
             --output "$RUNNER_TEMP/sync-model-changed.json" \
@@ -163,7 +163,7 @@ jobs:
 
       - name: Canonicalize model list after metadata enrichment
         if: ${{ steps.changed_models.outputs.count != '0' }}
-        run: pnpm dlx tsx packages/proxy/scripts/sync_models.ts normalize-local-models --write
+        run: pnpm exec tsx packages/proxy/scripts/sync_models.ts normalize-local-models --write
 
       - name: Check expected files only
         id: changes
@@ -399,7 +399,7 @@ jobs:
 
       - name: Canonicalize model list after Codex response
         if: steps.codex_comments.outputs.found == 'true'
-        run: pnpm dlx tsx packages/proxy/scripts/sync_models.ts normalize-local-models --write
+        run: pnpm exec tsx packages/proxy/scripts/sync_models.ts normalize-local-models --write
 
       - name: Check Codex response changes
         id: codex_changes

--- a/.github/workflows/verify-deployed-models.yaml
+++ b/.github/workflows/verify-deployed-models.yaml
@@ -192,7 +192,7 @@ jobs:
               git show "${temp_head_ref}:packages/proxy/schema/model_list.json" > "$RUNNER_TEMP/model_list.after.json"
             fi
 
-            pnpm dlx tsx packages/proxy/scripts/collect_changed_model_ids.ts \
+            pnpm exec tsx packages/proxy/scripts/collect_changed_model_ids.ts \
               --before "$RUNNER_TEMP/model_list.before.json" \
               --after "$RUNNER_TEMP/model_list.after.json" \
               --output "$RUNNER_TEMP/changed-models.json"
@@ -237,7 +237,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          pnpm dlx tsx packages/proxy/scripts/verify_proxy_models.ts \
+          pnpm exec tsx packages/proxy/scripts/verify_proxy_models.ts \
             --proxy-base-url "${{ inputs.proxy_base_url }}" \
             --model-file "${{ steps.models.outputs.path }}" \
             --model-catalog-file "${{ steps.models.outputs.catalog_path }}" \

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint": "^9.39.4",
     "eslint-config-turbo": "latest",
     "prettier": "3.3.2",
+    "tsx": "4.22.4",
     "turbo": "^2.9.14",
     "vite": "7.3.2",
     "vite-tsconfig-paths": "^6.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,18 +29,21 @@ importers:
       prettier:
         specifier: 3.3.2
         version: 3.3.2
+      tsx:
+        specifier: 4.22.4
+        version: 4.22.4
       turbo:
         specifier: ^2.9.14
         version: 2.9.14
       vite:
         specifier: 7.3.2
-        version: 7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.3)(yaml@2.9.0)
+        version: 7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0)
       vite-tsconfig-paths:
         specifier: ^6.1.1
-        version: 6.1.1(typescript@5.5.4)(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.3)(yaml@2.9.0))
+        version: 6.1.1(typescript@5.5.4)(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(msw@2.8.4(@types/node@20.19.40)(typescript@5.5.4))(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(msw@2.8.4(@types/node@20.19.40)(typescript@5.5.4))(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0))
 
   apis/cloudflare:
     dependencies:
@@ -80,7 +83,7 @@ importers:
         version: 3.0.12
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.22.3)(typescript@5.3.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.22.4)(typescript@5.3.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.0.4
         version: 5.3.3
@@ -196,7 +199,7 @@ importers:
         version: 8.5.14
       tailwindcss:
         specifier: ^3.4.19
-        version: 3.4.19(tsx@4.22.3)(yaml@2.9.0)
+        version: 3.4.19(tsx@4.22.4)(yaml@2.9.0)
       turbo:
         specifier: ^2.9.14
         version: 2.9.14
@@ -4568,6 +4571,11 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   turbo@2.9.14:
     resolution: {integrity: sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==}
     hasBin: true
@@ -7061,6 +7069,15 @@ snapshots:
       msw: 2.8.4(@types/node@20.19.40)(typescript@5.5.4)
       vite: 7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.3)(yaml@2.9.0)
 
+  '@vitest/mocker@4.1.5(msw@2.8.4(@types/node@20.19.40)(typescript@5.5.4))(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.8.4(@types/node@20.19.40)(typescript@5.5.4)
+      vite: 7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0)
+
   '@vitest/pretty-format@4.1.5':
     dependencies:
       tinyrainbow: 3.1.0
@@ -9098,6 +9115,15 @@ snapshots:
       tsx: 4.22.3
       yaml: 2.9.0
 
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 1.21.7
+      postcss: 8.5.14
+      tsx: 4.22.4
+      yaml: 2.9.0
+
   postcss-nested@6.2.0(postcss@8.5.14):
     dependencies:
       postcss: 8.5.14
@@ -9618,7 +9644,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  tailwindcss@3.4.19(tsx@4.22.3)(yaml@2.9.0):
+  tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -9637,7 +9663,7 @@ snapshots:
       postcss: 8.5.14
       postcss-import: 15.1.0(postcss@8.5.14)
       postcss-js: 4.0.1(postcss@8.5.14)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.22.3)(yaml@2.9.0)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.22.4)(yaml@2.9.0)
       postcss-nested: 6.2.0(postcss@8.5.14)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.8
@@ -9727,34 +9753,6 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.22.3)(typescript@5.3.3)(yaml@2.9.0):
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.0)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.4.0
-      debug: 4.4.3
-      esbuild: 0.27.0
-      fix-dts-default-cjs-exports: 1.0.1
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.22.3)(yaml@2.9.0)
-      resolve-from: 5.0.0
-      rollup: 4.60.3
-      source-map: 0.7.6
-      sucrase: 3.35.1
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tree-kill: 1.2.2
-    optionalDependencies:
-      postcss: 8.5.14
-      typescript: 5.3.3
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-
   tsup@8.5.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.22.3)(typescript@5.5.4)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.0)
@@ -9783,7 +9781,41 @@ snapshots:
       - tsx
       - yaml
 
+  tsup@8.5.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.22.4)(typescript@5.3.3)(yaml@2.9.0):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.0)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.0
+      debug: 4.4.3
+      esbuild: 0.27.0
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.22.4)(yaml@2.9.0)
+      resolve-from: 5.0.0
+      rollup: 4.60.3
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.14
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
   tsx@4.22.3:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  tsx@4.22.4:
     dependencies:
       esbuild: 0.28.0
     optionalDependencies:
@@ -9950,6 +9982,16 @@ snapshots:
       - supports-color
       - typescript
 
+  vite-tsconfig-paths@6.1.1(typescript@5.5.4)(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      debug: 4.4.3
+      globrex: 0.1.2
+      tsconfck: 3.1.4(typescript@5.5.4)
+      vite: 7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.3
@@ -9963,6 +10005,21 @@ snapshots:
       fsevents: 2.3.3
       jiti: 1.21.7
       tsx: 4.22.3
+      yaml: 2.9.0
+
+  vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.13
+      rollup: 4.60.3
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.19.40
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      tsx: 4.22.4
       yaml: 2.9.0
 
   vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(msw@2.8.4(@types/node@20.19.40)(typescript@5.5.4))(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.3)(yaml@2.9.0)):
@@ -9986,6 +10043,34 @@ snapshots:
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
       vite: 7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.3)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 20.19.40
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(msw@2.8.4(@types/node@20.19.40)(typescript@5.5.4))(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(msw@2.8.4(@types/node@20.19.40)(typescript@5.5.4))(vite@7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.3.2(@types/node@20.19.40)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0


### PR DESCRIPTION
The "sync new models" job failed with `Cannot find module 'zod'` when running sync_models.ts. The scripts were invoked via `pnpm dlx tsx`, which (1) fetches an unpinned tsx into an isolated dlx store on every run, and (2) resolves the script's bare imports outside the workspace. `zod` is a dependency of `packages/proxy` and is not hoisted to the repo root, so a tsx build whose `resolveTsPaths` no longer falls back to the package's node_modules (the proxy tsconfig sets `paths` without a `baseUrl`) cannot resolve it.

Pin `tsx` as a root devDependency and invoke the scripts via `pnpm exec tsx` — the same in-workspace pattern already used for `pnpm exec vitest` in these workflows. This makes the tsx version deterministic and resolves `zod` from the installed workspace tree. Applied across sync-models, fix-missing-model-bot-issues, and verify-deployed-models (all shared the same dlx pattern).

Verified locally on Node 24.16.0 (the CI version): `pnpm exec tsx packages/proxy/scripts/sync_models.ts normalize-local-models` runs to completion (rc=0), loading the full zod-based schema.