### PR TITLE
Fix flaky proxy CI

### DIFF
--- a/packages/proxy/scripts/fix_bot_issue.test.ts
+++ b/packages/proxy/scripts/fix_bot_issue.test.ts
@@ -37,7 +37,7 @@ describe("fix_bot_issue", () => {
 
       expect(updated).toBe(
         buildEndpointTypesFile([
-          '  "openai/gpt-oss-120b": ["together","groq","baseten","cerebras"],',
+          '  "openai/gpt-oss-120b": ["together", "groq", "baseten", "cerebras"],',
           '  "openai/gpt-oss-20b": ["groq"],',
         ]),
       );
@@ -53,7 +53,7 @@ describe("fix_bot_issue", () => {
         "openai/gpt-oss-20b": ["groq", "cerebras"],
       });
 
-      expect(updated).toContain('"openai/gpt-oss-20b": ["groq","cerebras"],');
+      expect(updated).toContain('"openai/gpt-oss-20b": ["groq", "cerebras"],');
     });
   });
 });

--- a/packages/proxy/src/providers/anthropic.test.ts
+++ b/packages/proxy/src/providers/anthropic.test.ts
@@ -1,5 +1,5 @@
-import { it, expect, describe } from "vitest";
-import { callProxyV1, createCapturingFetch } from "../../utils/tests";
+import { expect, describe } from "vitest";
+import { callProxyV1, createCapturingFetch, it } from "../../utils/tests";
 import { anthropicAuthHeaders, FetchFn } from "../proxy";
 import {
   OpenAIChatCompletion,

--- a/packages/proxy/src/providers/anthropic.test.ts
+++ b/packages/proxy/src/providers/anthropic.test.ts
@@ -18,7 +18,10 @@ import {
   VIDEO_DATA_URL,
 } from "../../tests/fixtures/base64";
 
-const ANTHROPIC_LIVE_TEST_MODEL = "claude-sonnet-4-20250514";
+// Anthropic retired the dated claude-sonnet-4-20250514 snapshot (its API now
+// returns not_found_error for it), so the live tests use the current Sonnet
+// alias — the same model the other live tests in this file already use.
+const ANTHROPIC_LIVE_TEST_MODEL = "claude-sonnet-4-5";
 
 it("should convert OpenAI streaming request to Anthropic and back", async () => {
   const { events } = await callProxyV1<

--- a/packages/proxy/src/providers/anthropic.test.ts
+++ b/packages/proxy/src/providers/anthropic.test.ts
@@ -236,7 +236,10 @@ it("should convert OpenAI non-streaming request to Anthropic and back", async ()
     ],
     created: expect.any(Number),
     id: expect.any(String),
-    model: ANTHROPIC_LIVE_TEST_MODEL,
+    // The alias resolves upstream to a dated snapshot (e.g.
+    // claude-sonnet-4-5-20250929), which Anthropic echoes back, so match the
+    // family rather than the exact requested id.
+    model: expect.stringMatching(/^claude-sonnet-4-5/),
     object: "chat.completion",
     usage: {
       completion_tokens: expect.any(Number),

--- a/packages/proxy/src/providers/azure.test.ts
+++ b/packages/proxy/src/providers/azure.test.ts
@@ -1,6 +1,6 @@
 import { OpenAIChatCompletion, OpenAIChatCompletionCreateParams } from "@types";
-import { expect, it } from "vitest";
-import { callProxyV1 } from "../../utils/tests";
+import { expect } from "vitest";
+import { callProxyV1, it } from "../../utils/tests";
 
 it("should filter Braintrust parameters when calling OpenAI", async () => {
   if (!process.env.AZURE_OPENAI_API_KEY) {

--- a/packages/proxy/src/providers/google.params.test.ts
+++ b/packages/proxy/src/providers/google.params.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { callProxyV1, createCapturingFetch } from "../../utils/tests";
+import { describe, expect } from "vitest";
+import { callProxyV1, createCapturingFetch, it } from "../../utils/tests";
 import {
   OpenAIChatCompletionChunk,
   OpenAIChatCompletionCreateParams,

--- a/packages/proxy/src/providers/google.test.ts
+++ b/packages/proxy/src/providers/google.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { callProxyV1 } from "../../utils/tests";
+import { describe, expect } from "vitest";
+import { callProxyV1, it } from "../../utils/tests";
 import {
   OpenAIChatCompletion,
   OpenAIChatCompletionChunk,

--- a/packages/proxy/src/providers/openai.test.ts
+++ b/packages/proxy/src/providers/openai.test.ts
@@ -13,11 +13,10 @@ import {
   beforeAll,
   describe,
   expect,
-  it,
   test,
   vi,
 } from "vitest";
-import { callProxyV1, createCapturingFetch } from "../../utils/tests";
+import { callProxyV1, createCapturingFetch, it } from "../../utils/tests";
 import * as proxyUtil from "../util";
 import { type FetchFn } from "../proxy";
 import { normalizeOpenAIContent } from "./openai";

--- a/packages/proxy/utils/provider-rate-limit.test.ts
+++ b/packages/proxy/utils/provider-rate-limit.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { isProviderRateLimit } from "./tests";
+
+describe("isProviderRateLimit", () => {
+  it("detects rate-limit / overloaded status codes", () => {
+    expect(isProviderRateLimit(429, "")).toBe(true);
+    expect(isProviderRateLimit(503, "")).toBe(true); // proxy OVERLOADED_ERROR_CODE
+    expect(isProviderRateLimit(529, "")).toBe(true); // Anthropic overloaded
+  });
+
+  it("detects the proxy's wrapped 'AI provider returned <code> error' text", () => {
+    expect(
+      isProviderRateLimit(
+        200,
+        "AI provider returned 503 error:\n\nupstream body\n\nHeaders:\n...",
+      ),
+    ).toBe(true);
+    expect(isProviderRateLimit(200, "AI provider returned 429 error:")).toBe(
+      true,
+    );
+  });
+
+  it("detects rate-limit / overloaded error bodies", () => {
+    expect(
+      isProviderRateLimit(200, '{"error":{"type":"overloaded_error"}}'),
+    ).toBe(true);
+    expect(
+      isProviderRateLimit(200, '{"error":{"type":"rate_limit_error"}}'),
+    ).toBe(true);
+    expect(isProviderRateLimit(200, "Too Many Requests")).toBe(true);
+  });
+
+  it("does not flag non-rate-limit failures", () => {
+    expect(isProviderRateLimit(400, "invalid model identifier")).toBe(false);
+    expect(
+      isProviderRateLimit(401, '{"error":{"type":"authentication_error"}}'),
+    ).toBe(false);
+    expect(
+      isProviderRateLimit(200, "AI provider returned 400 error: bad request"),
+    ).toBe(false);
+    expect(isProviderRateLimit(200, "")).toBe(false);
+  });
+});

--- a/packages/proxy/utils/tests.ts
+++ b/packages/proxy/utils/tests.ts
@@ -32,7 +32,10 @@ export class ProviderRateLimitError extends Error {
   }
 }
 
-const RATE_LIMIT_STATUS_CODES = new Set([429, 529]);
+// Rate-limit / transient-overload statuses. These mirror the proxy's own
+// RATE_LIMITING_ERROR_CODES (429 rate limit, 503 overloaded); 529 is included
+// because some providers (e.g. Anthropic) return it directly for overload.
+const RATE_LIMIT_STATUS_CODES = new Set([429, 503, 529]);
 const RATE_LIMIT_TEXT_PATTERN =
   /rate[\s_-]?limit|rate_limit_exceeded|too many requests|quota exceeded|insufficient_quota|overloaded/i;
 
@@ -41,6 +44,13 @@ export function isProviderRateLimit(
   responseText: string,
 ): boolean {
   if (RATE_LIMIT_STATUS_CODES.has(statusCode)) {
+    return true;
+  }
+  // When the proxy exhausts its own retries it streams the upstream failure as
+  // `AI provider returned <code> error: ...` with that status; catch the
+  // rate-limit codes embedded in that wrapper text too.
+  const wrapped = responseText.match(/AI provider returned (\d+) error/i);
+  if (wrapped && RATE_LIMIT_STATUS_CODES.has(Number(wrapped[1]))) {
     return true;
   }
   return RATE_LIMIT_TEXT_PATTERN.test(responseText);

--- a/packages/proxy/utils/tests.ts
+++ b/packages/proxy/utils/tests.ts
@@ -2,6 +2,7 @@
 
 import { TextDecoder } from "util";
 import { Buffer } from "node:buffer";
+import { it as vitestIt, type TestContext } from "vitest";
 import { proxyV1, FetchFn } from "../src/proxy";
 import { getModelEndpointTypes } from "@schema";
 import { createParser, ParsedEvent, ParseEvent } from "eventsource-parser";
@@ -12,6 +13,79 @@ export class CaptureOnlyError extends Error {
     this.name = "CaptureOnlyError";
   }
 }
+
+// Thrown by `callProxyV1` when an upstream model provider returns a rate-limit
+// or transient-overload response (HTTP 429, Anthropic's 529 "overloaded", or a
+// body that looks like a rate-limit error). Tests written with the `it` wrapper
+// exported below retry once and then skip on this error instead of failing, so
+// flaky provider rate limits don't turn into red CI.
+export class ProviderRateLimitError extends Error {
+  statusCode: number;
+  responseText: string;
+  constructor(statusCode: number, responseText: string) {
+    super(
+      `Model provider rate limit (status ${statusCode}): ${responseText.slice(0, 200)}`,
+    );
+    this.name = "ProviderRateLimitError";
+    this.statusCode = statusCode;
+    this.responseText = responseText;
+  }
+}
+
+const RATE_LIMIT_STATUS_CODES = new Set([429, 529]);
+const RATE_LIMIT_TEXT_PATTERN =
+  /rate[\s_-]?limit|rate_limit_exceeded|too many requests|quota exceeded|insufficient_quota|overloaded/i;
+
+export function isProviderRateLimit(
+  statusCode: number,
+  responseText: string,
+): boolean {
+  if (RATE_LIMIT_STATUS_CODES.has(statusCode)) {
+    return true;
+  }
+  return RATE_LIMIT_TEXT_PATTERN.test(responseText);
+}
+
+// Drop-in replacement for vitest's `it` for tests that make real model-provider
+// calls. It retries the test body once on any failure, and if the failure is a
+// provider rate limit (ProviderRateLimitError), skips the test instead of
+// failing. Non-rate-limit failures still fail after the single retry.
+type ProviderTestFn = (ctx: TestContext) => void | Promise<void>;
+
+export const it: typeof vitestIt = Object.assign(
+  function itWithProviderRetry(
+    name: string,
+    fn?: ProviderTestFn,
+    timeout?: number,
+  ) {
+    return vitestIt(
+      name,
+      async (ctx) => {
+        if (!fn) {
+          return;
+        }
+        const maxAttempts = 2; // initial attempt + one retry
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+          try {
+            await fn(ctx);
+            return;
+          } catch (err) {
+            if (attempt < maxAttempts) {
+              continue; // retry once on any failure
+            }
+            if (err instanceof ProviderRateLimitError) {
+              ctx.skip();
+              return;
+            }
+            throw err;
+          }
+        }
+      },
+      timeout,
+    );
+  } as typeof vitestIt,
+  vitestIt,
+);
 
 export interface CapturedRequest {
   url: string;
@@ -256,6 +330,12 @@ export async function callProxyV1<Input extends object, Output extends object>({
 
     const chunks = await Promise.race([chunksPromise, timeoutPromise]);
     const responseText = new TextDecoder().decode(Buffer.concat(chunks));
+
+    // Surface upstream rate-limit / overload responses as a typed error so the
+    // `it` wrapper above can retry-once-then-skip instead of failing CI.
+    if (isProviderRateLimit(ref.statusCode, responseText)) {
+      throw new ProviderRateLimitError(ref.statusCode, responseText);
+    }
 
     // TODO: avoid object reference trick
     // @ts-expect-error


### PR DESCRIPTION
There were 2 issues here:

- I missed that when I changed the script to conform with prettier, we were asserting on the actual string itself, so the extra spaces caused a failure 🤦 
- Sometimes our keys were hitting 429s, so now we retry once and otherwise skip them