### PR TITLE
Fix Gemini/Vertex estimated cost excluding thinking tokens

### DIFF
--- a/packages/proxy/src/providers/google-converter.ts
+++ b/packages/proxy/src/providers/google-converter.ts
@@ -147,7 +147,14 @@ const geminiUsageToOpenAIUsage = (
 
   const usage: OpenAICompletionUsage = {
     prompt_tokens: usageMetadata.promptTokenCount || 0,
-    completion_tokens: usageMetadata.candidatesTokenCount || 0,
+    // Gemini reports visible output (candidatesTokenCount) and thinking
+    // (thoughtsTokenCount) separately, and totalTokenCount is their sum. Follow
+    // the OpenAI convention (also used by the Anthropic converter and Lingua)
+    // where completion_tokens includes reasoning, so downstream cost estimation
+    // prices thinking tokens as output. reasoning_tokens below stays the subset
+    // breakdown.
+    completion_tokens:
+      (usageMetadata.candidatesTokenCount || 0) + (thoughtsTokenCount || 0),
     total_tokens: usageMetadata.totalTokenCount || 0,
   };
 

--- a/packages/proxy/src/providers/google.test.ts
+++ b/packages/proxy/src/providers/google.test.ts
@@ -1412,6 +1412,37 @@ describe("googleCompletionToOpenAICompletion", () => {
     expect(result.choices[0].finish_reason).toBe("stop");
   });
 
+  it("should include thinking tokens in completion_tokens for cost estimation", () => {
+    const geminiResponse: GenerateContentResponse = {
+      candidates: [
+        {
+          content: {
+            role: "model",
+            parts: [{ text: "The answer is 42." }],
+          },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 100,
+        candidatesTokenCount: 50,
+        thoughtsTokenCount: 25,
+        totalTokenCount: 175,
+      },
+    };
+
+    const result = googleCompletionToOpenAICompletion(
+      "gemini-2.5-flash",
+      geminiResponse,
+    );
+
+    // completion_tokens must include thinking tokens (50 + 25) so downstream
+    // cost estimation prices reasoning as output. reasoning_tokens is the subset.
+    expect(result.usage?.completion_tokens).toBe(75);
+    expect(result.usage?.completion_tokens_details?.reasoning_tokens).toBe(25);
+    expect(result.usage?.prompt_tokens).toBe(100);
+  });
+
   it("should map safety finish reasons to content_filter", () => {
     const geminiResponse: GenerateContentResponse = {
       candidates: [
@@ -1754,6 +1785,38 @@ describe("googleEventToOpenAIChatEvent", () => {
       }),
     });
     expect(result.event!.choices[0].finish_reason).toBe("tool_calls");
+  });
+
+  it("should include thinking tokens in streaming completion_tokens", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const geminiEvent: any = {
+      candidates: [
+        {
+          content: {
+            role: "model",
+            parts: [{ text: "The answer is 42." }],
+          },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 100,
+        candidatesTokenCount: 50,
+        thoughtsTokenCount: 25,
+        totalTokenCount: 175,
+      },
+    };
+
+    const result = googleEventToOpenAIChatEvent(
+      "gemini-2.5-flash",
+      geminiEvent,
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const usage = (result.event as any)?.usage;
+    expect(usage?.completion_tokens).toBe(75);
+    expect(usage?.completion_tokens_details?.reasoning_tokens).toBe(25);
+    expect(usage?.prompt_tokens).toBe(100);
   });
 });
 


### PR DESCRIPTION
## Summary

Vertex/Gemini thinking (reasoning) tokens were excluded from estimated LLM cost. `geminiUsageToOpenAIUsage` mapped `completion_tokens` from `candidatesTokenCount` only, which per Google's usage metadata **excludes** `thoughtsTokenCount` (`totalTokenCount = prompt + candidates + toolUse + thoughts`). Since every cost path prices `completion_tokens`, thinking tokens were never charged — undercounting cost for Gemini thinking models on Vertex (e.g. `gemini-3.1-pro-preview`).

## Root cause / fix

The canonical convention across the codebase is that `completion_tokens` is the total billable output **including** reasoning, with `reasoning_tokens` as a subset breakdown:

- **OpenAI** — `completion_tokens` already includes reasoning (pass-through).
- **Anthropic** — `completion_tokens = output_tokens`, which includes thinking.
- **Lingua** — `completion_tokens = candidates + thoughts`.

The legacy Gemini converter was the lone violator. This aligns it with the convention:

```ts
completion_tokens:
  (usageMetadata.candidatesTokenCount || 0) + (thoughtsTokenCount || 0),
```

`reasoning_tokens` stays the subset breakdown. This corrects every downstream cost path at once (proxy metric logging, ingestion, query-time, and UI) without touching the cost logic — and deliberately avoids adding reasoning inside the cost paths, which would **double-count** for OpenAI/Anthropic/Lingua where reasoning is already part of `completion_tokens`.

## Tests

Added streaming + non-streaming regression tests covering the reported payload (`candidatesTokenCount=50`, `thoughtsTokenCount=25` → `completion_tokens=75`, `reasoning_tokens=25`).

## Follow-up

Fixes new logs going forward via the proxy. Historical spans keep the undercounted `completion_tokens` and would need a separate backfill if corrected cost is required. A submodule bump in `braintrustdata/braintrust` is the deploy step after this merges.

Pylon #18680