### PR TITLE
Add bedrock models as gpt fallbacks

### DIFF
--- a/packages/proxy/schema/model_list.json
+++ b/packages/proxy/schema/model_list.json
@@ -58,6 +58,9 @@
     "input_cache_read_cost_per_mil_tokens": 0.5,
     "displayName": "GPT-5.5",
     "reasoning": true,
+    "fallback_models": [
+      "openai.gpt-5.5"
+    ],
     "max_input_tokens": 1050000,
     "max_output_tokens": 128000,
     "available_providers": [
@@ -158,6 +161,9 @@
     "input_cache_read_cost_per_mil_tokens": 0.25,
     "displayName": "GPT-5.4",
     "reasoning": true,
+    "fallback_models": [
+      "openai.gpt-5.4"
+    ],
     "max_input_tokens": 1050000,
     "max_output_tokens": 128000,
     "available_providers": [

--- a/packages/proxy/scripts/sync_models.test.ts
+++ b/packages/proxy/scripts/sync_models.test.ts
@@ -315,6 +315,44 @@ export const AvailableEndpointTypes = {
     ).toEqual(["vertex"]);
   });
 
+  it("registers Bedrock Mantle openai.gpt-* ids as fallbacks for the canonical gpt model", () => {
+    const models = applyEquivalentModels({
+      "gpt-5.5": {
+        format: "openai",
+        flavor: "chat",
+        available_providers: ["openai", "azure"],
+      },
+      "openai.gpt-5.5": {
+        format: "openai",
+        flavor: "chat",
+        available_providers: ["bedrock"],
+      },
+      "us.openai.gpt-5.4": {
+        format: "openai",
+        flavor: "chat",
+        available_providers: ["bedrock"],
+      },
+      "gpt-5.4": {
+        format: "openai",
+        flavor: "chat",
+        available_providers: ["openai", "azure"],
+      },
+      // gpt-oss is open-weight (converse format, not openai/azure) and must not
+      // be grouped even though its Bedrock id also starts with `openai.gpt-`.
+      "openai.gpt-oss-120b-1:0": {
+        format: "converse",
+        flavor: "chat",
+        available_providers: ["bedrock"],
+      },
+    });
+
+    expect(models["gpt-5.5"].fallback_models).toEqual(["openai.gpt-5.5"]);
+    expect(models["gpt-5.4"].fallback_models).toEqual(["us.openai.gpt-5.4"]);
+    expect(models["openai.gpt-5.5"].fallback_models).toBeUndefined();
+    expect(models["openai.gpt-5.5"].available_providers).toEqual(["bedrock"]);
+    expect(models["openai.gpt-oss-120b-1:0"].fallback_models).toBeUndefined();
+  });
+
   it("does not group lookalike variants that need curated equivalence", () => {
     const models = applyEquivalentModels({
       "gpt-4o": {

--- a/packages/proxy/scripts/sync_models.ts
+++ b/packages/proxy/scripts/sync_models.ts
@@ -573,6 +573,15 @@ const MISTRAL_VERTEX_EQUIVALENT_MODELS = new Set([
   "mistral-large-2411",
 ]);
 
+// AWS Bedrock serves OpenAI's GPT models through the Mantle engine under an
+// `openai.` prefix (optionally region-scoped, e.g. `us.openai.gpt-5.5`). These
+// are the same models as the canonical `gpt-*` ids available via openai/azure,
+// so register the Bedrock ids as fallbacks for the canonical model. The
+// open-weight `gpt-oss` family is excluded: it is a distinct (converse-format)
+// model served outside openai/azure, so it must not be grouped here.
+const BEDROCK_OPENAI_GPT_PATTERN =
+  /^(?:(?:global|us|eu|apac)\.)?openai\.(gpt-(?!oss).+)$/;
+
 type EquivalentModelCandidate = {
   canonicalName: string;
   managed: boolean;
@@ -626,6 +635,14 @@ function equivalentModelCandidate(
   ) {
     return {
       canonicalName: parts.slice(2).join("."),
+      managed: true,
+    };
+  }
+
+  const bedrockOpenAiGptMatch = modelName.match(BEDROCK_OPENAI_GPT_PATTERN);
+  if (bedrockOpenAiGptMatch) {
+    return {
+      canonicalName: bedrockOpenAiGptMatch[1],
       managed: true,
     };
   }


### PR DESCRIPTION
Now that bedrock offers gpt models, we want to provide bedrock as a fallback option for these models