### PR TITLE
Suppress Gemini returned thoughts for structured JSON output

### DIFF
--- a/packages/proxy/src/providers/google-converter.ts
+++ b/packages/proxy/src/providers/google-converter.ts
@@ -349,15 +349,23 @@ export const openaiParamsToGeminiMessageParams = (
     gemini.thinkingConfig = getGeminiThinkingParams({
       ...openai,
       max_completion_tokens: maxTokens,
+      includeThoughts: !isJSONResponseFormat(openai.response_format),
     });
   }
 
   return gemini;
 };
 
+const isJSONResponseFormat = (
+  responseFormat: OpenAIChatCompletionCreateParams["response_format"],
+): boolean =>
+  responseFormat?.type === "json_schema" ||
+  responseFormat?.type === "json_object";
+
 const getGeminiThinkingParams = (
   openai: OpenAIChatCompletionCreateParams & {
     max_completion_tokens?: Required<number>;
+    includeThoughts?: boolean;
   },
 ): ThinkingConfig => {
   if (openai.reasoning_enabled === false || openai.reasoning_budget === 0) {
@@ -367,7 +375,7 @@ const getGeminiThinkingParams = (
   }
 
   return {
-    includeThoughts: true,
+    ...(openai.includeThoughts ? { includeThoughts: true } : {}),
     thinkingBudget: getThinkingBudget(openai),
   };
 };

--- a/packages/proxy/src/providers/google.params.test.ts
+++ b/packages/proxy/src/providers/google.params.test.ts
@@ -950,6 +950,96 @@ describe("Google parameter translation (captureOnly)", () => {
         },
       });
     });
+
+    it("should omit returned thoughts for streaming json_schema with reasoning", async () => {
+      const { fetch, requests } = createCapturingFetch({ captureOnly: true });
+
+      await callProxyV1<
+        OpenAIChatCompletionCreateParams,
+        OpenAIChatCompletionChunk
+      >({
+        body: {
+          model: "gemini-2.5-flash",
+          messages: [
+            {
+              role: "user",
+              content: "Return a JSON object with the answer.",
+            },
+          ],
+          response_format: {
+            type: "json_schema",
+            json_schema: {
+              name: "answer",
+              strict: true,
+              schema: {
+                type: "object",
+                properties: {
+                  answer: { type: "string" },
+                },
+                required: ["answer"],
+                additionalProperties: false,
+              },
+            },
+          },
+          reasoning_budget: 1000,
+          max_tokens: 300,
+          stream: true,
+        },
+        fetch,
+      });
+
+      expect(requests).toHaveLength(1);
+      expect(requests[0].url).toContain("streamGenerateContent");
+      const body = requests[0].body as Record<string, unknown>;
+      const generationConfig = body.generationConfig as Record<
+        string,
+        unknown
+      >;
+      const thinkingConfig = generationConfig.thinkingConfig as Record<
+        string,
+        unknown
+      >;
+      expect(thinkingConfig.thinkingBudget).toBe(1000);
+      expect(thinkingConfig).not.toHaveProperty("includeThoughts");
+    });
+
+    it("should omit returned thoughts for streaming json_object with reasoning", async () => {
+      const { fetch, requests } = createCapturingFetch({ captureOnly: true });
+
+      await callProxyV1<
+        OpenAIChatCompletionCreateParams,
+        OpenAIChatCompletionChunk
+      >({
+        body: {
+          model: "gemini-2.5-flash",
+          messages: [
+            {
+              role: "user",
+              content: "Return a JSON object with name and age.",
+            },
+          ],
+          response_format: { type: "json_object" },
+          reasoning_budget: 1000,
+          max_tokens: 300,
+          stream: true,
+        },
+        fetch,
+      });
+
+      expect(requests).toHaveLength(1);
+      expect(requests[0].url).toContain("streamGenerateContent");
+      const body = requests[0].body as Record<string, unknown>;
+      const generationConfig = body.generationConfig as Record<
+        string,
+        unknown
+      >;
+      const thinkingConfig = generationConfig.thinkingConfig as Record<
+        string,
+        unknown
+      >;
+      expect(thinkingConfig.thinkingBudget).toBe(1000);
+      expect(thinkingConfig).not.toHaveProperty("includeThoughts");
+    });
   });
 
   describe("image input", () => {

--- a/packages/proxy/src/providers/google.test.ts
+++ b/packages/proxy/src/providers/google.test.ts
@@ -1709,6 +1709,41 @@ describe("googleCompletionToOpenAICompletion", () => {
 });
 
 describe("googleEventToOpenAIChatEvent", () => {
+  it("should emit thought text as reasoning and not content", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const geminiEvent: any = {
+      candidates: [
+        {
+          content: {
+            role: "model",
+            parts: [
+              {
+                thought: true,
+                text: "**Defining the response shape**",
+              },
+              {
+                text: '{"answer":"done"}',
+              },
+            ],
+          },
+          finishReason: "STOP",
+        },
+      ],
+    };
+
+    const result = googleEventToOpenAIChatEvent(
+      "gemini-2.0-flash",
+      geminiEvent,
+    );
+
+    expect(result.event).not.toBeNull();
+    expect(result.event!.choices).toHaveLength(1);
+    expect(result.event!.choices[0].delta.content).toBe('{"answer":"done"}');
+    expect(result.event!.choices[0].delta.reasoning?.content).toBe(
+      "**Defining the response shape**",
+    );
+  });
+
   it("should handle snake_case function_call in streaming output", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const geminiEvent: any = {

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -3472,6 +3472,13 @@ async function fetchGoogleChatCompletions({
     oaiParams.response_format?.type === "json_schema"
   ) {
     params.response_mime_type = "application/json";
+    if (
+      params.thinkingConfig &&
+      typeof params.thinkingConfig === "object" &&
+      !Array.isArray(params.thinkingConfig)
+    ) {
+      delete (params.thinkingConfig as Record<string, unknown>).includeThoughts;
+    }
   }
   if (oaiParams.response_format?.type === "json_schema") {
     params.response_schema = await googleSchemaFromJsonSchema(


### PR DESCRIPTION
 ## Summary

  Fixes Gemini structured/JSON output failures when reasoning is enabled by not requesting returned thought text for JSON-mode Gemini requests.

  When `response_format.type` is `json_schema` or `json_object`, Gemini can emit markdown-like thought text before the actual JSON if `thinkingConfig.includeThoughts` is enabled.
  That text reaches Braintrust as normal content and is later parsed as JSON, causing errors like:

  ```text
  invalid JSON: SyntaxError: Unexpected token '*', "**Defining"... is not valid JSON

  ## Changes

  - Preserve Gemini thinking budget for structured/JSON output requests.
  - Suppress thinkingConfig.includeThoughts: true for Gemini json_schema and json_object requests.
  - Keep existing returned-thought behavior for plain-text Gemini reasoning requests.
  - Add regression coverage for Gemini structured/JSON output with reasoning enabled.

  ## Why

  Structured-output parsing should only receive final JSON content. Returned model thoughts are useful for text responses, but in JSON mode they can contaminate the parse buffer
  and break otherwise valid structured responses.

  ## Test Plan

  - Add/update tests in proxy/packages/proxy/src/providers/google.params.test.ts.
  - Verify json_schema + reasoning_budget > 0 sends thinkingBudget but does not set includeThoughts: true.
  - Verify analogous behavior for json_object.
  - Verify existing plain-text Gemini reasoning tests still include returned thoughts.