### PR TITLE
test: replace retired Claude models in tests with current ones

### DIFF
--- a/packages/proxy/src/providers/anthropic.test.ts
+++ b/packages/proxy/src/providers/anthropic.test.ts
@@ -816,12 +816,12 @@ it("should return error when non-3.7 model receives max_tokens exceeding its lim
   expect(statusCode).toBeGreaterThanOrEqual(400);
 });
 
-it("should use 64000 max_tokens and avoid 128k beta header for claude-3-7-sonnet when unset", async () => {
+it("should use 64000 max_tokens and avoid 128k beta header for claude-sonnet-4-5 when unset", async () => {
   const { fetch, requests } = createCapturingFetch({ captureOnly: true });
 
   await callProxyV1<OpenAIChatCompletionCreateParams, OpenAIChatCompletion>({
     body: {
-      model: "claude-3-7-sonnet-latest",
+      model: "claude-sonnet-4-5",
       messages: [{ role: "user", content: "Say hi" }],
       stream: false,
     },
@@ -840,7 +840,7 @@ it("should convert plain text file to Anthropic PlainTextSource document", async
 
   await callProxyV1<OpenAIChatCompletionCreateParams, OpenAIChatCompletion>({
     body: {
-      model: "claude-3-7-sonnet-latest",
+      model: "claude-sonnet-4-5",
       messages: [
         {
           role: "user",
@@ -885,7 +885,7 @@ it("should convert markdown file to Anthropic PlainTextSource document", async (
 
   await callProxyV1<OpenAIChatCompletionCreateParams, OpenAIChatCompletion>({
     body: {
-      model: "claude-3-7-sonnet-latest",
+      model: "claude-sonnet-4-5",
       messages: [
         {
           role: "user",
@@ -929,7 +929,7 @@ it("should convert CSV file to Anthropic PlainTextSource document", async () => 
 
   await callProxyV1<OpenAIChatCompletionCreateParams, OpenAIChatCompletion>({
     body: {
-      model: "claude-3-7-sonnet-latest",
+      model: "claude-sonnet-4-5",
       messages: [
         {
           role: "user",

--- a/packages/proxy/src/proxy.bedrock-openai-skip.test.ts
+++ b/packages/proxy/src/proxy.bedrock-openai-skip.test.ts
@@ -113,7 +113,7 @@ describe("bedrock secret skipped for openai-format models (#18324)", () => {
     // failure must NOT be our "No API keys found" skip path.
     await expect(
       runProxy({
-        model: "claude-3-5-sonnet-20240620",
+        model: "anthropic.claude-sonnet-4-6",
         secrets: [bedrockSecret],
         customFetch: async () => fakeOpenAIResponse(),
       }),


### PR DESCRIPTION
These tests hardcoded models Anthropic has retired and that were removed from the catalog, so they failed deterministically (getModelEndpointTypes returns nothing -> "Unknown model", or the removed entry no longer routes to bedrock):

- anthropic.test.ts: claude-3-7-sonnet-latest -> claude-sonnet-4-5 (the 64000 max_tokens / no-128k-beta test and the three PlainTextSource file-conversion tests; claude-sonnet-4-5 is already the file's standard test model).
- proxy.bedrock-openai-skip.test.ts: claude-3-5-sonnet-20240620 ->
  anthropic.claude-sonnet-4-6 (a current anthropic-format model that still routes to bedrock, preserving the "no over-skipping" assertion).

Verified: bedrock test 3/3; the anthropic capture tests pass (they mock the upstream fetch and just need a resolving current model).