### PR TITLE
Add normalizeModelNameForCost for wrapper model slugs

### DIFF
--- a/packages/proxy/schema/models.test.ts
+++ b/packages/proxy/schema/models.test.ts
@@ -110,9 +110,9 @@ it("normalizes Cursor CLI reasoning-effort slugs to the base model for cost", ()
     normalizeModelNameForCost("some-unknown-model-high", isKnown),
   ).toBeUndefined();
   expect(normalizeModelNameForCost("gpt-9-max", isKnown)).toBeUndefined();
-  expect(
-    normalizeModelNameForCost("gemini-2.5-pro-high", isKnown),
-  ).toBeUndefined();
+  expect(normalizeModelNameForCost("gemini-2.5-pro-high", isKnown)).toBe(
+    "gemini-2.5-pro",
+  );
 });
 
 it("prefers exact catalog entries over Cursor model normalization", () => {

--- a/packages/proxy/schema/models.test.ts
+++ b/packages/proxy/schema/models.test.ts
@@ -81,19 +81,13 @@ it("Does not deprecate models if deprecation date has not yet passed", () => {
 });
 
 it("normalizes Cursor CLI reasoning-effort slugs to the base model for cost", () => {
-  const known = new Set([
-    "claude-opus-4-8",
-    "claude-opus-4-7",
-    "gpt-5.3-codex",
-  ]);
+  const known = new Set(["claude-opus-4-8", "gpt-5.3-codex", "gemini-2.5-pro"]);
   const isKnown = (name: string) => known.has(name);
 
-  // Exact matches pass through untouched.
   expect(normalizeModelNameForCost("claude-opus-4-8", isKnown)).toBe(
     "claude-opus-4-8",
   );
 
-  // Effort and thinking suffixes collapse to the base model.
   for (const slug of [
     "claude-opus-4-8-low",
     "claude-opus-4-8-medium",
@@ -105,25 +99,32 @@ it("normalizes Cursor CLI reasoning-effort slugs to the base model for cost", ()
   ]) {
     expect(normalizeModelNameForCost(slug, isKnown)).toBe("claude-opus-4-8");
   }
-  expect(
-    normalizeModelNameForCost("claude-opus-4-7-thinking-high", isKnown),
-  ).toBe("claude-opus-4-7");
   expect(normalizeModelNameForCost("gpt-5.3-codex-low", isKnown)).toBe(
     "gpt-5.3-codex",
   );
+  expect(
+    normalizeModelNameForCost(" Claude-Opus-4-8-Thinking-High ", isKnown),
+  ).toBe("claude-opus-4-8");
 
-  // Unknown base models are not invented.
   expect(
     normalizeModelNameForCost("some-unknown-model-high", isKnown),
   ).toBeUndefined();
   expect(normalizeModelNameForCost("gpt-9-max", isKnown)).toBeUndefined();
+  expect(
+    normalizeModelNameForCost("gemini-2.5-pro-high", isKnown),
+  ).toBeUndefined();
+});
+
+it("prefers exact catalog entries over Cursor model normalization", () => {
+  const known = new Set(["gpt-5.3-codex", "gpt-5.3-codex-low"]);
+  expect(
+    normalizeModelNameForCost("gpt-5.3-codex-low", (name) => known.has(name)),
+  ).toBe("gpt-5.3-codex-low");
 });
 
 it("does not strip -fast, which can denote a distinct model", () => {
   const known = new Set(["grok-4"]);
   const isKnown = (name: string) => known.has(name);
-  // grok-4-fast is a separate, cheaper model, so it stays unpriced rather than
-  // collapsing onto grok-4.
   expect(normalizeModelNameForCost("grok-4-fast", isKnown)).toBeUndefined();
 });
 

--- a/packages/proxy/schema/models.test.ts
+++ b/packages/proxy/schema/models.test.ts
@@ -2,7 +2,11 @@ import { expect } from "vitest";
 import { it } from "vitest";
 import raw_models from "./model_list.json";
 import { getModelEndpointTypes } from "./index";
-import { markModelsPastDeprecationDate, ModelSchema } from "./models";
+import {
+  markModelsPastDeprecationDate,
+  ModelSchema,
+  normalizeModelNameForCost,
+} from "./models";
 import { z } from "zod";
 
 it("parse model list", () => {
@@ -74,6 +78,53 @@ it("Does not deprecate models if deprecation date has not yet passed", () => {
     },
   });
   expect(result["testModel"].deprecated).toBe(undefined);
+});
+
+it("normalizes Cursor CLI reasoning-effort slugs to the base model for cost", () => {
+  const known = new Set([
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "gpt-5.3-codex",
+  ]);
+  const isKnown = (name: string) => known.has(name);
+
+  // Exact matches pass through untouched.
+  expect(normalizeModelNameForCost("claude-opus-4-8", isKnown)).toBe(
+    "claude-opus-4-8",
+  );
+
+  // Effort and thinking suffixes collapse to the base model.
+  for (const slug of [
+    "claude-opus-4-8-low",
+    "claude-opus-4-8-medium",
+    "claude-opus-4-8-high",
+    "claude-opus-4-8-xhigh",
+    "claude-opus-4-8-max",
+    "claude-opus-4-8-thinking-high",
+    "claude-opus-4-8-thinking-max",
+  ]) {
+    expect(normalizeModelNameForCost(slug, isKnown)).toBe("claude-opus-4-8");
+  }
+  expect(
+    normalizeModelNameForCost("claude-opus-4-7-thinking-high", isKnown),
+  ).toBe("claude-opus-4-7");
+  expect(normalizeModelNameForCost("gpt-5.3-codex-low", isKnown)).toBe(
+    "gpt-5.3-codex",
+  );
+
+  // Unknown base models are not invented.
+  expect(
+    normalizeModelNameForCost("some-unknown-model-high", isKnown),
+  ).toBeUndefined();
+  expect(normalizeModelNameForCost("gpt-9-max", isKnown)).toBeUndefined();
+});
+
+it("does not strip -fast, which can denote a distinct model", () => {
+  const known = new Set(["grok-4"]);
+  const isKnown = (name: string) => known.has(name);
+  // grok-4-fast is a separate, cheaper model, so it stays unpriced rather than
+  // collapsing onto grok-4.
+  expect(normalizeModelNameForCost("grok-4-fast", isKnown)).toBeUndefined();
 });
 
 it("Ignores malformed deprecation dates", () => {

--- a/packages/proxy/schema/models.ts
+++ b/packages/proxy/schema/models.ts
@@ -214,6 +214,48 @@ async function loadModelsFromControlPlane(
   }
 }
 
+// Reasoning-effort / thinking tier suffixes that tools such as the Cursor CLI
+// append to a base provider model (e.g. "claude-opus-4-8-thinking-high"). They
+// bill at the base per-token rate, so for cost tracking we collapse them onto
+// the base model. "-fast" is intentionally excluded: some providers use it for
+// genuinely distinct, separately-priced models (e.g. grok-4-fast).
+const COST_MODEL_SUFFIX_TOKENS = new Set([
+  "thinking",
+  "none",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+]);
+
+// Returns the catalog model name whose pricing should be used for `modelName`,
+// or undefined if none applies. An exact match wins first, so distinct provider
+// models keep their own pricing; otherwise wrapper suffix tokens are stripped
+// one at a time until a known base model is found.
+export function normalizeModelNameForCost(
+  modelName: string,
+  isKnownModel: (name: string) => boolean,
+): string | undefined {
+  if (isKnownModel(modelName)) {
+    return modelName;
+  }
+  let candidate = modelName;
+  while (true) {
+    const dash = candidate.lastIndexOf("-");
+    if (dash <= 0) {
+      return undefined;
+    }
+    if (!COST_MODEL_SUFFIX_TOKENS.has(candidate.slice(dash + 1))) {
+      return undefined;
+    }
+    candidate = candidate.slice(0, dash);
+    if (isKnownModel(candidate)) {
+      return candidate;
+    }
+  }
+}
+
 export function markModelsPastDeprecationDate(models: {
   [name: string]: ModelSpec;
 }): { [name: string]: ModelSpec } {

--- a/packages/proxy/schema/models.ts
+++ b/packages/proxy/schema/models.ts
@@ -214,11 +214,8 @@ async function loadModelsFromControlPlane(
   }
 }
 
-// Reasoning-effort / thinking tier suffixes that tools such as the Cursor CLI
-// append to a base provider model (e.g. "claude-opus-4-8-thinking-high"). They
-// bill at the base per-token rate, so for cost tracking we collapse them onto
-// the base model. "-fast" is intentionally excluded: some providers use it for
-// genuinely distinct, separately-priced models (e.g. grok-4-fast).
+const CURSOR_COST_BASE_MODELS = new Set(["claude-opus-4-8", "gpt-5.3-codex"]);
+
 const COST_MODEL_SUFFIX_TOKENS = new Set([
   "thinking",
   "none",
@@ -229,10 +226,6 @@ const COST_MODEL_SUFFIX_TOKENS = new Set([
   "max",
 ]);
 
-// Returns the catalog model name whose pricing should be used for `modelName`,
-// or undefined if none applies. An exact match wins first, so distinct provider
-// models keep their own pricing; otherwise wrapper suffix tokens are stripped
-// one at a time until a known base model is found.
 export function normalizeModelNameForCost(
   modelName: string,
   isKnownModel: (name: string) => boolean,
@@ -240,7 +233,7 @@ export function normalizeModelNameForCost(
   if (isKnownModel(modelName)) {
     return modelName;
   }
-  let candidate = modelName;
+  let candidate = modelName.trim().toLowerCase();
   while (true) {
     const dash = candidate.lastIndexOf("-");
     if (dash <= 0) {
@@ -250,7 +243,7 @@ export function normalizeModelNameForCost(
       return undefined;
     }
     candidate = candidate.slice(0, dash);
-    if (isKnownModel(candidate)) {
+    if (CURSOR_COST_BASE_MODELS.has(candidate) && isKnownModel(candidate)) {
       return candidate;
     }
   }

--- a/packages/proxy/schema/models.ts
+++ b/packages/proxy/schema/models.ts
@@ -214,8 +214,6 @@ async function loadModelsFromControlPlane(
   }
 }
 
-const CURSOR_COST_BASE_MODELS = new Set(["claude-opus-4-8", "gpt-5.3-codex"]);
-
 const COST_MODEL_SUFFIX_TOKENS = new Set([
   "thinking",
   "none",
@@ -243,7 +241,7 @@ export function normalizeModelNameForCost(
       return undefined;
     }
     candidate = candidate.slice(0, dash);
-    if (CURSOR_COST_BASE_MODELS.has(candidate) && isKnownModel(candidate)) {
+    if (isKnownModel(candidate)) {
       return candidate;
     }
   }


### PR DESCRIPTION
## What

Adds `normalizeModelNameForCost(modelName, isKnownModel)` to `schema/models.ts`: when a logged model slug is not itself in the pricing catalog, strip reasoning-effort / thinking tier suffix tokens one at a time and price-match the first base model that exists.

## Why

Customers logging **Cursor CLI agent slugs** as their model name (e.g. `claude-opus-4-8-thinking-high`, `gpt-5.3-codex-low`, `claude-opus-4-8-max`) get `$0` estimated cost today because those slugs aren't catalog entries — so they hand-maintain custom cost sheets (Pylon #18928).

## Behavior

- Exact catalog match always wins first → genuinely distinct provider models keep their own pricing.
- Suffix vocabulary: `thinking`, `none`, `low`, `medium`, `high`, `xhigh`, `max`.
- **`-fast` is intentionally excluded** — some providers use it for distinct, separately-priced models (e.g. `grok-4-fast`); those stay unpriced rather than mispriced.
- Unknown base models are never invented.

This is the shared TS helper; the authoritative Rust cost path (ingestion / BTQL / Monitor) mirrors it in the main repo, which also bumps this submodule pointer.

## Test

`schema/models.test.ts` covers slug collapse across providers, exact-match precedence, `-fast` exclusion, and unknown-model rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)