### PR TITLE
Fix bt-org-id issue

### DIFF
--- a/apis/cloudflare/src/proxy.ts
+++ b/apis/cloudflare/src/proxy.ts
@@ -11,6 +11,7 @@ import {
   flushMetrics,
   ORG_NAME_HEADER,
   parseAuthHeader,
+  resolveProxyOrgName,
 } from "@braintrust/proxy";
 import { handleRealtimeProxy } from "./realtime";
 import { braintrustAppUrl } from "./env";
@@ -119,7 +120,24 @@ export async function handleProxyV1(
   let spanId: string | undefined;
   let spanExport: string | undefined;
   let billingOrgId: string | undefined;
-  const orgName = request.headers.get(ORG_NAME_HEADER) ?? undefined;
+  const url = new URL(request.url);
+  const relativeUrl = url.pathname.slice(proxyV1Prefix.length);
+  let resolvedOrgSelection: ReturnType<typeof resolveProxyOrgName>;
+  try {
+    resolvedOrgSelection = resolveProxyOrgName({
+      headerOrgName: request.headers.get(ORG_NAME_HEADER) ?? undefined,
+      url: relativeUrl,
+    });
+  } catch (error) {
+    return new Response(
+      error instanceof Error ? error.message : String(error),
+      {
+        status: 400,
+        headers: { "Content-Type": "text/plain" },
+      },
+    );
+  }
+  const orgName = resolvedOrgSelection.orgName;
   const apiKey =
     parseAuthHeader({
       authorization: request.headers.get("authorization") ?? undefined,
@@ -177,8 +195,8 @@ export async function handleProxyV1(
   }
 
   const opts: ProxyOpts = {
-    getRelativeURL(request: Request): string {
-      return new URL(request.url).pathname.slice(proxyV1Prefix.length);
+    getRelativeURL(): string {
+      return relativeUrl;
     },
     cors: true,
     credentialsCache,
@@ -230,7 +248,6 @@ export async function handleProxyV1(
     nativeInferenceSecretKey: env.NATIVE_INFERENCE_SECRET_KEY,
   };
 
-  const url = new URL(request.url);
   if (url.pathname === `${proxyV1Prefix}/realtime`) {
     return await handleRealtimeProxy({
       request,

--- a/packages/proxy/src/proxy-org-selection.test.ts
+++ b/packages/proxy/src/proxy-org-selection.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { proxyV1 } from "./proxy";
+
+describe("proxy org selection", () => {
+  it("rejects conflicting header and path org selectors before secret lookup", async () => {
+    await expect(
+      proxyV1({
+        method: "POST",
+        url: "/btorg/effective-org/chat/completions",
+        proxyHeaders: {
+          authorization: "Bearer test-token",
+          "x-bt-org-name": "header-org",
+        },
+        body: JSON.stringify({
+          model: "braintrust-native-model",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+        setHeader: () => {},
+        setStatusCode: () => {},
+        res: new WritableStream<Uint8Array>({ write() {} }),
+        getApiSecrets: async () => {
+          throw new Error("getApiSecrets should not be called");
+        },
+        cacheGet: async () => null,
+        cachePut: async () => {},
+        digest: async (message: string) => message,
+      }),
+    ).rejects.toThrow(/Conflicting organization selectors/);
+  });
+});

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -386,6 +386,7 @@ export async function proxyV1({
     proxyHeaders[FORMAT_HEADER],
   );
 
+  // Checks x-bt-org-name and /btorg/my-org/ agree
   const resolvedOrgSelection = resolveProxyOrgName({
     headerOrgName: proxyHeaders[ORG_NAME_HEADER] ?? undefined,
     url,

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -177,6 +177,31 @@ export const USED_ENDPOINT_HEADER = "x-bt-used-endpoint";
 
 const CACHE_MODES = ["auto", "always", "never"] as const;
 
+export function resolveProxyOrgName({
+  headerOrgName,
+  url,
+}: {
+  headerOrgName?: string;
+  url: string;
+}): { orgName?: string; url: string } {
+  // "/btorg/my-org/chat/completions" -> ["btorg", "my-org", "chat", "completions"].
+  const pieces = url.split("/").filter((p) => p.trim() !== "");
+
+  if (pieces.length <= 2 || pieces[0].toLowerCase() !== "btorg") {
+    return { orgName: headerOrgName, url };
+  }
+
+  const pathOrgName = decodeURIComponent(pieces[1]);
+  if (headerOrgName && headerOrgName !== pathOrgName) {
+    throw new ProxyBadRequestError("Conflicting organization selectors");
+  }
+
+  return {
+    orgName: pathOrgName,
+    url: `/${pieces.slice(2).join("/")}`,
+  };
+}
+
 // The Anthropic SDK generates /v1/messages appended to the base URL, so we support both
 const ANTHROPIC_MESSAGES = "/anthropic/messages";
 const ANTHROPIC_V1_MESSAGES = "/anthropic/v1/messages";
@@ -361,20 +386,15 @@ export async function proxyV1({
     proxyHeaders[FORMAT_HEADER],
   );
 
-  let orgName: string | undefined = proxyHeaders[ORG_NAME_HEADER] ?? undefined;
+  const resolvedOrgSelection = resolveProxyOrgName({
+    headerOrgName: proxyHeaders[ORG_NAME_HEADER] ?? undefined,
+    url,
+  });
+  let orgName = resolvedOrgSelection.orgName;
   let resolvedOrgName: string | undefined = orgName;
+  url = resolvedOrgSelection.url;
   const projectId: string | undefined =
     proxyHeaders[PROJECT_ID_HEADER] ?? undefined;
-
-  const pieces = url
-    .split("/")
-    .filter((p) => p.trim() !== "")
-    .map((d) => decodeURIComponent(d));
-
-  if (pieces.length > 2 && pieces[0].toLowerCase() === "btorg") {
-    orgName = pieces[1];
-    url = "/" + pieces.slice(2).map(encodeURIComponent).join("/");
-  }
 
   const isGoogleUrl = GOOGLE_URL_REGEX.test(url);
 


### PR DESCRIPTION
bt-org-id and /bt-org/<ORG_ID> can disagree and pass through. This is incorrect behavior since this is an inconsistent state for the PR to be in. This PR fails fast to prevent potentially ambiguous conditions