### PR TITLE
Reinstall dependencies after PR branch checkout in GH actions

### DIFF
--- a/.github/workflows/fix-missing-model-bot-issues.yaml
+++ b/.github/workflows/fix-missing-model-bot-issues.yaml
@@ -603,6 +603,10 @@ jobs:
           fetch-depth: 0
           ref: ${{ steps.pr.outputs.pull-request-branch }}
 
+      - name: Reinstall dependencies after PR branch checkout
+        if: steps.pr.outputs.pull-request-number != ''
+        run: pnpm install --frozen-lockfile
+
       - name: Fetch base branch for Codex review
         if: steps.pr.outputs.pull-request-number != ''
         run: git fetch --no-tags origin main

--- a/.github/workflows/sync-models.yaml
+++ b/.github/workflows/sync-models.yaml
@@ -213,6 +213,10 @@ jobs:
           fetch-depth: 0
           ref: ${{ steps.pr.outputs.pull-request-branch }}
 
+      - name: Reinstall dependencies after PR branch checkout
+        if: steps.pr.outputs.pull-request-number != ''
+        run: pnpm install --frozen-lockfile
+
       - name: Fetch base branch for Codex review
         if: steps.pr.outputs.pull-request-number != ''
         run: git fetch --no-tags origin main


### PR DESCRIPTION
the last fix missed the fact that switching branches deletes node_modules, so we need to re-install