### PR TITLE
Allow GPT-5 temperature with reasoning none

### DIFF
--- a/packages/proxy/src/providers/openai.test.ts
+++ b/packages/proxy/src/providers/openai.test.ts
@@ -368,6 +368,61 @@ it("uses custom api base when routing appropriate models through responses", asy
   });
 });
 
+it("preserves temperature for GPT-5.1+ when reasoning_effort is none", async () => {
+  const { fetch, requests } = createCapturingFetch({ captureOnly: true });
+
+  await callProxyV1<OpenAIChatCompletionCreateParams, OpenAIChatCompletion>({
+    body: {
+      model: "gpt-5.5",
+      messages: [{ role: "user", content: "hello" }],
+      reasoning_effort: "none",
+      stream: false,
+      temperature: 0.2,
+    },
+    fetch,
+    getApiSecrets: async () => [
+      {
+        type: "openai",
+        name: "openai",
+        secret: "sk-fake-key",
+      },
+    ],
+  });
+
+  expect(requests.length).toBe(1);
+  expect(requests[0].url).toBe("https://api.openai.com/v1/responses");
+  expect(requests[0].body).toMatchObject({
+    model: "gpt-5.5",
+    temperature: 0.2,
+  });
+});
+
+it("removes temperature for GPT-5.1+ when reasoning_effort is not none", async () => {
+  const { fetch, requests } = createCapturingFetch({ captureOnly: true });
+
+  await callProxyV1<OpenAIChatCompletionCreateParams, OpenAIChatCompletion>({
+    body: {
+      model: "gpt-5.5",
+      messages: [{ role: "user", content: "hello" }],
+      reasoning_effort: "low",
+      stream: false,
+      temperature: 0.2,
+    },
+    fetch,
+    getApiSecrets: async () => [
+      {
+        type: "openai",
+        name: "openai",
+        secret: "sk-fake-key",
+      },
+    ],
+  });
+
+  expect(requests.length).toBe(1);
+  expect(requests[0].url).toBe("https://api.openai.com/v1/responses");
+  expect(requests[0].body).not.toHaveProperty("temperature");
+});
+
 it("handles /responses as endpoint_path", async () => {
   const { fetch, requests } = createCapturingFetch({ captureOnly: true });
 

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -2367,13 +2367,21 @@ async function fetchOpenAI(
     (typeof bodyData?.model === "string" &&
       modelProviderHasReasoning.openai?.test(bodyData.model));
 
+  const canKeepTemperature =
+    typeof bodyData?.model === "string" &&
+    bodyData.model.toLowerCase().includes("gpt-5") &&
+    Object.prototype.hasOwnProperty.call(bodyData, "reasoning_effort") &&
+    bodyData.reasoning_effort === "none";
+
   if (hasReasoning) {
     if (!isEmpty(bodyData.max_tokens)) {
       bodyData.max_completion_tokens = bodyData.max_tokens;
       delete bodyData.max_tokens;
     }
 
-    delete bodyData.temperature;
+    if (!canKeepTemperature) {
+      delete bodyData.temperature;
+    }
     delete bodyData.parallel_tool_calls;
 
     // gpt-5.1 models don't support "minimal" reasoning_effort, so convert to "low"


### PR DESCRIPTION
 ### Context

PR #16823 updates api-ts to preserve temperature for GPT-5 prompts when reasoning_effort is explicitly set to "none". The proxy was still stripping temperature for GPT-5/reasoning-model requests before forwarding them, so proxied OpenAI-format requests would not get the benefit of that fix.

 ### Changes

Update the OpenAI proxy path to preserve temperature for GPT-5 requests when reasoning_effort === "none", while continuing to remove temperature for GPT-5 requests where reasoning is still enabled. This is implemented by adding a canKeepTemperature check in repos/braintrust-proxy/packages/proxy/src/proxy.ts:2370 and only deleting temperature when that condition is false.

###  Testing

Add coverage in repos/braintrust-proxy/packages/proxy/src/providers/openai.test.ts:371 for both cases:

  - GPT-5.5 with reasoning_effort: "none" preserves temperature in the translated /responses request
  - GPT-5.5 with reasoning_effort: "low" continues to omit temperature