### PR TITLE
Skip Bedrock credentials for OpenAI-format requests in legacy proxy

### DIFF
--- a/packages/proxy/src/proxy.bedrock-openai-skip.test.ts
+++ b/packages/proxy/src/proxy.bedrock-openai-skip.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { proxyV1, CACHE_HEADER, CREDS_CACHE_HEADER } from "./proxy";
+import { type APISecret } from "../schema";
+
+const bedrockSecret: APISecret = {
+  id: "00000000-0000-0000-0000-0000000000b1",
+  type: "bedrock",
+  name: "my-bedrock",
+  secret: "fake-secret-access-key",
+  metadata: { region: "us-east-1", access_key: "fake-access-key-id" },
+};
+
+const openaiSecret: APISecret = {
+  id: "00000000-0000-0000-0000-0000000000a1",
+  type: "openai",
+  name: "my-openai",
+  secret: "sk-fake-openai-key",
+  metadata: {},
+};
+
+function fakeOpenAIResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      id: "chatcmpl-test",
+      object: "chat.completion",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: "ok" },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+async function runProxy({
+  model,
+  secrets,
+  customFetch,
+}: {
+  model: string;
+  secrets: APISecret[];
+  customFetch: (
+    url: RequestInfo | URL,
+    init?: RequestInit,
+  ) => Promise<Response>;
+}): Promise<void> {
+  await proxyV1({
+    method: "POST",
+    url: "/chat/completions",
+    proxyHeaders: {
+      authorization: "Bearer test-token",
+      [CACHE_HEADER]: "never",
+      [CREDS_CACHE_HEADER]: "never",
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: "user", content: "hi" }],
+      stream: false,
+    }),
+    setHeader: () => {},
+    setStatusCode: () => {},
+    res: new WritableStream<Uint8Array>({ write() {} }),
+    getApiSecrets: async () => secrets,
+    cacheGet: async () => null,
+    cachePut: async () => {},
+    digest: async (message: string) => message,
+    customFetch: customFetch as typeof globalThis.fetch,
+  });
+}
+
+describe("bedrock secret skipped for openai-format models (#18324)", () => {
+  it("uses a compatible secret instead of hard-failing when bedrock is a candidate", async () => {
+    // Run repeatedly: fetchModelLoop picks a random starting secret, so without
+    // the skip this would intermittently route to the bedrock secret and throw
+    // "Bedrock does not support OpenAI format".
+    for (let attempt = 0; attempt < 25; attempt++) {
+      const fetched: string[] = [];
+      const customFetch = async (url: RequestInfo | URL) => {
+        fetched.push(url.toString());
+        return fakeOpenAIResponse();
+      };
+
+      await runProxy({
+        model: "gpt-4o",
+        secrets: [bedrockSecret, openaiSecret],
+        customFetch,
+      });
+
+      expect(fetched).toHaveLength(1);
+      expect(fetched[0]).toContain("openai.com");
+    }
+  });
+
+  it("returns a clear no-keys error (not the bedrock format error) when only bedrock is configured", async () => {
+    await expect(
+      runProxy({
+        model: "gpt-4o",
+        secrets: [bedrockSecret],
+        customFetch: async () => {
+          throw new Error("customFetch should not be called");
+        },
+      }),
+    ).rejects.toThrow(/No API keys found/);
+  });
+
+  it("still routes anthropic-format models to a bedrock secret (no over-skipping)", async () => {
+    // The bedrock secret must remain eligible for claude (anthropic format),
+    // which Bedrock can serve. With fake creds the AWS SDK call fails, but the
+    // failure must NOT be our "No API keys found" skip path.
+    await expect(
+      runProxy({
+        model: "claude-3-5-sonnet-20240620",
+        secrets: [bedrockSecret],
+        customFetch: async () => fakeOpenAIResponse(),
+      }),
+    ).rejects.not.toThrow(/No API keys found/);
+  });
+});

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -1422,6 +1422,18 @@ async function fetchModelLoop(
         ? secret.metadata?.customModels?.[model] ?? getAvailableModels()[model]
         : null) ?? null;
 
+    // Bedrock has no OpenAI-compatible endpoint, so an OpenAI-format request can
+    // never be served by a Bedrock credential (fetchOpenAI throws for it). A
+    // Bedrock credential can land here when a model lists Bedrock among its
+    // providers via fallback_models (e.g. gpt-5.5 -> openai.gpt-5.5). Skip it so
+    // a compatible credential can be tried instead of hard-failing the request.
+    if (
+      secret.type === "bedrock" &&
+      (modelSpec?.format ?? "openai") === "openai"
+    ) {
+      continue;
+    }
+
     let endpointUrl = url;
     if (endpointUrl === "/auto") {
       switch (modelSpec?.flavor) {


### PR DESCRIPTION
Now that canonical OpenAI models list their Bedrock-served counterparts as fallback_models (e.g. gpt-5.5 -> openai.gpt-5.5, added in #857), getModelEndpointTypes() returns `bedrock` for those models. In the legacy proxy, getApiSecrets() therefore returns an org's Bedrock credential as a candidate for an OpenAI-format request, and fetchModelLoop picks a starting secret at random. When it lands on the Bedrock credential, fetchOpenAI throws `Bedrock does not support OpenAI format`, surfacing as an intermittent hard failure (the error is a ProxyBadRequestError and is rethrown without trying the next secret).

Skip a Bedrock credential when the resolved model format is `openai`, mirroring fetchOpenAI's throw condition, so a compatible credential is used instead. This preserves Bedrock eligibility for anthropic/converse-format models (which Bedrock can serve) and leaves the fallback_models data untouched for the gateway. A Bedrock-only org requesting an OpenAI model now gets the clear "No API keys found" error instead of the confusing Bedrock one.

Adds a proxyV1-level regression test covering: random-pick no longer routes an OpenAI request to Bedrock, the clean no-keys error, and no over-skipping of anthropic-format models.