### PR TITLE
Precompute model provider/fallback stuff

### DIFF
--- a/packages/proxy/schema/index.ts
+++ b/packages/proxy/schema/index.ts
@@ -7,8 +7,6 @@ import type {
 import {
   ModelFormat,
   ModelEndpointType,
-  type ModelName,
-  ModelSpec,
   getAvailableModels,
 } from "./models";
 
@@ -1111,40 +1109,52 @@ export const AvailableEndpointTypes: { [name: string]: ModelEndpointType[] } = {
   "accounts/fireworks/models/kimi-k2-instruct": ["fireworks"],
 };
 
+const modelEndpointAvailableModels = getAvailableModels();
+const fallbackModelsByName: Record<string, Set<string>> = {};
+const modelEndpointTypesByName: Record<string, ModelEndpointType[]> = {};
+
+for (const [modelName, spec] of Object.entries(modelEndpointAvailableModels)) {
+  const fallbackModels = spec.fallback_models ?? [];
+  if (fallbackModels.length === 0) {
+    continue;
+  }
+  fallbackModelsByName[modelName] ??= new Set<string>();
+  for (const fallbackModel of fallbackModels) {
+    fallbackModelsByName[modelName].add(fallbackModel);
+    fallbackModelsByName[fallbackModel] ??= new Set<string>();
+    fallbackModelsByName[fallbackModel].add(modelName);
+    for (const relatedFallbackModel of fallbackModels) {
+      fallbackModelsByName[fallbackModel].add(relatedFallbackModel);
+    }
+  }
+}
+
 function getDirectModelEndpointTypes(model: string): ModelEndpointType[] {
   return (
     AvailableEndpointTypes[model] ||
-    (getAvailableModels()[model] &&
-      DefaultEndpointTypes[getAvailableModels()[model].format]) ||
+    (modelEndpointAvailableModels[model] &&
+      DefaultEndpointTypes[modelEndpointAvailableModels[model].format]) ||
     []
   );
 }
 
 export function getModelEndpointTypes(model: string): ModelEndpointType[] {
-  const availableModels = getAvailableModels();
+  if (modelEndpointTypesByName[model]) {
+    return modelEndpointTypesByName[model];
+  }
+
   const endpointTypes = new Set<ModelEndpointType>(
     getDirectModelEndpointTypes(model),
   );
 
-  const fallbackModels = new Set<string>(
-    availableModels[model]?.fallback_models ?? [],
-  );
-  for (const [candidate, spec] of Object.entries(availableModels)) {
-    if (spec.fallback_models?.includes(model)) {
-      fallbackModels.add(candidate);
-      for (const fallbackModel of spec.fallback_models) {
-        fallbackModels.add(fallbackModel);
-      }
-    }
-  }
-
-  for (const fallbackModel of fallbackModels) {
+  for (const fallbackModel of fallbackModelsByName[model] ?? []) {
     for (const endpointType of getDirectModelEndpointTypes(fallbackModel)) {
       endpointTypes.add(endpointType);
     }
   }
 
-  return [...endpointTypes];
+  modelEndpointTypesByName[model] = [...endpointTypes];
+  return modelEndpointTypesByName[model];
 }
 
 export const AISecretTypes: { [keyName: string]: ModelEndpointType } = {

--- a/packages/proxy/schema/index.ts
+++ b/packages/proxy/schema/index.ts
@@ -4,11 +4,7 @@ import type {
   MessageRoleType as MessageRole,
   ModelParamsType as ModelParams,
 } from "../src/generated_types";
-import {
-  ModelFormat,
-  ModelEndpointType,
-  getAvailableModels,
-} from "./models";
+import { ModelFormat, ModelEndpointType, getAvailableModels } from "./models";
 
 export * from "./secrets";
 export * from "./models";


### PR DESCRIPTION
debugging some client perf issues from `useAvailableModels` and we're doing a shitload of scans that are like 1ms each but add up to the whole browser locking up when we do that for repeatedly in each hook call and call that hook a ton of times

goes with 
https://github.com/braintrustdata/braintrust/pull/16301