### PR TITLE
fix(ci): run model-sync tsx scripts via root pnpm exec, not -C package exec

### DIFF
--- a/.github/workflows/fix-missing-model-bot-issues.yaml
+++ b/.github/workflows/fix-missing-model-bot-issues.yaml
@@ -236,7 +236,7 @@ jobs:
             body_file="$BATCH_DIR/issue-${issue_number}.body.md"
             result_file="$BATCH_DIR/results/issue-${issue_number}.initial.json"
 
-            pnpm -C packages/proxy exec tsx scripts/fix_bot_issue.ts resolve-issue \
+            pnpm exec tsx packages/proxy/scripts/fix_bot_issue.ts resolve-issue \
               --title "$issue_title" \
               --body-file "$body_file" \
               --result-path "$result_file" \
@@ -370,7 +370,7 @@ jobs:
               cp "$original_body" "$enriched_body"
             fi
 
-            pnpm -C packages/proxy exec tsx scripts/fix_bot_issue.ts resolve-issue \
+            pnpm exec tsx packages/proxy/scripts/fix_bot_issue.ts resolve-issue \
               --title "$issue_title" \
               --body-file "$enriched_body" \
               --result-path "$result_file" \
@@ -788,7 +788,7 @@ jobs:
 
       - name: Canonicalize model list after Codex response
         if: steps.codex_comments.outputs.found == 'true'
-        run: pnpm -C packages/proxy exec tsx scripts/sync_models.ts normalize-local-models --write
+        run: pnpm exec tsx packages/proxy/scripts/sync_models.ts normalize-local-models --write
 
       - name: Check Codex response changes
         id: codex_changes

--- a/.github/workflows/sync-models.yaml
+++ b/.github/workflows/sync-models.yaml
@@ -72,8 +72,8 @@ jobs:
           echo "Syncing providers: $providers"
 
           for provider in $providers; do
-            pnpm -C packages/proxy exec tsx scripts/sync_models.ts update-models --provider "$provider" --write
-            pnpm -C packages/proxy exec tsx scripts/sync_models.ts add-models --provider "$provider" --write
+            pnpm exec tsx packages/proxy/scripts/sync_models.ts update-models --provider "$provider" --write
+            pnpm exec tsx packages/proxy/scripts/sync_models.ts add-models --provider "$provider" --write
           done
 
       - name: Collect changed model ids
@@ -82,9 +82,9 @@ jobs:
           set -euo pipefail
 
           git show HEAD:packages/proxy/schema/model_list.json > "$RUNNER_TEMP/model_list.head.json"
-          pnpm -C packages/proxy exec tsx scripts/collect_changed_model_ids.ts \
+          pnpm exec tsx packages/proxy/scripts/collect_changed_model_ids.ts \
             --before "$RUNNER_TEMP/model_list.head.json" \
-            --after "schema/model_list.json" \
+            --after "packages/proxy/schema/model_list.json" \
             --output "$RUNNER_TEMP/sync-model-changed.json" \
             --github-output "$GITHUB_OUTPUT"
 
@@ -162,7 +162,7 @@ jobs:
 
       - name: Canonicalize model list after metadata enrichment
         if: ${{ steps.changed_models.outputs.count != '0' }}
-        run: pnpm -C packages/proxy exec tsx scripts/sync_models.ts normalize-local-models --write
+        run: pnpm exec tsx packages/proxy/scripts/sync_models.ts normalize-local-models --write
 
       - name: Check expected files only
         id: changes
@@ -397,7 +397,7 @@ jobs:
 
       - name: Canonicalize model list after Codex response
         if: steps.codex_comments.outputs.found == 'true'
-        run: pnpm -C packages/proxy exec tsx scripts/sync_models.ts normalize-local-models --write
+        run: pnpm exec tsx packages/proxy/scripts/sync_models.ts normalize-local-models --write
 
       - name: Check Codex response changes
         id: codex_changes

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint": "^9.39.4",
     "eslint-config-turbo": "latest",
     "prettier": "3.3.2",
+    "tsx": "^4.8.1",
     "turbo": "^2.9.14",
     "vite": "7.3.2",
     "vite-tsconfig-paths": "^6.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       prettier:
         specifier: 3.3.2
         version: 3.3.2
+      tsx:
+        specifier: ^4.8.1
+        version: 4.22.3
       turbo:
         specifier: ^2.9.14
         version: 2.9.14
@@ -7862,7 +7865,7 @@ snapshots:
       eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@1.21.7))
@@ -7895,7 +7898,7 @@ snapshots:
       enhanced-resolve: 5.15.0
       eslint: 9.39.4(jiti@1.21.7)
       eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.16.1
@@ -7917,7 +7920,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.4(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.5.4))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
The ["Sync new models" job fails with](https://github.com/braintrustdata/braintrust-proxy/actions/runs/27354572992): 
  undefined
  ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "tsx" not found


I believe that explicitly using tsx here will resolve the issue-- I'm honestly not sure why this keeps running into issues but hopefully this fixes them for good