### PR TITLE
fix(ci): add baseten to the agent gap-audit provider inventory

### DIFF
--- a/.github/workflows/agent-provider-model-sync.yaml
+++ b/.github/workflows/agent-provider-model-sync.yaml
@@ -55,6 +55,7 @@ jobs:
 
             - `anthropic` — models and pricing: `https://docs.anthropic.com/en/docs/about-claude/models/all-models`
             - `azure` — models: `https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models` ; pricing: `https://azure.microsoft.com/en-us/pricing/details/azure-openai/`
+            - `baseten` — models: `https://www.baseten.co/library/` (Model APIs library; per-model pages live at `https://www.baseten.co/library/<id>/`) ; pricing: the per-model library page, else `https://www.baseten.co/pricing/`
             - `bedrock` — models: `https://docs.aws.amazon.com/en_us/bedrock/latest/userguide/foundation-models-reference.html` ; pricing: `https://aws.amazon.com/bedrock/pricing/`
             - `cerebras` — models: `https://inference-docs.cerebras.ai/models/overview` ; pricing: `https://inference-docs.cerebras.ai/support/pricing`
             - `databricks` — models: `https://docs.databricks.com/aws/en/machine-learning/model-serving/foundation-model-overview`


### PR DESCRIPTION
baseten was in the LiteLLM sync allowlist (DEFAULT_PROVIDERS) but absent from the agent gap-audit's provider inventory, so the agent never audited baseten's catalog directly. The LiteLLM sync is baseten's only coverage, and LiteLLM doesn't track baseten's library (e.g. it has no GLM-5.2 entry), so newly available baseten models like GLM 5.2
(https://www.baseten.co/library/glm-52/) fall through both flows. Add baseten (Model APIs library + pricing) to the inventory so the agent discovers baseten models the same way it does fireworks.