### PR TITLE
Model ordering by release and tier

### DIFF
--- a/packages/proxy/schema/model_list.json
+++ b/packages/proxy/schema/model_list.json
@@ -6044,6 +6044,600 @@
       "groq"
     ]
   },
+  "publishers/google/models/gemini-3.5-flash": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.5,
+    "output_cost_per_mil_tokens": 9,
+    "input_cache_read_cost_per_mil_tokens": 0.15,
+    "displayName": "Gemini 3.5 Flash",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "locations": [
+      "global"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-3.1-flash-image": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 3,
+    "displayName": "Gemini 3.1 Flash Image",
+    "locations": [
+      "global"
+    ],
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-3.1-flash-image-preview": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 3,
+    "displayName": "Gemini 3.1 Flash Image Preview",
+    "locations": [
+      "global"
+    ],
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-3.1-flash-lite": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 1.5,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "displayName": "Gemini 3.1 Flash-Lite",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "locations": [
+      "global"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-3.1-flash-lite-image": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 1.5,
+    "displayName": "Gemini 3.1 Flash-Lite Image",
+    "locations": [
+      "global"
+    ],
+    "max_input_tokens": 65536,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-3.1-flash-lite-preview": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 1.5,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "displayName": "Gemini 3.1 Flash-Lite (Preview)",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "locations": [
+      "global"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-3.1-pro-preview": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 12,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "Gemini 3.1 Pro Preview",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "locations": [
+      "global"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-3.1-pro-preview-customtools": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 12,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "Gemini 3.1 Pro Custom Tools Preview",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "locations": [
+      "global"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-3-flash-preview": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 3,
+    "input_cache_read_cost_per_mil_tokens": 0.05,
+    "displayName": "Gemini 3 Flash Preview",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "locations": [
+      "global"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-3-pro-image": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 12,
+    "displayName": "Gemini 3 Pro Image",
+    "locations": [
+      "global"
+    ],
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-3-pro-image-preview": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 12,
+    "displayName": "Gemini 3 Pro Image Preview",
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-3-pro-preview": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 12,
+    "input_cache_read_cost_per_mil_tokens": 0.3125,
+    "displayName": "Gemini 3 Pro Preview",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "locations": [
+      "global"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-computer-use-preview-10-2025": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "Gemini 2.5 Computer Use Preview (10-2025)",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-2.5-flash-lite-preview-09-2025": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "input_cache_read_cost_per_mil_tokens": 0.01,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": true,
+    "parent": "gemini-2.5-flash-lite",
+    "fallback_models": [
+      "publishers/google/models/gemini-2.5-flash-lite-preview-09-2025"
+    ],
+    "supported_regions": [
+      "global"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-2.5-flash-preview-09-2025": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 2.5,
+    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": false,
+    "parent": "gemini-2.5-flash",
+    "fallback_models": [
+      "publishers/google/models/gemini-2.5-flash-preview-09-2025"
+    ],
+    "supported_regions": [
+      "global"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-flash-lite-preview-09-2025": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": true,
+    "parent": "publishers/google/models/gemini-2.5-flash-lite",
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-flash-preview-09-2025": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "publishers/google/models/gemini-2.5-flash",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-2.5-flash-lite-preview-06-17": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": true,
+    "deprecated": true,
+    "deprecation_date": "2025-11-18",
+    "parent": "gemini-2.5-flash-lite",
+    "fallback_models": [
+      "publishers/google/models/gemini-2.5-flash-lite-preview-06-17"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-flash-lite-preview-06-17": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": true,
+    "deprecated": true,
+    "parent": "publishers/google/models/gemini-2.5-flash-lite",
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-2.5-pro-preview-06-05": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": false,
+    "deprecated": true,
+    "parent": "gemini-2.5-pro",
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-2.5-flash-preview-05-20": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 2.5,
+    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": false,
+    "deprecated": true,
+    "deprecation_date": "2025-11-18",
+    "parent": "gemini-2.5-flash",
+    "fallback_models": [
+      "publishers/google/models/gemini-2.5-flash-preview-05-20"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-flash-preview-05-20": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "deprecated": true,
+    "parent": "publishers/google/models/gemini-2.5-flash",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-2.5-pro-preview-05-06": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": false,
+    "deprecated": true,
+    "deprecation_date": "2025-12-02",
+    "parent": "gemini-2.5-pro",
+    "fallback_models": [
+      "publishers/google/models/gemini-2.5-pro-preview-05-06"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-pro-preview-05-06": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "deprecated": true,
+    "parent": "publishers/google/models/gemini-2.5-pro",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-2.5-flash-preview-04-17": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "input_cache_read_cost_per_mil_tokens": 0.0375,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": false,
+    "deprecated": true,
+    "parent": "gemini-2.5-flash",
+    "fallback_models": [
+      "publishers/google/models/gemini-2.5-flash-preview-04-17"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-flash-preview-04-17": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "deprecated": true,
+    "parent": "publishers/google/models/gemini-2.5-flash",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-2.5-pro-exp-03-25": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "reasoning": true,
+    "experimental": true,
+    "parent": "gemini-2.5-pro",
+    "fallback_models": [
+      "publishers/google/models/gemini-2.5-pro-exp-03-25"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-2.5-pro-preview-03-25": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": false,
+    "deprecated": true,
+    "deprecation_date": "2025-12-02",
+    "parent": "gemini-2.5-pro",
+    "fallback_models": [
+      "publishers/google/models/gemini-2.5-pro-preview-03-25"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-pro-exp-03-25": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 2.5 Pro Experimental",
+    "experimental": true,
+    "parent": "publishers/google/models/gemini-2.5-pro",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-pro-preview-03-25": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "deprecated": true,
+    "parent": "publishers/google/models/gemini-2.5-pro",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-flash": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 2.5,
+    "displayName": "Gemini 2.5 Flash",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-flash-image": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 2.5,
+    "displayName": "Gemini 2.5 Flash Image",
+    "locations": [
+      "global"
+    ],
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-flash-lite": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "displayName": "Gemini 2.5 Flash-Lite",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-pro": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "Gemini 2.5 Pro",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-2.0-pro-exp-02-05": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.3125,
+    "experimental": true,
+    "deprecated": true,
+    "parent": "gemini-2.5-pro",
+    "max_input_tokens": 2097152,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "vertex"
+    ]
+  },
   "publishers/google/models/gemini-2.0-flash-lite-preview-02-05": {
     "format": "google",
     "flavor": "chat",
@@ -6052,6 +6646,243 @@
     "output_cost_per_mil_tokens": 0.3,
     "displayName": "Gemini 2.0 Flash-Lite",
     "deprecated": true
+  },
+  "gemini-2.0-flash-thinking-exp-01-21": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": true,
+    "deprecated": true,
+    "deprecation_date": "2025-12-02",
+    "parent": "gemini-2.0-flash",
+    "fallback_models": [
+      "publishers/google/models/gemini-2.0-flash-thinking-exp-01-21"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.0-flash-thinking-exp-01-21": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 2.0 Flash Thinking Mode",
+    "experimental": true,
+    "deprecated": true,
+    "parent": "publishers/google/models/gemini-2.0-flash",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.0-flash-001": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "deprecation_date": "2026-03-31",
+    "parent": "publishers/google/models/gemini-2.0-flash",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.0-flash-lite-001": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.075,
+    "output_cost_per_mil_tokens": 0.3,
+    "deprecation_date": "2026-03-31",
+    "parent": "publishers/google/models/gemini-2.0-flash-lite",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-2.0-flash-exp": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "input_cache_read_cost_per_mil_tokens": 0.0375,
+    "experimental": true,
+    "parent": "gemini-2.0-flash",
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.0-flash": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "Gemini 2.0 Flash",
+    "deprecation_date": "2026-03-31",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.0-flash-lite": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.075,
+    "output_cost_per_mil_tokens": 0.3,
+    "displayName": "Gemini 2.0 Flash-Lite",
+    "deprecation_date": "2026-03-31",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-1.5-flash-002": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.075,
+    "output_cost_per_mil_tokens": 0.3,
+    "input_cache_read_cost_per_mil_tokens": 0.01875,
+    "input_cache_write_cost_per_mil_tokens": 1,
+    "deprecation_date": "2025-09-24",
+    "parent": "gemini-1.5-flash",
+    "fallback_models": [
+      "publishers/google/models/gemini-1.5-flash-002"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-1.5-pro-002": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 5,
+    "deprecation_date": "2025-09-24",
+    "parent": "gemini-1.5-pro",
+    "fallback_models": [
+      "publishers/google/models/gemini-1.5-pro-002"
+    ],
+    "max_input_tokens": 2097152,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-1.5-flash-002": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "parent": "publishers/google/models/gemini-1.5-flash",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-1.5-pro-002": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "parent": "publishers/google/models/gemini-1.5-pro",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-1.5-flash-001": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.075,
+    "output_cost_per_mil_tokens": 0.3,
+    "input_cache_read_cost_per_mil_tokens": 0.01875,
+    "input_cache_write_cost_per_mil_tokens": 1,
+    "deprecation_date": "2025-05-24",
+    "parent": "gemini-1.5-flash",
+    "fallback_models": [
+      "publishers/google/models/gemini-1.5-flash-001"
+    ],
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-1.5-pro-001": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 5,
+    "deprecation_date": "2025-05-24",
+    "parent": "gemini-1.5-pro",
+    "fallback_models": [
+      "publishers/google/models/gemini-1.5-pro-001"
+    ],
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-1.5-flash-001": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "parent": "publishers/google/models/gemini-1.5-flash",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-1.5-pro-001": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "parent": "publishers/google/models/gemini-1.5-pro",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-1.5-pro": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 5,
+    "displayName": "Gemini 1.5 Pro",
+    "deprecation_date": "2025-09-29",
+    "fallback_models": [
+      "publishers/google/models/gemini-1.5-pro"
+    ],
+    "max_input_tokens": 2097152,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-1.5-flash": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 1.5 Flash",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-1.5-pro": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 1.5 Pro",
+    "available_providers": [
+      "vertex"
+    ]
   },
   "publishers/google/models/gemini-1.0-pro-002": {
     "format": "google",
@@ -6069,11 +6900,120 @@
     "multimodal": true,
     "parent": "publishers/google/models/gemini-1.0-pro-vision"
   },
+  "gemini-1.0-pro": {
+    "format": "google",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 1.5,
+    "displayName": "Gemini 1.0 Pro",
+    "deprecated": true,
+    "fallback_models": [
+      "publishers/google/models/gemini-1.0-pro"
+    ],
+    "max_input_tokens": 32760,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-1.0-pro": {
+    "format": "google",
+    "flavor": "chat",
+    "displayName": "Gemini 1.0 Pro",
+    "available_providers": [
+      "vertex"
+    ]
+  },
   "publishers/google/models/gemini-1.0-pro-vision": {
     "format": "google",
     "flavor": "chat",
     "multimodal": true,
     "displayName": "Gemini 1.0 Pro Vision"
+  },
+  "gemini-pro": {
+    "format": "google",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 1.5,
+    "displayName": "Gemini Pro",
+    "deprecated": true,
+    "max_input_tokens": 32760,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-fable-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 10,
+    "output_cost_per_mil_tokens": 50,
+    "input_cache_read_cost_per_mil_tokens": 1,
+    "input_cache_write_cost_per_mil_tokens": 12.5,
+    "displayName": "Claude Fable 5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-opus-4-8": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "displayName": "Claude Opus 4.8",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-opus-4-7": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 10,
+    "displayName": "Claude Opus 4.7",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-opus-4-6": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 10,
+    "displayName": "Claude Opus 4.6",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "vertex"
+    ]
   },
   "publishers/anthropic/models/claude-opus-4-5@20251101": {
     "format": "anthropic",
@@ -6135,6 +7075,61 @@
     "reasoning_budget": true,
     "parent": "publishers/anthropic/models/claude-opus-4"
   },
+  "publishers/anthropic/models/claude-sonnet-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "displayName": "Claude Sonnet 5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-sonnet-4-6": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "displayName": "Claude Sonnet 4.6",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-sonnet-4-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "displayName": "Claude Sonnet 4.5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "available_providers": [
+      "vertex"
+    ]
+  },
   "publishers/anthropic/models/claude-sonnet-4-5@20250929": {
     "format": "anthropic",
     "flavor": "chat",
@@ -6179,6 +7174,25 @@
     "experimental": true,
     "parent": "publishers/anthropic/models/claude-sonnet-4"
   },
+  "publishers/anthropic/models/claude-haiku-4-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 5,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "input_cache_write_cost_per_mil_tokens": 1.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 1.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 2,
+    "displayName": "Claude Haiku 4.5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
   "publishers/anthropic/models/claude-haiku-4-5@20251001": {
     "format": "anthropic",
     "flavor": "chat",
@@ -6194,6 +7208,43 @@
     "parent": "publishers/anthropic/models/claude-haiku-4-5",
     "max_input_tokens": 200000,
     "max_output_tokens": 64000
+  },
+  "publishers/mistralai/models/mistral-large-2411": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 6,
+    "displayName": "Mistral Large (24.11)",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/mistralai/models/codestral-2501": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 0.9,
+    "displayName": "Codestral (25.01)",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-embedding-2": {
+    "format": "google",
+    "flavor": "embedding",
+    "multimodal": true,
+    "displayName": "Gemini embedding 2",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-embedding-001": {
+    "format": "google",
+    "flavor": "embedding",
+    "displayName": "Gemini embedding 001",
+    "available_providers": [
+      "vertex"
+    ]
   },
   "publishers/anthropic/models/claude-3-7-sonnet": {
     "format": "anthropic",
@@ -7208,1057 +8259,6 @@
     "max_output_tokens": 32000,
     "available_providers": [
       "anthropic"
-    ]
-  },
-  "publishers/google/models/gemini-3.5-flash": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.5,
-    "output_cost_per_mil_tokens": 9,
-    "input_cache_read_cost_per_mil_tokens": 0.15,
-    "displayName": "Gemini 3.5 Flash",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-3.1-flash-image": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 3,
-    "displayName": "Gemini 3.1 Flash Image",
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-3.1-flash-image-preview": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 3,
-    "displayName": "Gemini 3.1 Flash Image Preview",
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-3.1-flash-lite": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 1.5,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "displayName": "Gemini 3.1 Flash-Lite",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-3.1-flash-lite-image": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 1.5,
-    "displayName": "Gemini 3.1 Flash-Lite Image",
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 65536,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-3.1-flash-lite-preview": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 1.5,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "displayName": "Gemini 3.1 Flash-Lite (Preview)",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-3.1-pro-preview": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 12,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Gemini 3.1 Pro Preview",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-3.1-pro-preview-customtools": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 12,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Gemini 3.1 Pro Custom Tools Preview",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-3-flash-preview": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 3,
-    "input_cache_read_cost_per_mil_tokens": 0.05,
-    "displayName": "Gemini 3 Flash Preview",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-3-pro-image": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 12,
-    "displayName": "Gemini 3 Pro Image",
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 65536,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-3-pro-image-preview": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 12,
-    "displayName": "Gemini 3 Pro Image Preview",
-    "max_input_tokens": 65536,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-3-pro-preview": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 12,
-    "input_cache_read_cost_per_mil_tokens": 0.3125,
-    "displayName": "Gemini 3 Pro Preview",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-computer-use-preview-10-2025": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "Gemini 2.5 Computer Use Preview (10-2025)",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-2.5-flash-lite-preview-09-2025": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "input_cache_read_cost_per_mil_tokens": 0.01,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": true,
-    "parent": "gemini-2.5-flash-lite",
-    "fallback_models": [
-      "publishers/google/models/gemini-2.5-flash-lite-preview-09-2025"
-    ],
-    "supported_regions": [
-      "global"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-2.5-flash-preview-09-2025": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 2.5,
-    "input_cache_read_cost_per_mil_tokens": 0.075,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": false,
-    "parent": "gemini-2.5-flash",
-    "fallback_models": [
-      "publishers/google/models/gemini-2.5-flash-preview-09-2025"
-    ],
-    "supported_regions": [
-      "global"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-flash-lite-preview-09-2025": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": true,
-    "parent": "publishers/google/models/gemini-2.5-flash-lite",
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-flash-preview-09-2025": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "publishers/google/models/gemini-2.5-flash",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-2.5-flash-lite-preview-06-17": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": true,
-    "deprecated": true,
-    "deprecation_date": "2025-11-18",
-    "parent": "gemini-2.5-flash-lite",
-    "fallback_models": [
-      "publishers/google/models/gemini-2.5-flash-lite-preview-06-17"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-flash-lite-preview-06-17": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": true,
-    "deprecated": true,
-    "parent": "publishers/google/models/gemini-2.5-flash-lite",
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-2.5-pro-preview-06-05": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": false,
-    "deprecated": true,
-    "parent": "gemini-2.5-pro",
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-2.5-flash-preview-05-20": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 2.5,
-    "input_cache_read_cost_per_mil_tokens": 0.075,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": false,
-    "deprecated": true,
-    "deprecation_date": "2025-11-18",
-    "parent": "gemini-2.5-flash",
-    "fallback_models": [
-      "publishers/google/models/gemini-2.5-flash-preview-05-20"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-flash-preview-05-20": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "deprecated": true,
-    "parent": "publishers/google/models/gemini-2.5-flash",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-2.5-pro-preview-05-06": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": false,
-    "deprecated": true,
-    "deprecation_date": "2025-12-02",
-    "parent": "gemini-2.5-pro",
-    "fallback_models": [
-      "publishers/google/models/gemini-2.5-pro-preview-05-06"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-pro-preview-05-06": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "deprecated": true,
-    "parent": "publishers/google/models/gemini-2.5-pro",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-2.5-flash-preview-04-17": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "input_cache_read_cost_per_mil_tokens": 0.0375,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": false,
-    "deprecated": true,
-    "parent": "gemini-2.5-flash",
-    "fallback_models": [
-      "publishers/google/models/gemini-2.5-flash-preview-04-17"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-flash-preview-04-17": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "deprecated": true,
-    "parent": "publishers/google/models/gemini-2.5-flash",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-2.5-pro-exp-03-25": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "reasoning": true,
-    "experimental": true,
-    "parent": "gemini-2.5-pro",
-    "fallback_models": [
-      "publishers/google/models/gemini-2.5-pro-exp-03-25"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-2.5-pro-preview-03-25": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": false,
-    "deprecated": true,
-    "deprecation_date": "2025-12-02",
-    "parent": "gemini-2.5-pro",
-    "fallback_models": [
-      "publishers/google/models/gemini-2.5-pro-preview-03-25"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-pro-exp-03-25": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 2.5 Pro Experimental",
-    "experimental": true,
-    "parent": "publishers/google/models/gemini-2.5-pro",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-pro-preview-03-25": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "deprecated": true,
-    "parent": "publishers/google/models/gemini-2.5-pro",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-flash": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 2.5,
-    "displayName": "Gemini 2.5 Flash",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-flash-image": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 2.5,
-    "displayName": "Gemini 2.5 Flash Image",
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-flash-lite": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "displayName": "Gemini 2.5 Flash-Lite",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-pro": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "Gemini 2.5 Pro",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-2.0-pro-exp-02-05": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.3125,
-    "experimental": true,
-    "deprecated": true,
-    "parent": "gemini-2.5-pro",
-    "max_input_tokens": 2097152,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-2.0-flash-thinking-exp-01-21": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": true,
-    "deprecated": true,
-    "deprecation_date": "2025-12-02",
-    "parent": "gemini-2.0-flash",
-    "fallback_models": [
-      "publishers/google/models/gemini-2.0-flash-thinking-exp-01-21"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.0-flash-thinking-exp-01-21": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 2.0 Flash Thinking Mode",
-    "experimental": true,
-    "deprecated": true,
-    "parent": "publishers/google/models/gemini-2.0-flash",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.0-flash-001": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "deprecation_date": "2026-03-31",
-    "parent": "publishers/google/models/gemini-2.0-flash",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.0-flash-lite-001": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.075,
-    "output_cost_per_mil_tokens": 0.3,
-    "deprecation_date": "2026-03-31",
-    "parent": "publishers/google/models/gemini-2.0-flash-lite",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-2.0-flash-exp": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "input_cache_read_cost_per_mil_tokens": 0.0375,
-    "experimental": true,
-    "parent": "gemini-2.0-flash",
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.0-flash": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "Gemini 2.0 Flash",
-    "deprecation_date": "2026-03-31",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.0-flash-lite": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.075,
-    "output_cost_per_mil_tokens": 0.3,
-    "displayName": "Gemini 2.0 Flash-Lite",
-    "deprecation_date": "2026-03-31",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-1.5-flash-002": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.075,
-    "output_cost_per_mil_tokens": 0.3,
-    "input_cache_read_cost_per_mil_tokens": 0.01875,
-    "input_cache_write_cost_per_mil_tokens": 1,
-    "deprecation_date": "2025-09-24",
-    "parent": "gemini-1.5-flash",
-    "fallback_models": [
-      "publishers/google/models/gemini-1.5-flash-002"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-1.5-pro-002": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 5,
-    "deprecation_date": "2025-09-24",
-    "parent": "gemini-1.5-pro",
-    "fallback_models": [
-      "publishers/google/models/gemini-1.5-pro-002"
-    ],
-    "max_input_tokens": 2097152,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-1.5-flash-002": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "parent": "publishers/google/models/gemini-1.5-flash",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-1.5-pro-002": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "parent": "publishers/google/models/gemini-1.5-pro",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-1.5-flash-001": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.075,
-    "output_cost_per_mil_tokens": 0.3,
-    "input_cache_read_cost_per_mil_tokens": 0.01875,
-    "input_cache_write_cost_per_mil_tokens": 1,
-    "deprecation_date": "2025-05-24",
-    "parent": "gemini-1.5-flash",
-    "fallback_models": [
-      "publishers/google/models/gemini-1.5-flash-001"
-    ],
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-1.5-pro-001": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 5,
-    "deprecation_date": "2025-05-24",
-    "parent": "gemini-1.5-pro",
-    "fallback_models": [
-      "publishers/google/models/gemini-1.5-pro-001"
-    ],
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-1.5-flash-001": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "parent": "publishers/google/models/gemini-1.5-flash",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-1.5-pro-001": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "parent": "publishers/google/models/gemini-1.5-pro",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-1.5-pro": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 5,
-    "displayName": "Gemini 1.5 Pro",
-    "deprecation_date": "2025-09-29",
-    "fallback_models": [
-      "publishers/google/models/gemini-1.5-pro"
-    ],
-    "max_input_tokens": 2097152,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-1.5-flash": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 1.5 Flash",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-1.5-pro": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 1.5 Pro",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-1.0-pro": {
-    "format": "google",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 1.5,
-    "displayName": "Gemini 1.0 Pro",
-    "deprecated": true,
-    "fallback_models": [
-      "publishers/google/models/gemini-1.0-pro"
-    ],
-    "max_input_tokens": 32760,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-1.0-pro": {
-    "format": "google",
-    "flavor": "chat",
-    "displayName": "Gemini 1.0 Pro",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-pro": {
-    "format": "google",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 1.5,
-    "displayName": "Gemini Pro",
-    "deprecated": true,
-    "max_input_tokens": 32760,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-fable-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 10,
-    "output_cost_per_mil_tokens": 50,
-    "input_cache_read_cost_per_mil_tokens": 1,
-    "input_cache_write_cost_per_mil_tokens": 12.5,
-    "displayName": "Claude Fable 5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-opus-4-8": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "displayName": "Claude Opus 4.8",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-opus-4-7": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 10,
-    "displayName": "Claude Opus 4.7",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-opus-4-6": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 10,
-    "displayName": "Claude Opus 4.6",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-sonnet-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "displayName": "Claude Sonnet 5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-sonnet-4-6": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "displayName": "Claude Sonnet 4.6",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-sonnet-4-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "displayName": "Claude Sonnet 4.5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-haiku-4-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 5,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "input_cache_write_cost_per_mil_tokens": 1.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 1.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 2,
-    "displayName": "Claude Haiku 4.5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/mistralai/models/mistral-large-2411": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 6,
-    "displayName": "Mistral Large (24.11)",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/mistralai/models/codestral-2501": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 0.9,
-    "displayName": "Codestral (25.01)",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-embedding-2": {
-    "format": "google",
-    "flavor": "embedding",
-    "multimodal": true,
-    "displayName": "Gemini embedding 2",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-embedding-001": {
-    "format": "google",
-    "flavor": "embedding",
-    "displayName": "Gemini embedding 001",
-    "available_providers": [
-      "vertex"
     ]
   },
   "anthropic.claude-fable-5": {

--- a/packages/proxy/schema/model_list.json
+++ b/packages/proxy/schema/model_list.json
@@ -68,6 +68,41 @@
       "azure"
     ]
   },
+  "gpt-5.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 30,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "GPT-5.5",
+    "reasoning": true,
+    "fallback_models": [
+      "openai.gpt-5.5"
+    ],
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.5-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 30,
+    "output_cost_per_mil_tokens": 180,
+    "input_cache_read_cost_per_mil_tokens": 3,
+    "displayName": "GPT-5.5 Pro",
+    "reasoning": true,
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
   "gpt-5.5-2026-04-23": {
     "format": "openai",
     "flavor": "chat",
@@ -102,17 +137,17 @@
       "azure"
     ]
   },
-  "gpt-5.5": {
+  "gpt-5.4": {
     "format": "openai",
     "flavor": "chat",
     "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 30,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "displayName": "GPT-5.5",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.25,
+    "displayName": "GPT-5.4",
     "reasoning": true,
     "fallback_models": [
-      "openai.gpt-5.5"
+      "openai.gpt-5.4"
     ],
     "max_input_tokens": 1050000,
     "max_output_tokens": 128000,
@@ -121,14 +156,46 @@
       "azure"
     ]
   },
-  "gpt-5.5-pro": {
+  "gpt-5.4-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.75,
+    "output_cost_per_mil_tokens": 4.5,
+    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "displayName": "GPT-5.4 mini",
+    "reasoning": true,
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.4-nano": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 1.25,
+    "input_cache_read_cost_per_mil_tokens": 0.02,
+    "displayName": "GPT-5.4 nano",
+    "reasoning": true,
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.4-pro": {
     "format": "openai",
     "flavor": "chat",
     "multimodal": true,
     "input_cost_per_mil_tokens": 30,
     "output_cost_per_mil_tokens": 180,
     "input_cache_read_cost_per_mil_tokens": 3,
-    "displayName": "GPT-5.5 Pro",
+    "displayName": "GPT-5.4 Pro",
     "reasoning": true,
     "max_input_tokens": 1050000,
     "max_output_tokens": 128000,
@@ -205,73 +272,6 @@
       "azure"
     ]
   },
-  "gpt-5.4": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.25,
-    "displayName": "GPT-5.4",
-    "reasoning": true,
-    "fallback_models": [
-      "openai.gpt-5.4"
-    ],
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.4-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.75,
-    "output_cost_per_mil_tokens": 4.5,
-    "input_cache_read_cost_per_mil_tokens": 0.075,
-    "displayName": "GPT-5.4 mini",
-    "reasoning": true,
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.4-nano": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 1.25,
-    "input_cache_read_cost_per_mil_tokens": 0.02,
-    "displayName": "GPT-5.4 nano",
-    "reasoning": true,
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.4-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 30,
-    "output_cost_per_mil_tokens": 180,
-    "input_cache_read_cost_per_mil_tokens": 3,
-    "displayName": "GPT-5.4 Pro",
-    "reasoning": true,
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
   "gpt-5.3-chat-latest": {
     "format": "openai",
     "flavor": "chat",
@@ -298,39 +298,6 @@
     "input_cache_read_cost_per_mil_tokens": 0.175,
     "displayName": "GPT-5.3 Codex",
     "reasoning": true,
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.2-2025-12-11": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.75,
-    "output_cost_per_mil_tokens": 14,
-    "input_cache_read_cost_per_mil_tokens": 0.175,
-    "displayName": "GPT-5.2 (2025-12-11)",
-    "reasoning": true,
-    "parent": "gpt-5.2",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.2-pro-2025-12-11": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 21,
-    "output_cost_per_mil_tokens": 168,
-    "displayName": "GPT-5.2 Pro (2025-12-11)",
-    "reasoning": true,
-    "parent": "gpt-5.2-pro",
     "max_input_tokens": 272000,
     "max_output_tokens": 128000,
     "available_providers": [
@@ -405,16 +372,32 @@
       "azure"
     ]
   },
-  "gpt-5.1-2025-11-13": {
+  "gpt-5.2-2025-12-11": {
     "format": "openai",
     "flavor": "chat",
     "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5.1 (2025-11-13)",
+    "input_cost_per_mil_tokens": 1.75,
+    "output_cost_per_mil_tokens": 14,
+    "input_cache_read_cost_per_mil_tokens": 0.175,
+    "displayName": "GPT-5.2 (2025-12-11)",
     "reasoning": true,
-    "parent": "gpt-5.1",
+    "parent": "gpt-5.2",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.2-pro-2025-12-11": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 21,
+    "output_cost_per_mil_tokens": 168,
+    "displayName": "GPT-5.2 Pro (2025-12-11)",
+    "reasoning": true,
+    "parent": "gpt-5.2-pro",
     "max_input_tokens": 272000,
     "max_output_tokens": 128000,
     "available_providers": [
@@ -509,84 +492,16 @@
       "azure"
     ]
   },
-  "gpt-5-search-api-2025-10-14": {
+  "gpt-5.1-2025-11-13": {
     "format": "openai",
     "flavor": "chat",
     "multimodal": true,
     "input_cost_per_mil_tokens": 1.25,
     "output_cost_per_mil_tokens": 10,
     "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5 Search API (2025-10-14)",
-    "parent": "gpt-5-search-api",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-pro-2025-10-06": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 15,
-    "output_cost_per_mil_tokens": 120,
-    "displayName": "GPT-5 Pro (2025-10-06)",
+    "displayName": "GPT-5.1 (2025-11-13)",
     "reasoning": true,
-    "parent": "gpt-5-pro",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 272000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-2025-08-07": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5 (2025-08-07)",
-    "reasoning": true,
-    "deprecation_date": "2026-12-11",
-    "parent": "gpt-5",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-mini-2025-08-07": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 2,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "displayName": "GPT-5 mini (2025-08-07)",
-    "reasoning": true,
-    "deprecation_date": "2026-12-11",
-    "parent": "gpt-5-mini",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-nano-2025-08-07": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.05,
-    "output_cost_per_mil_tokens": 0.4,
-    "input_cache_read_cost_per_mil_tokens": 0.005,
-    "displayName": "GPT-5 nano (2025-08-07)",
-    "reasoning": true,
-    "parent": "gpt-5-nano",
+    "parent": "gpt-5.1",
     "max_input_tokens": 272000,
     "max_output_tokens": 128000,
     "available_providers": [
@@ -706,49 +621,86 @@
       "azure"
     ]
   },
-  "gpt-4.1-2025-04-14": {
+  "gpt-5-search-api-2025-10-14": {
     "format": "openai",
     "flavor": "chat",
     "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 8,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "displayName": "GPT-4.1 (2025-04-14)",
-    "parent": "gpt-4.1",
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "GPT-5 Search API (2025-10-14)",
+    "parent": "gpt-5-search-api",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
     "available_providers": [
       "openai",
       "azure"
     ]
   },
-  "gpt-4.1-mini-2025-04-14": {
+  "gpt-5-pro-2025-10-06": {
     "format": "openai",
     "flavor": "chat",
     "multimodal": true,
-    "input_cost_per_mil_tokens": 0.4,
-    "output_cost_per_mil_tokens": 1.6,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "displayName": "GPT-4.1 mini (2025-04-14)",
-    "parent": "gpt-4.1-mini",
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
+    "input_cost_per_mil_tokens": 15,
+    "output_cost_per_mil_tokens": 120,
+    "displayName": "GPT-5 Pro (2025-10-06)",
+    "reasoning": true,
+    "parent": "gpt-5-pro",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 272000,
     "available_providers": [
       "openai",
       "azure"
     ]
   },
-  "gpt-4.1-nano-2025-04-14": {
+  "gpt-5-2025-08-07": {
     "format": "openai",
     "flavor": "chat",
     "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "GPT-5 (2025-08-07)",
+    "reasoning": true,
+    "deprecation_date": "2026-12-11",
+    "parent": "gpt-5",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-mini-2025-08-07": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 2,
     "input_cache_read_cost_per_mil_tokens": 0.025,
-    "displayName": "GPT-4.1 nano (2025-04-14)",
-    "parent": "gpt-4.1-nano",
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
+    "displayName": "GPT-5 mini (2025-08-07)",
+    "reasoning": true,
+    "deprecation_date": "2026-12-11",
+    "parent": "gpt-5-mini",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-nano-2025-08-07": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.05,
+    "output_cost_per_mil_tokens": 0.4,
+    "input_cache_read_cost_per_mil_tokens": 0.005,
+    "displayName": "GPT-5 nano (2025-08-07)",
+    "reasoning": true,
+    "parent": "gpt-5-nano",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
     "available_providers": [
       "openai",
       "azure"
@@ -799,253 +751,49 @@
       "azure"
     ]
   },
-  "gpt-4o-audio-preview-2024-12-17": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "GPT-4o Audio Preview (2024-12-17)",
-    "parent": "gpt-4o-audio-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-audio-preview-2024-12-17": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "GPT-4o mini Audio Preview (2024-12-17)",
-    "parent": "gpt-4o-mini-audio-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-realtime-preview-2024-12-17": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "displayName": "GPT-4o mini Realtime Preview (2024-12-17)",
-    "parent": "gpt-4o-mini-realtime-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-realtime-preview-2024-12-17": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 20,
-    "input_cache_read_cost_per_mil_tokens": 2.5,
-    "displayName": "GPT-4o Realtime Preview (2024-12-17)",
-    "parent": "gpt-4o-realtime-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-transcribe-2025-12-15": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 5,
-    "displayName": "GPT-4o mini Transcribe (2025-12-15)",
-    "parent": "gpt-4o-mini-transcribe",
-    "max_input_tokens": 16000,
-    "max_output_tokens": 2000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-tts-2025-12-15": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "GPT-4o mini TTS (2025-12-15)",
-    "parent": "gpt-4o-mini-tts",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-2024-11-20": {
+  "gpt-4.1-2025-04-14": {
     "format": "openai",
     "flavor": "chat",
     "multimodal": true,
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "displayName": "GPT-4o (2024-11-20)",
-    "parent": "gpt-4o",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 8,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "GPT-4.1 (2025-04-14)",
+    "parent": "gpt-4.1",
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
     "available_providers": [
       "openai",
       "azure"
     ]
   },
-  "gpt-4o-2024-08-06": {
+  "gpt-4.1-mini-2025-04-14": {
     "format": "openai",
     "flavor": "chat",
     "multimodal": true,
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "displayName": "GPT-4o (2024-08-06)",
-    "parent": "gpt-4o",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
+    "input_cost_per_mil_tokens": 0.4,
+    "output_cost_per_mil_tokens": 1.6,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "displayName": "GPT-4.1 mini (2025-04-14)",
+    "parent": "gpt-4.1-mini",
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
     "available_providers": [
       "openai",
       "azure"
     ]
   },
-  "gpt-4o-mini-2024-07-18": {
+  "gpt-4.1-nano-2025-04-14": {
     "format": "openai",
     "flavor": "chat",
     "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "input_cache_read_cost_per_mil_tokens": 0.075,
-    "displayName": "GPT-4o mini (2024-07-18)",
-    "parent": "gpt-4o-mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-audio-preview-2025-06-03": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "GPT-4o Audio Preview (2025-06-03)",
-    "parent": "gpt-4o-audio-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-realtime-preview-2025-06-03": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 20,
-    "input_cache_read_cost_per_mil_tokens": 2.5,
-    "displayName": "GPT-4o Realtime Preview (2025-06-03)",
-    "parent": "gpt-4o-realtime-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-2024-05-13": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 15,
-    "displayName": "GPT-4o (2024-05-13)",
-    "deprecation_date": "2026-10-23",
-    "parent": "gpt-4o",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4-turbo-2024-04-09": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 10,
-    "output_cost_per_mil_tokens": 30,
-    "displayName": "GPT-4 Turbo (2024-04-09)",
-    "parent": "gpt-4-turbo",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-transcribe-2025-03-20": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 5,
-    "displayName": "GPT-4o mini Transcribe (2025-03-20)",
-    "parent": "gpt-4o-mini-transcribe",
-    "max_input_tokens": 16000,
-    "max_output_tokens": 2000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-tts-2025-03-20": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "GPT-4o mini TTS (2025-03-20)",
-    "parent": "gpt-4o-mini-tts",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-search-preview-2025-03-11": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "input_cache_read_cost_per_mil_tokens": 0.075,
-    "displayName": "GPT-4o mini Search Preview (2025-03-11)",
-    "experimental": true,
-    "parent": "gpt-4o-mini-search-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-search-preview-2025-03-11": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "displayName": "GPT-4o Search Preview (2025-03-11)",
-    "experimental": true,
-    "parent": "gpt-4o-search-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "displayName": "GPT-4.1 nano (2025-04-14)",
+    "parent": "gpt-4.1-nano",
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
     "available_providers": [
       "openai",
       "azure"
@@ -1242,6 +990,258 @@
       "azure"
     ]
   },
+  "gpt-4o-mini-transcribe-2025-12-15": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 5,
+    "displayName": "GPT-4o mini Transcribe (2025-12-15)",
+    "parent": "gpt-4o-mini-transcribe",
+    "max_input_tokens": 16000,
+    "max_output_tokens": 2000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-tts-2025-12-15": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "GPT-4o mini TTS (2025-12-15)",
+    "parent": "gpt-4o-mini-tts",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-audio-preview-2025-06-03": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "GPT-4o Audio Preview (2025-06-03)",
+    "parent": "gpt-4o-audio-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-realtime-preview-2025-06-03": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 20,
+    "input_cache_read_cost_per_mil_tokens": 2.5,
+    "displayName": "GPT-4o Realtime Preview (2025-06-03)",
+    "parent": "gpt-4o-realtime-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-transcribe-2025-03-20": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 5,
+    "displayName": "GPT-4o mini Transcribe (2025-03-20)",
+    "parent": "gpt-4o-mini-transcribe",
+    "max_input_tokens": 16000,
+    "max_output_tokens": 2000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-tts-2025-03-20": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "GPT-4o mini TTS (2025-03-20)",
+    "parent": "gpt-4o-mini-tts",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-search-preview-2025-03-11": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "displayName": "GPT-4o mini Search Preview (2025-03-11)",
+    "experimental": true,
+    "parent": "gpt-4o-mini-search-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-search-preview-2025-03-11": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "displayName": "GPT-4o Search Preview (2025-03-11)",
+    "experimental": true,
+    "parent": "gpt-4o-search-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-audio-preview-2024-12-17": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "GPT-4o Audio Preview (2024-12-17)",
+    "parent": "gpt-4o-audio-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-audio-preview-2024-12-17": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "GPT-4o mini Audio Preview (2024-12-17)",
+    "parent": "gpt-4o-mini-audio-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-realtime-preview-2024-12-17": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "displayName": "GPT-4o mini Realtime Preview (2024-12-17)",
+    "parent": "gpt-4o-mini-realtime-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-realtime-preview-2024-12-17": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 20,
+    "input_cache_read_cost_per_mil_tokens": 2.5,
+    "displayName": "GPT-4o Realtime Preview (2024-12-17)",
+    "parent": "gpt-4o-realtime-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-2024-11-20": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "displayName": "GPT-4o (2024-11-20)",
+    "parent": "gpt-4o",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-2024-08-06": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "displayName": "GPT-4o (2024-08-06)",
+    "parent": "gpt-4o",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-2024-07-18": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "displayName": "GPT-4o mini (2024-07-18)",
+    "parent": "gpt-4o-mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-2024-05-13": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 15,
+    "displayName": "GPT-4o (2024-05-13)",
+    "deprecation_date": "2026-10-23",
+    "parent": "gpt-4o",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4-turbo-2024-04-09": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 10,
+    "output_cost_per_mil_tokens": 30,
+    "displayName": "GPT-4 Turbo (2024-04-09)",
+    "parent": "gpt-4-turbo",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
   "gpt-4-0613": {
     "format": "openai",
     "flavor": "chat",
@@ -1341,111 +1341,35 @@
       "azure"
     ]
   },
-  "accounts/fireworks/models/gpt-oss-120b": {
+  "o4-mini": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "input_cache_read_cost_per_mil_tokens": 0.015,
-    "displayName": "GPT-OSS (120B)",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.1,
+    "output_cost_per_mil_tokens": 4.4,
+    "input_cache_read_cost_per_mil_tokens": 0.275,
+    "displayName": "o4-mini",
     "reasoning": true,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
     "available_providers": [
-      "fireworks"
+      "openai",
+      "azure"
     ]
   },
-  "accounts/fireworks/models/gpt-oss-safeguard-120b": {
+  "o4-mini-deep-research": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 8,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "o4-mini Deep Research",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
     "available_providers": [
-      "fireworks"
-    ]
-  },
-  "gpt-oss-120b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.35,
-    "output_cost_per_mil_tokens": 0.75,
-    "displayName": "OpenAI GPT-OSS (120B)",
-    "reasoning": true,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 40960,
-    "available_providers": [
-      "cerebras"
-    ]
-  },
-  "openai/gpt-oss-120b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.5,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "displayName": "OpenAI GPT-OSS (120B)",
-    "reasoning": true,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "groq",
-      "together",
-      "baseten"
-    ]
-  },
-  "accounts/fireworks/models/gpt-oss-20b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.07,
-    "output_cost_per_mil_tokens": 0.3,
-    "input_cache_read_cost_per_mil_tokens": 0.035,
-    "displayName": "GPT-OSS (20B)",
-    "reasoning": true,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/gpt-oss-safeguard-20b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "openai/gpt-oss-20b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.075,
-    "output_cost_per_mil_tokens": 0.3,
-    "input_cache_read_cost_per_mil_tokens": 0.0375,
-    "displayName": "OpenAI GPT-OSS (20B)",
-    "reasoning": true,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "groq",
-      "together"
-    ]
-  },
-  "openai/gpt-oss-safeguard-20b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.075,
-    "output_cost_per_mil_tokens": 0.3,
-    "displayName": "GPT-OSS Safeguard (20B)",
-    "experimental": true,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "groq"
+      "openai",
+      "azure"
     ]
   },
   "o4-mini-deep-research-2025-06-26": {
@@ -1483,14 +1407,14 @@
       "azure"
     ]
   },
-  "o4-mini": {
+  "o3": {
     "format": "openai",
     "flavor": "chat",
     "multimodal": true,
-    "input_cost_per_mil_tokens": 1.1,
-    "output_cost_per_mil_tokens": 4.4,
-    "input_cache_read_cost_per_mil_tokens": 0.275,
-    "displayName": "o4-mini",
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 8,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "o3",
     "reasoning": true,
     "max_input_tokens": 200000,
     "max_output_tokens": 100000,
@@ -1499,14 +1423,45 @@
       "azure"
     ]
   },
-  "o4-mini-deep-research": {
+  "o3-deep-research": {
     "format": "openai",
     "flavor": "chat",
     "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 8,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "displayName": "o4-mini Deep Research",
+    "input_cost_per_mil_tokens": 10,
+    "output_cost_per_mil_tokens": 40,
+    "input_cache_read_cost_per_mil_tokens": 2.5,
+    "displayName": "o3 Deep Research",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o3-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.1,
+    "output_cost_per_mil_tokens": 4.4,
+    "input_cache_read_cost_per_mil_tokens": 0.55,
+    "displayName": "o3 mini",
+    "reasoning": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o3-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 20,
+    "output_cost_per_mil_tokens": 80,
+    "displayName": "o3 Pro",
+    "reasoning": true,
     "max_input_tokens": 200000,
     "max_output_tokens": 100000,
     "available_providers": [
@@ -1582,102 +1537,6 @@
       "azure"
     ]
   },
-  "o3": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 8,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "displayName": "o3",
-    "reasoning": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o3-deep-research": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 10,
-    "output_cost_per_mil_tokens": 40,
-    "input_cache_read_cost_per_mil_tokens": 2.5,
-    "displayName": "o3 Deep Research",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o3-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.1,
-    "output_cost_per_mil_tokens": 4.4,
-    "input_cache_read_cost_per_mil_tokens": 0.55,
-    "displayName": "o3 mini",
-    "reasoning": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o3-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 20,
-    "output_cost_per_mil_tokens": 80,
-    "displayName": "o3 Pro",
-    "reasoning": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o1-2024-12-17": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 15,
-    "output_cost_per_mil_tokens": 60,
-    "input_cache_read_cost_per_mil_tokens": 7.5,
-    "displayName": "o1 (2024-12-17)",
-    "reasoning": true,
-    "deprecation_date": "2026-10-23",
-    "parent": "o1",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o1-pro-2025-03-19": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 150,
-    "output_cost_per_mil_tokens": 600,
-    "displayName": "o1 Pro (2025-03-19)",
-    "reasoning": true,
-    "parent": "o1-pro",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
   "o1": {
     "format": "openai",
     "flavor": "chat",
@@ -1709,1031 +1568,1183 @@
       "azure"
     ]
   },
-  "text-davinci-003": {
+  "o1-pro-2025-03-19": {
     "format": "openai",
-    "flavor": "completion",
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 2,
-    "displayName": "Text Davinci 003",
-    "deprecated": true
-  },
-  "claude-sonnet-4-6": {
-    "format": "anthropic",
     "flavor": "chat",
     "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "displayName": "Claude Sonnet 4.6",
+    "input_cost_per_mil_tokens": 150,
+    "output_cost_per_mil_tokens": 600,
+    "displayName": "o1 Pro (2025-03-19)",
     "reasoning": true,
-    "reasoning_budget": true,
-    "fallback_models": [
-      "anthropic.claude-sonnet-4-6",
-      "global.anthropic.claude-sonnet-4-6",
-      "publishers/anthropic/models/claude-sonnet-4-6",
-      "us.anthropic.claude-sonnet-4-6"
-    ],
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "anthropic"
-    ]
-  },
-  "claude-sonnet-4-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "displayName": "Claude Sonnet 4.5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "fallback_models": [
-      "publishers/anthropic/models/claude-sonnet-4-5"
-    ],
+    "parent": "o1-pro",
     "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
+    "max_output_tokens": 100000,
     "available_providers": [
-      "anthropic"
+      "openai",
+      "azure"
     ]
   },
-  "claude-sonnet-4-5-20250929": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "displayName": "Claude Sonnet 4.5 (2025-09-29)",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "claude-sonnet-4-5",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "anthropic"
-    ]
-  },
-  "claude-haiku-4-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 5,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "input_cache_write_cost_per_mil_tokens": 1.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 1.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 2,
-    "displayName": "Claude Haiku 4.5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "fallback_models": [
-      "publishers/anthropic/models/claude-haiku-4-5"
-    ],
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "anthropic"
-    ]
-  },
-  "claude-haiku-4-5-20251001": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 5,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "input_cache_write_cost_per_mil_tokens": 1.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 1.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 2,
-    "displayName": "Claude Haiku 4.5 (2025-10-01)",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "claude-haiku-4-5",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "anthropic"
-    ]
-  },
-  "claude-opus-4-7": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 10,
-    "displayName": "Claude Opus 4.7",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "fallback_models": [
-      "anthropic.claude-opus-4-7",
-      "global.anthropic.claude-opus-4-7",
-      "publishers/anthropic/models/claude-opus-4-7",
-      "us.anthropic.claude-opus-4-7"
-    ],
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "anthropic"
-    ]
-  },
-  "publishers/anthropic/models/claude-opus-4-7": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 10,
-    "displayName": "Claude Opus 4.7",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "claude-opus-4-6": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 10,
-    "displayName": "Claude Opus 4.6",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "fallback_models": [
-      "publishers/anthropic/models/claude-opus-4-6"
-    ],
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "anthropic"
-    ]
-  },
-  "publishers/anthropic/models/claude-opus-4-6": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 10,
-    "displayName": "Claude Opus 4.6",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "claude-opus-4-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 10,
-    "displayName": "Claude Opus 4.5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "anthropic"
-    ]
-  },
-  "claude-opus-4-5-20251101": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 10,
-    "displayName": "Claude Opus 4.5 (2025-11-01)",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "claude-opus-4-5",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "anthropic"
-    ]
-  },
-  "publishers/anthropic/models/claude-opus-4-5@20251101": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 10,
-    "displayName": "Claude Opus 4.5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000
-  },
-  "claude-opus-4-1": {
-    "format": "anthropic",
+  "o1-2024-12-17": {
+    "format": "openai",
     "flavor": "chat",
     "multimodal": true,
     "input_cost_per_mil_tokens": 15,
-    "output_cost_per_mil_tokens": 75,
-    "input_cache_read_cost_per_mil_tokens": 1.5,
-    "input_cache_write_cost_per_mil_tokens": 18.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 18.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 30,
-    "displayName": "Claude Opus 4.1",
+    "output_cost_per_mil_tokens": 60,
+    "input_cache_read_cost_per_mil_tokens": 7.5,
+    "displayName": "o1 (2024-12-17)",
     "reasoning": true,
+    "deprecation_date": "2026-10-23",
+    "parent": "o1",
     "max_input_tokens": 200000,
-    "max_output_tokens": 32000,
+    "max_output_tokens": 100000,
     "available_providers": [
-      "anthropic"
+      "openai",
+      "azure"
     ]
   },
-  "claude-opus-4-1-20250805": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 15,
-    "output_cost_per_mil_tokens": 75,
-    "input_cache_read_cost_per_mil_tokens": 1.5,
-    "input_cache_write_cost_per_mil_tokens": 18.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 18.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 30,
-    "displayName": "Claude Opus 4.1 (2025-08-05)",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "deprecation_date": "2026-08-05",
-    "parent": "claude-opus-4-1",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 32000,
-    "available_providers": [
-      "anthropic"
-    ]
-  },
-  "publishers/anthropic/models/claude-opus-4-1@20250805": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 15,
-    "output_cost_per_mil_tokens": 75,
-    "input_cache_read_cost_per_mil_tokens": 1.5,
-    "input_cache_write_cost_per_mil_tokens": 18.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 18.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 30,
-    "displayName": "Claude Opus 4.1",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 32000
-  },
-  "publishers/anthropic/models/claude-opus-4": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 15,
-    "output_cost_per_mil_tokens": 75,
-    "input_cache_read_cost_per_mil_tokens": 1.5,
-    "input_cache_write_cost_per_mil_tokens": 18.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 18.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 30,
-    "displayName": "Claude Opus 4",
-    "reasoning": true,
-    "reasoning_budget": true
-  },
-  "publishers/anthropic/models/claude-opus-4@20250514": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 15,
-    "output_cost_per_mil_tokens": 75,
-    "input_cache_read_cost_per_mil_tokens": 1.5,
-    "input_cache_write_cost_per_mil_tokens": 18.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 18.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 30,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "publishers/anthropic/models/claude-opus-4"
-  },
-  "claude-instant-1.2": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.163,
-    "output_cost_per_mil_tokens": 0.551,
-    "displayName": "Claude Instant 1.2",
-    "deprecated": true,
-    "max_input_tokens": 100000,
-    "max_output_tokens": 8191
-  },
-  "claude-instant-1": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.63,
-    "output_cost_per_mil_tokens": 5.51,
-    "displayName": "Claude Instant 1",
-    "deprecated": true,
-    "max_input_tokens": 100000,
-    "max_output_tokens": 8191
-  },
-  "claude-2.1": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 8,
-    "output_cost_per_mil_tokens": 24,
-    "displayName": "Claude 2.1",
-    "deprecated": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 8191
-  },
-  "claude-2.0": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 8,
-    "output_cost_per_mil_tokens": 24,
-    "displayName": "Claude 2.0",
-    "deprecated": true
-  },
-  "claude-2": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 8,
-    "output_cost_per_mil_tokens": 24,
-    "displayName": "Claude 2",
-    "deprecated": true,
-    "max_input_tokens": 100000,
-    "max_output_tokens": 8191
-  },
-  "claude-opus-4-8": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 10,
-    "displayName": "Claude Opus 4.8",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "fallback_models": [
-      "anthropic.claude-opus-4-8",
-      "global.anthropic.claude-opus-4-8",
-      "publishers/anthropic/models/claude-opus-4-8",
-      "us.anthropic.claude-opus-4-8"
-    ],
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "anthropic"
-    ]
-  },
-  "claude-fable-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 10,
-    "output_cost_per_mil_tokens": 50,
-    "input_cache_read_cost_per_mil_tokens": 1,
-    "input_cache_write_cost_per_mil_tokens": 12.5,
-    "input_cache_write_5m_cost_per_mil_tokens": 12.5,
-    "input_cache_write_1h_cost_per_mil_tokens": 20,
-    "displayName": "Claude Fable 5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "fallback_models": [
-      "anthropic.claude-fable-5",
-      "global.anthropic.claude-fable-5",
-      "publishers/anthropic/models/claude-fable-5"
-    ],
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "anthropic"
-    ]
-  },
-  "meta/llama-2-70b-chat": {
+  "gpt-audio-2025-08-28": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.65,
-    "output_cost_per_mil_tokens": 2.75,
-    "displayName": "LLaMA 2 70b Chat"
-  },
-  "mistral.mixtral-8x7b-instruct-v0:1": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.45,
-    "output_cost_per_mil_tokens": 0.7,
-    "displayName": "Mixtral 8x7B",
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8191,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "accounts/fireworks/models/mistral-7b-instruct-4k": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mistral-7b-instruct-v3": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "mistralai/Mistral-7B-Instruct-v0.3": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "displayName": "Mistral (7B) Instruct v0.3"
-  },
-  "accounts/fireworks/models/mistral-7b-instruct-v0p2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mistral-7b-v0p2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "mistral.mistral-7b-instruct-v0:2": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.2,
-    "displayName": "Mistral 7B",
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8191,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "mistralai/Mistral-7B-Instruct-v0.2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "displayName": "Mistral (7B) Instruct v0.2"
-  },
-  "mistralai/Mistral-7B-Instruct-v0.1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "displayName": "Mistral (7B) Instruct",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "accounts/fireworks/models/mistral-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "mistral-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.07,
-    "output_cost_per_mil_tokens": 0.07,
-    "displayName": "Mistral 7B"
-  },
-  "mistral.mistral-large-2402-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 8,
-    "output_cost_per_mil_tokens": 24,
-    "displayName": "Mistral Large 24.02",
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8191,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "mistral.mistral-small-2402-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 3,
-    "displayName": "Mistral Small 24.02",
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8191,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "mistral.mistral-large-3-675b-instruct": {
-    "format": "converse",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 1.5,
-    "displayName": "Mistral Large 3 (675B)",
-    "max_input_tokens": 256000,
-    "max_output_tokens": 32000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "mistral": {
-    "format": "openai",
-    "flavor": "chat"
-  },
-  "accounts/fireworks/models/phi-3-mini-128k-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/phi-3-vision-128k-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "displayName": "Phi 3.5 Vision Instruct",
-    "max_input_tokens": 32064,
-    "max_output_tokens": 32064,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/phi-2-3b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 2048,
-    "max_output_tokens": 2048,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "phi": {
-    "format": "openai",
-    "flavor": "chat",
-    "deprecated": true
-  },
-  "sonar": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 1,
-    "displayName": "Sonar",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "GPT Audio (2025-08-28)",
+    "parent": "gpt-audio",
     "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
     "available_providers": [
-      "perplexity"
+      "openai",
+      "azure"
     ]
   },
-  "sonar-pro": {
+  "gpt-audio-1.5": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "displayName": "Sonar Pro",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 8000,
-    "available_providers": [
-      "perplexity"
-    ]
-  },
-  "sonar-reasoning-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 8,
-    "displayName": "Sonar Reasoning Pro",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
     "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
     "available_providers": [
-      "perplexity"
+      "openai",
+      "azure"
     ]
   },
-  "sonar-deep-research": {
+  "gpt-audio": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 8,
-    "displayName": "Sonar Deep Research",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "GPT Audio",
     "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
     "available_providers": [
-      "perplexity"
+      "openai",
+      "azure"
     ]
   },
-  "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.27,
-    "output_cost_per_mil_tokens": 0.85,
-    "displayName": "Llama 4 Maverick Instruct (17Bx128E)",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.18,
-    "output_cost_per_mil_tokens": 0.59,
-    "displayName": "Llama 4 Scout Instruct (17Bx16E)",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta-llama/Llama-3.3-70B-Instruct-Turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.04,
-    "output_cost_per_mil_tokens": 1.04,
-    "displayName": "Llama 3.3 70B Instruct Turbo",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta-llama/Llama-3.3-70B-Instruct-Turbo-Free": {
-    "format": "openai",
-    "flavor": "chat",
-    "displayName": "Llama 3.3 70B Instruct Turbo Free",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta-llama/Llama-3.2-90B-Vision-Instruct-Turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "displayName": "Llama 3.2 90B Vision Instruct Turbo"
-  },
-  "meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.18,
-    "output_cost_per_mil_tokens": 0.18,
-    "displayName": "Llama 3.2 11B Vision Instruct Turbo"
-  },
-  "meta-llama/Llama-Vision-Free": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Llama Vision Free"
-  },
-  "meta-llama/Llama-3.2-3B-Instruct-Turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.06,
-    "output_cost_per_mil_tokens": 0.06,
-    "displayName": "Llama 3.2 3B Instruct Turbo",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3.5,
-    "output_cost_per_mil_tokens": 3.5,
-    "displayName": "Llama 3.1 405B Instruct Turbo",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.88,
-    "output_cost_per_mil_tokens": 0.88,
-    "displayName": "Llama 3.1 70B Instruct Turbo",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.18,
-    "output_cost_per_mil_tokens": 0.18,
-    "displayName": "Llama 3.1 8B Instruct Turbo",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta-llama/Llama-3-70b-chat-hf": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "displayName": "Llama 3 70B Instruct Reference"
-  },
-  "meta-llama/Meta-Llama-3-70B-Instruct-Turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.88,
-    "output_cost_per_mil_tokens": 0.88,
-    "displayName": "Llama 3 70B Instruct Turbo"
-  },
-  "meta-llama/Meta-Llama-3-70B-Instruct-Lite": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.54,
-    "output_cost_per_mil_tokens": 0.54,
-    "displayName": "Llama 3 70B Instruct Lite"
-  },
-  "meta-llama/Llama-3-8b-chat-hf": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "displayName": "Llama 3 8B Instruct Reference"
-  },
-  "meta-llama/Meta-Llama-3-8B-Instruct-Lite": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "displayName": "Llama 3 8B Instruct Lite"
-  },
-  "accounts/fireworks/models/gemma-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/gemma-7b-it": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/gemma-3-27b-it": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "google/gemma-2-27b-it": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.35,
-    "output_cost_per_mil_tokens": 1.05,
-    "displayName": "Gemma-2 Instruct (27B)",
-    "max_output_tokens": 8192
-  },
-  "accounts/fireworks/models/gemma2-9b-it": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "google/gemma-2-9b-it": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.35,
-    "output_cost_per_mil_tokens": 1.05,
-    "displayName": "Gemma-2 Instruct (9B)",
-    "max_output_tokens": 8192
-  },
-  "accounts/fireworks/models/gemma-2b-it": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "google/gemma-2b-it": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "displayName": "Gemma Instruct (2B)"
-  },
-  "google/gemma-4-31B-it": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.39,
-    "output_cost_per_mil_tokens": 0.97,
-    "displayName": "Gemma 4 31B IT",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "google/gemma-3n-E4B-it": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.06,
-    "output_cost_per_mil_tokens": 0.12,
-    "displayName": "Gemma 3n E4B IT",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "mistralai/Mistral-Small-24B-Instruct-2501": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.8,
-    "output_cost_per_mil_tokens": 0.8,
-    "displayName": "Mistral Small (24B) Instruct 25.01",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "mistralai/Mixtral-8x22B-Instruct-v0.1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "displayName": "Mixtral 8x22B Instruct v0.1"
-  },
-  "accounts/fireworks/models/mixtral-8x22b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 65536,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mixtral-8x22b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "displayName": "Mixtral MoE 8x22B Instruct",
-    "max_input_tokens": 65536,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mixtral-8x22b-instruct-hf": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 65536,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "mistralai/Mixtral-8x22B": {
-    "format": "openai",
-    "flavor": "completion",
-    "input_cost_per_mil_tokens": 1.08,
-    "output_cost_per_mil_tokens": 1.08,
-    "displayName": "Mixtral 8x22B",
-    "deprecated": true
-  },
-  "mistralai/Mixtral-8x7B-Instruct-v0.1": {
+  "gpt-audio-mini": {
     "format": "openai",
     "flavor": "chat",
     "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "Mixtral 8x7B Instruct v0.1",
+    "output_cost_per_mil_tokens": 2.4,
+    "displayName": "GPT Audio mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
     "available_providers": [
-      "together"
+      "openai",
+      "azure"
     ]
   },
-  "accounts/fireworks/models/mixtral-8x7b": {
+  "gpt-audio-mini-2025-12-15": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "displayName": "GPT Audio mini (2025-12-15)",
+    "parent": "gpt-audio-mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-audio-mini-2025-10-06": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "displayName": "GPT Audio mini (2025-10-06)",
+    "parent": "gpt-audio-mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-realtime-2025-08-28": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 4,
+    "output_cost_per_mil_tokens": 16,
+    "input_cache_read_cost_per_mil_tokens": 0.4,
+    "displayName": "GPT Realtime (2025-08-28)",
+    "parent": "gpt-realtime",
+    "max_input_tokens": 32000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-realtime-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 4,
+    "output_cost_per_mil_tokens": 16,
+    "input_cache_read_cost_per_mil_tokens": 0.4,
+    "displayName": "GPT Realtime 2",
+    "max_input_tokens": 32000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-realtime-1.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 4,
+    "output_cost_per_mil_tokens": 16,
+    "input_cache_read_cost_per_mil_tokens": 0.4,
+    "max_input_tokens": 32000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-realtime": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 4,
+    "output_cost_per_mil_tokens": 16,
+    "input_cache_read_cost_per_mil_tokens": 0.4,
+    "displayName": "GPT Realtime",
+    "max_input_tokens": 32000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-realtime-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "displayName": "GPT Realtime mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-realtime-mini-2025-12-15": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "input_cache_read_cost_per_mil_tokens": 0.06,
+    "displayName": "GPT Realtime mini (2025-12-15)",
+    "parent": "gpt-realtime-mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-realtime-mini-2025-10-06": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "input_cache_read_cost_per_mil_tokens": 0.06,
+    "displayName": "GPT Realtime mini (2025-10-06)",
+    "parent": "gpt-realtime-mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-image-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "displayName": "GPT Image 2",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-image-2-2026-04-21": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "displayName": "GPT Image 2 (2026-04-21)",
+    "parent": "gpt-image-2",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "1024-x-1024/gpt-image-1.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Square",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "1024-x-1536/gpt-image-1.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Portrait",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "1536-x-1024/gpt-image-1.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Landscape",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-image-1.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "displayName": "GPT Image 1.5",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "high/1024-x-1024/gpt-image-1.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 High Square",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "high/1024-x-1536/gpt-image-1.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 High Portrait",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "high/1536-x-1024/gpt-image-1.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 High Landscape",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "low/1024-x-1024/gpt-image-1.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Low Square",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "low/1024-x-1536/gpt-image-1.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Low Portrait",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "low/1536-x-1024/gpt-image-1.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Low Landscape",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "medium/1024-x-1024/gpt-image-1.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Medium Square",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "medium/1024-x-1536/gpt-image-1.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Medium Portrait",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "medium/1536-x-1024/gpt-image-1.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Medium Landscape",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "standard/1024-x-1024/gpt-image-1.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Standard Square",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "standard/1024-x-1536/gpt-image-1.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Standard Portrait",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "standard/1536-x-1024/gpt-image-1.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Standard Landscape",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "1024-x-1024/gpt-image-1.5-2025-12-16": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Square (2025-12-16)",
+    "parent": "1024-x-1024/gpt-image-1.5",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "1024-x-1536/gpt-image-1.5-2025-12-16": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Portrait (2025-12-16)",
+    "parent": "1024-x-1536/gpt-image-1.5",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "1536-x-1024/gpt-image-1.5-2025-12-16": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Landscape (2025-12-16)",
+    "parent": "1536-x-1024/gpt-image-1.5",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-image-1.5-2025-12-16": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "displayName": "GPT Image 1.5 (2025-12-16)",
+    "parent": "gpt-image-1.5",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "high/1024-x-1024/gpt-image-1.5-2025-12-16": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 High Square (2025-12-16)",
+    "parent": "high/1024-x-1024/gpt-image-1.5",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "high/1024-x-1536/gpt-image-1.5-2025-12-16": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 High Portrait (2025-12-16)",
+    "parent": "high/1024-x-1536/gpt-image-1.5",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "high/1536-x-1024/gpt-image-1.5-2025-12-16": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 High Landscape (2025-12-16)",
+    "parent": "high/1536-x-1024/gpt-image-1.5",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "low/1024-x-1024/gpt-image-1.5-2025-12-16": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Low Square (2025-12-16)",
+    "parent": "low/1024-x-1024/gpt-image-1.5",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "low/1024-x-1536/gpt-image-1.5-2025-12-16": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Low Portrait (2025-12-16)",
+    "parent": "low/1024-x-1536/gpt-image-1.5",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "low/1536-x-1024/gpt-image-1.5-2025-12-16": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Low Landscape (2025-12-16)",
+    "parent": "low/1536-x-1024/gpt-image-1.5",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "medium/1024-x-1024/gpt-image-1.5-2025-12-16": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Medium Square (2025-12-16)",
+    "parent": "medium/1024-x-1024/gpt-image-1.5",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "medium/1024-x-1536/gpt-image-1.5-2025-12-16": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Medium Portrait (2025-12-16)",
+    "parent": "medium/1024-x-1536/gpt-image-1.5",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "medium/1536-x-1024/gpt-image-1.5-2025-12-16": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Medium Landscape (2025-12-16)",
+    "parent": "medium/1536-x-1024/gpt-image-1.5",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "standard/1024-x-1024/gpt-image-1.5-2025-12-16": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Standard Square (2025-12-16)",
+    "parent": "standard/1024-x-1024/gpt-image-1.5",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "standard/1024-x-1536/gpt-image-1.5-2025-12-16": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Standard Portrait (2025-12-16)",
+    "parent": "standard/1024-x-1536/gpt-image-1.5",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "standard/1536-x-1024/gpt-image-1.5-2025-12-16": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT Image 1.5 Standard Landscape (2025-12-16)",
+    "parent": "standard/1536-x-1024/gpt-image-1.5",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-image-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 5,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-image-1-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "high/1024-x-1024/gpt-image-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "high/1024-x-1536/gpt-image-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "high/1536-x-1024/gpt-image-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "low/1024-x-1024/gpt-image-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "low/1024-x-1024/gpt-image-1-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "low/1024-x-1536/gpt-image-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "low/1024-x-1536/gpt-image-1-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "low/1536-x-1024/gpt-image-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "low/1536-x-1024/gpt-image-1-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "medium/1024-x-1024/gpt-image-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "medium/1024-x-1024/gpt-image-1-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "medium/1024-x-1536/gpt-image-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "medium/1024-x-1536/gpt-image-1-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "medium/1536-x-1024/gpt-image-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "medium/1536-x-1024/gpt-image-1-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "chatgpt-image-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 5,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "dall-e-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "hd/1024-x-1024/dall-e-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "hd/1024-x-1792/dall-e-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "hd/1792-x-1024/dall-e-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "standard/1024-x-1024/dall-e-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "standard/1024-x-1792/dall-e-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "standard/1792-x-1024/dall-e-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "1024-x-1024/dall-e-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "256-x-256/dall-e-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "512-x-512/dall-e-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "dall-e-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "openai/sora-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "openai/sora-2-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "openai/sora-2-pro-high-res": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "sora-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "sora-2-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "sora-2-pro-high-res": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "tts-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "tts-1-hd": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "tts-1-1106": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "tts-1-hd-1106": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "whisper-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "omni-moderation-latest": {
+    "format": "openai",
+    "flavor": "chat",
     "max_input_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "omni-moderation-2024-09-26": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "text-moderation-007": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "text-moderation-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "text-moderation-stable": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "babbage-002": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.4,
+    "output_cost_per_mil_tokens": 0.4,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "davinci-002": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "ft:gpt-4.1-2025-04-14": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 12,
+    "input_cache_read_cost_per_mil_tokens": 0.75,
+    "max_input_tokens": 1047576,
     "max_output_tokens": 32768,
     "available_providers": [
-      "fireworks"
+      "openai",
+      "azure"
     ]
   },
-  "accounts/fireworks/models/mixtral-8x7b-instruct": {
+  "ft:gpt-4.1-mini-2025-04-14": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "displayName": "Mixtral MoE 8x7B Instruct",
-    "max_input_tokens": 32768,
+    "input_cost_per_mil_tokens": 0.8,
+    "output_cost_per_mil_tokens": 3.2,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 1047576,
     "max_output_tokens": 32768,
     "available_providers": [
-      "fireworks"
+      "openai",
+      "azure"
     ]
   },
-  "accounts/fireworks/models/mixtral-8x7b-instruct-hf": {
+  "ft:gpt-4.1-nano-2025-04-14": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "max_input_tokens": 32768,
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.8,
+    "input_cache_read_cost_per_mil_tokens": 0.05,
+    "max_input_tokens": 1047576,
     "max_output_tokens": 32768,
     "available_providers": [
-      "fireworks"
+      "openai",
+      "azure"
     ]
   },
-  "mixtral-8x7b": {
+  "ft:o4-mini-2025-04-16": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "displayName": "Mixtral 8x7b"
+    "input_cost_per_mil_tokens": 4,
+    "output_cost_per_mil_tokens": 16,
+    "input_cache_read_cost_per_mil_tokens": 1,
+    "reasoning": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "ft:gpt-4o-2024-11-20": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3.75,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_write_cost_per_mil_tokens": 1.875,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "ft:gpt-4o-2024-08-06": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3.75,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 1.875,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "ft:gpt-4o-mini-2024-07-18": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 1.2,
+    "input_cache_read_cost_per_mil_tokens": 0.15,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "ft:gpt-4-0613": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 30,
+    "output_cost_per_mil_tokens": 60,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "ft:gpt-3.5-turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 6,
+    "max_input_tokens": 16385,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "ft:gpt-3.5-turbo-1106": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 6,
+    "max_input_tokens": 16385,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "ft:gpt-3.5-turbo-0613": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 6,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "ft:gpt-3.5-turbo-0125": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 6,
+    "max_input_tokens": 16385,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "ft:babbage-002": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.6,
+    "output_cost_per_mil_tokens": 1.6,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "ft:davinci-002": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 12,
+    "output_cost_per_mil_tokens": 12,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "openai/container": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "chat-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 30,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "GPT Chat Latest",
+    "reasoning": true,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
   },
   "accounts/fireworks/models/deepseek-v4-flash": {
     "format": "openai",
@@ -2759,19 +2770,6 @@
     "max_output_tokens": 384000,
     "available_providers": [
       "fireworks"
-    ]
-  },
-  "deepseek-ai/DeepSeek-V4-Pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.74,
-    "output_cost_per_mil_tokens": 3.48,
-    "input_cache_read_cost_per_mil_tokens": 0.145,
-    "displayName": "DeepSeek V4 Pro",
-    "max_input_tokens": 512000,
-    "available_providers": [
-      "together",
-      "baseten"
     ]
   },
   "accounts/fireworks/models/deepseek-v3p2": {
@@ -2810,15 +2808,6 @@
       "fireworks"
     ]
   },
-  "deepseek-ai/DeepSeek-V3.1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 1.5,
-    "available_providers": [
-      "baseten"
-    ]
-  },
   "accounts/fireworks/models/deepseek-v3": {
     "format": "openai",
     "flavor": "chat",
@@ -2829,18 +2818,6 @@
     "max_output_tokens": 8192,
     "available_providers": [
       "fireworks"
-    ]
-  },
-  "deepseek-ai/DeepSeek-V3": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 1.25,
-    "displayName": "DeepSeek V3",
-    "max_input_tokens": 65536,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "together"
     ]
   },
   "accounts/fireworks/models/deepseek-v3-0324": {
@@ -2877,13 +2854,6 @@
       "fireworks"
     ]
   },
-  "deepseek-ai/deepseek-llm-67b-chat": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "displayName": "DeepSeek LLM Chat (67B)"
-  },
   "accounts/fireworks/models/deepseek-coder-33b-instruct": {
     "format": "openai",
     "flavor": "chat",
@@ -2894,14 +2864,6 @@
     "available_providers": [
       "fireworks"
     ]
-  },
-  "deepseek-ai/deepseek-coder-33b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.8,
-    "output_cost_per_mil_tokens": 0.8,
-    "displayName": "Deepseek Coder 33b Instruct",
-    "deprecated": true
   },
   "accounts/fireworks/models/deepseek-coder-7b-base-v1p5": {
     "format": "openai",
@@ -2934,28 +2896,6 @@
     "max_output_tokens": 4096,
     "available_providers": [
       "fireworks"
-    ]
-  },
-  "deepseek.v3.2": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.62,
-    "output_cost_per_mil_tokens": 1.85,
-    "displayName": "DeepSeek V3.2",
-    "max_input_tokens": 164000,
-    "max_output_tokens": 8000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "deepseek.v3-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "displayName": "DeepSeek V3.1",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8000,
-    "available_providers": [
-      "bedrock"
     ]
   },
   "accounts/fireworks/models/deepseek-coder-v2-instruct": {
@@ -3013,18 +2953,6 @@
       "fireworks"
     ]
   },
-  "deepseek-ai/DeepSeek-R1-Distill-Llama-70B": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 2,
-    "displayName": "DeepSeek R1 Distill Llama 70B"
-  },
-  "deepseek-ai/DeepSeek-R1-Distill-Llama-70B-Free": {
-    "format": "openai",
-    "flavor": "chat",
-    "displayName": "DeepSeek R1 Distill Llama 70B Free"
-  },
   "accounts/fireworks/models/deepseek-r1-distill-qwen-32b": {
     "format": "openai",
     "flavor": "chat",
@@ -3046,13 +2974,6 @@
     "available_providers": [
       "fireworks"
     ]
-  },
-  "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.6,
-    "output_cost_per_mil_tokens": 1.6,
-    "displayName": "DeepSeek R1 Distill Qwen 14B"
   },
   "accounts/fireworks/models/deepseek-r1-distill-llama-8b": {
     "format": "openai",
@@ -3098,24 +3019,6 @@
       "fireworks"
     ]
   },
-  "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.18,
-    "output_cost_per_mil_tokens": 0.18,
-    "displayName": "DeepSeek R1 Distill Qwen 1.5B"
-  },
-  "deepseek.r1-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "displayName": "DeepSeek R1",
-    "reasoning": true,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
   "accounts/fireworks/models/deepseek-coder-1b-base": {
     "format": "openai",
     "flavor": "chat",
@@ -3151,18 +3054,6 @@
       "fireworks"
     ]
   },
-  "deepseek-ai/DeepSeek-R1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 7,
-    "displayName": "DeepSeek R1",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 20480,
-    "available_providers": [
-      "together"
-    ]
-  },
   "accounts/fireworks/models/deepseek-r1-0528": {
     "format": "openai",
     "flavor": "chat",
@@ -3170,6 +3061,30 @@
     "output_cost_per_mil_tokens": 8,
     "max_input_tokens": 160000,
     "max_output_tokens": 160000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/qwen3p7-plus": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.4,
+    "output_cost_per_mil_tokens": 1.6,
+    "input_cache_read_cost_per_mil_tokens": 0.08,
+    "displayName": "Qwen3.7 Plus",
+    "max_input_tokens": 262144,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/qwen3p6-plus": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 3,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "displayName": "Qwen3.6 Plus",
     "available_providers": [
       "fireworks"
     ]
@@ -3254,19 +3169,6 @@
       "fireworks"
     ]
   },
-  "publishers/qwen/models/qwen3-235b-a22b-instruct-2507-maas": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.22,
-    "output_cost_per_mil_tokens": 0.88,
-    "displayName": "Qwen3 235B A22B Instruct 2507",
-    "locations": [
-      "global",
-      "us-south1"
-    ],
-    "max_input_tokens": 262144,
-    "max_output_tokens": 16384
-  },
   "accounts/fireworks/models/qwen3-next-80b-a3b-instruct": {
     "format": "openai",
     "flavor": "chat",
@@ -3310,32 +3212,6 @@
     "max_output_tokens": 4096,
     "available_providers": [
       "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/qwen3p6-plus": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 3,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "displayName": "Qwen3.6 Plus",
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "qwen/qwen3-32b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.29,
-    "output_cost_per_mil_tokens": 0.59,
-    "displayName": "Qwen3-32B",
-    "reasoning": true,
-    "experimental": true,
-    "deprecation_date": "2026-07-17",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 40960,
-    "available_providers": [
-      "groq"
     ]
   },
   "accounts/fireworks/models/qwen3-30b-a3b": {
@@ -3588,16 +3464,6 @@
       "fireworks"
     ]
   },
-  "Qwen/Qwen2.5-72B-Instruct-Turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "displayName": "Qwen 2.5 72B Instruct Turbo",
-    "available_providers": [
-      "together"
-    ]
-  },
   "accounts/fireworks/models/qwen2p5-coder-32b-instruct-128k": {
     "format": "openai",
     "flavor": "chat",
@@ -3686,13 +3552,6 @@
     "available_providers": [
       "fireworks"
     ]
-  },
-  "Qwen/Qwen2.5-Coder-32B-Instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.8,
-    "output_cost_per_mil_tokens": 0.8,
-    "displayName": "Qwen 2.5 Coder 32B Instruct"
   },
   "accounts/fireworks/models/qwen-v2p5-14b-instruct": {
     "format": "openai",
@@ -3791,16 +3650,6 @@
     "max_output_tokens": 128000,
     "available_providers": [
       "fireworks"
-    ]
-  },
-  "Qwen/Qwen2.5-7B-Instruct-Turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 0.3,
-    "displayName": "Qwen 2.5 7B Instruct Turbo",
-    "available_providers": [
-      "together"
     ]
   },
   "accounts/fireworks/models/qwen2p5-coder-3b": {
@@ -3925,20 +3774,6 @@
       "fireworks"
     ]
   },
-  "Qwen/Qwen2-72B-Instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "displayName": "Qwen 2 Instruct (72B)"
-  },
-  "Qwen/Qwen2-VL-72B-Instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "displayName": "Qwen-2VL (72B) Instruct"
-  },
   "accounts/fireworks/models/qwen2-7b-instruct": {
     "format": "openai",
     "flavor": "chat",
@@ -3996,842 +3831,117 @@
       "fireworks"
     ]
   },
-  "Qwen/QwQ-32B": {
+  "accounts/fireworks/models/qwq-32b": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.8,
-    "output_cost_per_mil_tokens": 0.8,
-    "displayName": "Qwen QwQ 32B"
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "displayName": "Qwen QwQ 32B",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
   },
-  "nvidia/Llama-3.1-Nemotron-70B-Instruct-HF": {
+  "accounts/fireworks/models/glm-5p2": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.88,
+    "input_cost_per_mil_tokens": 1.4,
+    "output_cost_per_mil_tokens": 4.4,
+    "input_cache_read_cost_per_mil_tokens": 0.14,
+    "displayName": "GLM 5.2",
+    "reasoning": true,
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/glm-5p1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.4,
+    "output_cost_per_mil_tokens": 4.4,
+    "input_cache_read_cost_per_mil_tokens": 0.26,
+    "displayName": "GLM 5.1",
+    "reasoning": true,
+    "max_input_tokens": 202800,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/glm-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 3.2,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "GLM 5",
+    "max_input_tokens": 202752,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/glm-4p7": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.2,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "reasoning": true,
+    "max_input_tokens": 202800,
+    "max_output_tokens": 202800,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/glm-4p6": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.55,
+    "output_cost_per_mil_tokens": 2.19,
+    "reasoning": true,
+    "max_input_tokens": 202800,
+    "max_output_tokens": 202800,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/glm-4p5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.55,
+    "output_cost_per_mil_tokens": 2.19,
+    "reasoning": true,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 96000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/glm-4p5-air": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.22,
     "output_cost_per_mil_tokens": 0.88,
-    "displayName": "Llama 3.1 Nemotron 70B Instruct HF"
+    "reasoning": true,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 96000,
+    "available_providers": [
+      "fireworks"
+    ]
   },
-  "microsoft/WizardLM-2-8x22B": {
+  "accounts/fireworks/models/glm-4p5v": {
     "format": "openai",
     "flavor": "chat",
     "input_cost_per_mil_tokens": 1.2,
     "output_cost_per_mil_tokens": 1.2,
-    "displayName": "WizardLM-2 (8x22B)"
-  },
-  "accounts/fireworks/models/dbrx-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nous-hermes-llama2-70b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nous-hermes-2-yi-34b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "NousResearch/Nous-Hermes-2-Yi-34B": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.8,
-    "output_cost_per_mil_tokens": 0.8,
-    "displayName": "Nous Hermes 2 Yi 34B",
-    "deprecated": true
-  },
-  "accounts/fireworks/models/nous-hermes-llama2-13b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "nous-hermes-llama2-13b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.18,
-    "output_cost_per_mil_tokens": 0.18,
-    "displayName": "Nous: Hermes 13B"
-  },
-  "accounts/fireworks/models/nous-hermes-2-mixtral-8x7b-dpo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "Nous Hermes 2 - Mixtral 8x7B-DPO"
-  },
-  "accounts/fireworks/models/nous-hermes-llama2-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mythomax-l2-13b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "Gryphe/MythoMax-L2-13b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 0.3,
-    "displayName": "MythoMax-L2 (13B)"
-  },
-  "Gryphe/MythoMax-L2-13b-Lite": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "displayName": "Gryphe MythoMax L2 Lite (13B)"
-  },
-  "meta-llama/Meta-Llama-3-70B": {
-    "format": "openai",
-    "flavor": "completion",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "displayName": "Llama 3 70b",
-    "deprecated": true
-  },
-  "meta-llama/Llama-3-8b-hf": {
-    "format": "openai",
-    "flavor": "completion",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "displayName": "Llama 3 8b HF",
-    "deprecated": true
-  },
-  "meta-llama/Llama-2-70b-chat-hf": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "displayName": "Llama 2 70b Chat HF",
-    "deprecated": true
-  },
-  "Qwen/QwQ-32B-Preview": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.8,
-    "output_cost_per_mil_tokens": 0.8,
-    "displayName": "Qwen QwQ 32B Preview",
-    "deprecated": true
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 3.6,
-    "input_cache_read_cost_per_mil_tokens": 0.35,
-    "displayName": "Qwen3.5 397B A17B",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "Qwen/Qwen3.6-Plus": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 3,
-    "displayName": "Qwen3.6 Plus",
-    "max_input_tokens": 1000000,
-    "supports_streaming": true,
-    "streaming_only": true,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "Qwen/Qwen3.5-9B": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.17,
-    "output_cost_per_mil_tokens": 0.25,
-    "displayName": "Qwen3.5 9B",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "Qwen/Qwen3-Coder-Next-FP8": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 1.2,
-    "displayName": "Qwen3 Coder Next FP8",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "Qwen/Qwen3-235B-A22B-Instruct-2507-tput": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "Qwen3 235B A22B Instruct 2507 (Throughput)",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "Qwen/Qwen3.7-Max": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 3.75,
-    "input_cache_read_cost_per_mil_tokens": 0.13,
-    "displayName": "Qwen3.7 Max",
     "reasoning": true,
-    "max_input_tokens": 1000000,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "Qwen/Qwen3.7-Plus": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.32,
-    "output_cost_per_mil_tokens": 1.28,
-    "displayName": "Qwen 3.7 Plus",
-    "max_input_tokens": 1000000,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "magistral-medium-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 5,
-    "displayName": "Magistral Medium Latest",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 40000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "magistral-small-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 1.5,
-    "displayName": "Magistral Small Latest",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 40000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "magistral-medium-2509": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 5,
-    "displayName": "Magistral Medium (2509)",
-    "deprecation_date": "2026-07-31",
-    "parent": "magistral-medium-latest",
-    "max_input_tokens": 128000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "magistral-small-2509": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 1.5,
-    "displayName": "Magistral Small (2509)",
-    "deprecation_date": "2026-07-31",
-    "parent": "magistral-small-latest",
-    "max_input_tokens": 128000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "devstral-small-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.3,
-    "displayName": "Devstral Small Latest",
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "devstral-2512": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.4,
-    "output_cost_per_mil_tokens": 2,
-    "displayName": "Devstral 2512",
-    "deprecation_date": "2026-07-31",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "devstral-medium-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.4,
-    "output_cost_per_mil_tokens": 2,
-    "displayName": "Devstral Medium Latest",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "devstral-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.4,
-    "output_cost_per_mil_tokens": 2,
-    "displayName": "Devstral Latest",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "accounts/fireworks/models/devstral-small-2505": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
     "max_input_tokens": 131072,
     "max_output_tokens": 131072,
     "available_providers": [
       "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mistral-large-3-fp8": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "mistral-large-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 1.5,
-    "displayName": "Mistral Large",
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "publishers/mistralai/models/mistral-large-2411": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 6,
-    "displayName": "Mistral Large (24.11)",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "mistral-medium-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.5,
-    "output_cost_per_mil_tokens": 7.5,
-    "displayName": "Mistral Medium 3.5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 256000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-medium-2505": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.4,
-    "output_cost_per_mil_tokens": 2,
-    "deprecation_date": "2026-05-22",
-    "parent": "mistral-medium-latest",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 8191,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-small-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "Mistral Small",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-small-2501": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.3,
-    "parent": "mistral-small-latest"
-  },
-  "codestral-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 0.9,
-    "displayName": "Codestral",
-    "max_input_tokens": 128000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "codestral-2501": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 0.9,
-    "parent": "codestral-latest",
-    "fallback_models": [
-      "publishers/mistralai/models/codestral-2501"
-    ],
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "codestral-2508": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 0.9,
-    "displayName": "Codestral 2508",
-    "parent": "codestral-latest",
-    "max_input_tokens": 256000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "ministral-8b-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.15,
-    "displayName": "Ministral 8B",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "ministral-8b-2410": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "parent": "ministral-8b-latest"
-  },
-  "accounts/fireworks/models/ministral-3-14b-instruct-2512": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/ministral-3-8b-instruct-2512": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/ministral-3-3b-instruct-2512": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "ministral-3b-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "displayName": "Ministral 3B",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "ministral-3b-2410": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.04,
-    "output_cost_per_mil_tokens": 0.04,
-    "parent": "ministral-3b-latest"
-  },
-  "ministral-14b-2512": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "displayName": "Ministral 14B 2512",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "ministral-8b-2512": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.15,
-    "displayName": "Ministral 8B (2512)",
-    "parent": "ministral-8b-latest",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "ministral-3b-2512": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "displayName": "Ministral 3B (2512)",
-    "parent": "ministral-3b-latest",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "ministral-14b-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "displayName": "Ministral 14B",
-    "max_input_tokens": 256000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-saba-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "Mistral Saba"
-  },
-  "mistral-saba-2502": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.6,
-    "parent": "mistral-saba-latest"
-  },
-  "pixtral-12b-2409": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.15,
-    "displayName": "Pixtral 12B",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "open-mistral-nemo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.15,
-    "displayName": "Mistral NeMo",
-    "deprecation_date": "2026-07-31",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "open-mistral-nemo-2407": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.15,
-    "deprecation_date": "2026-07-31",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "open-mixtral-8x22b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 6,
-    "displayName": "Mixtral 8x22B",
-    "deprecated": true,
-    "max_input_tokens": 65336,
-    "max_output_tokens": 8191,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-tiny": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 0.25,
-    "displayName": "Mistral Tiny",
-    "deprecated": true,
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8191,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-small": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.3,
-    "displayName": "Mistral Small",
-    "deprecated": true,
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8191,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-medium": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.7,
-    "output_cost_per_mil_tokens": 8.1,
-    "displayName": "Mistral Medium",
-    "deprecated": true,
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8191,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "llama-3.3-70b-versatile": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.59,
-    "output_cost_per_mil_tokens": 0.79,
-    "displayName": "Llama 3.3 70B Versatile 128k",
-    "deprecation_date": "2026-08-16",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "groq"
-    ]
-  },
-  "llama-3.1-8b-instant": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.05,
-    "output_cost_per_mil_tokens": 0.08,
-    "displayName": "Llama 3.1 8B Instant 128k",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "groq"
-    ]
-  },
-  "accounts/fireworks/models/llama-guard-3-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-guard-3-1b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-guard-2-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "meta-llama/llama-4-scout-17b-16e-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.11,
-    "output_cost_per_mil_tokens": 0.34,
-    "displayName": "Llama 4 Scout (17Bx16E)",
-    "experimental": true,
-    "deprecation_date": "2026-07-17",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "groq"
-    ]
-  },
-  "mistral-large-2512": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 1.5,
-    "displayName": "Mistral Large (2512)",
-    "parent": "mistral-large-latest",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-small-2603": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "Mistral Small (2603)",
-    "parent": "mistral-small-latest",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-medium-2508": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.4,
-    "output_cost_per_mil_tokens": 2,
-    "displayName": "Mistral Medium (2508)",
-    "deprecation_date": "2026-05-22",
-    "parent": "mistral-medium-latest",
-    "max_input_tokens": 128000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-medium-3.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.5,
-    "output_cost_per_mil_tokens": 7.5,
-    "displayName": "Mistral Medium 3.5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 256000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-medium-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.5,
-    "output_cost_per_mil_tokens": 7.5,
-    "displayName": "Mistral Medium 3",
-    "parent": "mistral-medium-3.5",
-    "max_input_tokens": 256000,
-    "available_providers": [
-      "mistral"
     ]
   },
   "accounts/fireworks/models/kimi-k2p7-code": {
@@ -4845,19 +3955,6 @@
     "max_output_tokens": 262144,
     "available_providers": [
       "fireworks"
-    ]
-  },
-  "moonshotai/Kimi-K2.7-Code": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.95,
-    "output_cost_per_mil_tokens": 4,
-    "input_cache_read_cost_per_mil_tokens": 0.16,
-    "displayName": "Kimi K2.7 Code",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "together",
-      "baseten"
     ]
   },
   "accounts/fireworks/models/kimi-k2p6": {
@@ -4874,18 +3971,6 @@
       "fireworks"
     ]
   },
-  "moonshotai/Kimi-K2.6": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.95,
-    "output_cost_per_mil_tokens": 4,
-    "input_cache_read_cost_per_mil_tokens": 0.16,
-    "displayName": "Kimi K2.6",
-    "available_providers": [
-      "baseten",
-      "together"
-    ]
-  },
   "accounts/fireworks/models/kimi-k2p5": {
     "format": "openai",
     "flavor": "chat",
@@ -4898,17 +3983,6 @@
     "max_output_tokens": 262144,
     "available_providers": [
       "fireworks"
-    ]
-  },
-  "moonshotai/Kimi-K2.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 3,
-    "input_cache_read_cost_per_mil_tokens": 0.12,
-    "available_providers": [
-      "baseten",
-      "together"
     ]
   },
   "accounts/fireworks/models/kimi-k2-instruct": {
@@ -4935,16 +4009,6 @@
       "fireworks"
     ]
   },
-  "moonshotai/Kimi-K2-Instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 3,
-    "displayName": "Kimi K2 Instruct",
-    "available_providers": [
-      "together"
-    ]
-  },
   "accounts/fireworks/models/kimi-k2-instruct-0905": {
     "format": "openai",
     "flavor": "chat",
@@ -4956,97 +4020,74 @@
       "fireworks"
     ]
   },
-  "llama3-3-70b": {
+  "accounts/fireworks/models/minimax-m3": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.8,
-    "output_cost_per_mil_tokens": 0.8,
-    "displayName": "Llama 3.3 70B"
-  },
-  "llama3-2-3b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.03,
-    "output_cost_per_mil_tokens": 0.03,
-    "displayName": "Llama 3.2 3B"
-  },
-  "llama3-2-1b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.01,
-    "output_cost_per_mil_tokens": 0.01,
-    "displayName": "Llama 3.2 1B"
-  },
-  "llama3-1-70b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.8,
-    "output_cost_per_mil_tokens": 0.8,
-    "displayName": "Llama 3.1 70B"
-  },
-  "llama3-1-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.07,
-    "output_cost_per_mil_tokens": 0.07,
-    "displayName": "Llama 3.1 8B"
-  },
-  "llama3-70b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.8,
-    "output_cost_per_mil_tokens": 0.8,
-    "displayName": "Llama 3 70B"
-  },
-  "llama3-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.07,
-    "output_cost_per_mil_tokens": 0.07,
-    "displayName": "Llama 3 8B"
-  },
-  "wizardlm-2-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.07,
-    "output_cost_per_mil_tokens": 0.07,
-    "displayName": "WizardLM-2 7B"
-  },
-  "wizardlm-2-8x22b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 1,
-    "displayName": "WizardLM-2 8x22B"
-  },
-  "dolphin-mixtral-8x7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "displayName": "Dolphin Mixtral 8x7b"
-  },
-  "accounts/fireworks/models/llama4-maverick-instruct-basic": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.22,
-    "output_cost_per_mil_tokens": 0.88,
-    "displayName": "Llama 4 Maverick Instruct (Basic)",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 1.2,
+    "input_cache_read_cost_per_mil_tokens": 0.06,
+    "displayName": "MiniMax M3",
+    "max_input_tokens": 512000,
+    "max_output_tokens": 512000,
     "available_providers": [
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/llama4-scout-instruct-basic": {
+  "accounts/fireworks/models/minimax-m2p7": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "Llama 4 Scout Instruct (Basic)",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 1.2,
+    "input_cache_read_cost_per_mil_tokens": 0.06,
+    "displayName": "MiniMax M2.7",
+    "max_input_tokens": 196608,
+    "max_output_tokens": 196608,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/minimax-m2p5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 1.2,
+    "input_cache_read_cost_per_mil_tokens": 0.03,
+    "displayName": "MiniMax M2.5",
+    "max_input_tokens": 196608,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/minimax-m2p1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 1.2,
+    "input_cache_read_cost_per_mil_tokens": 0.03,
+    "max_input_tokens": 204800,
+    "max_output_tokens": 204800,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/minimax-m2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/minimax-m1-80k": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
     "available_providers": [
       "fireworks"
     ]
@@ -5314,6 +4355,1027 @@
       "fireworks"
     ]
   },
+  "accounts/fireworks/models/llama4-maverick-instruct-basic": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.22,
+    "output_cost_per_mil_tokens": 0.88,
+    "displayName": "Llama 4 Maverick Instruct (Basic)",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama4-scout-instruct-basic": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "Llama 4 Scout Instruct (Basic)",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-70b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-70b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-70b-python": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-34b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-34b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-34b-python": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-13b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-13b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-13b-python": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-7b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-7b-python": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mixtral-8x22b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 65536,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mixtral-8x22b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "displayName": "Mixtral MoE 8x22B Instruct",
+    "max_input_tokens": 65536,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mixtral-8x22b-instruct-hf": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 65536,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mixtral-8x7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mixtral-8x7b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "displayName": "Mixtral MoE 8x7B Instruct",
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mixtral-8x7b-instruct-hf": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-7b-instruct-4k": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-7b-instruct-v3": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-7b-instruct-v0p2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-7b-v0p2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gemma-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gemma-7b-it": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gemma-3-27b-it": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gemma2-9b-it": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gemma-2b-it": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/yi-34b-200k-capybara": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 200000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/yi-34b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/yi-34b-chat": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/yi-6b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/phi-3-mini-128k-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/phi-3-vision-128k-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "displayName": "Phi 3.5 Vision Instruct",
+    "max_input_tokens": 32064,
+    "max_output_tokens": 32064,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/phi-2-3b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 2048,
+    "max_output_tokens": 2048,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/chronos-hermes-13b-v2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-qwen-1p5-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 65536,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/codegemma-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/codegemma-2b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/cogito-671b-v2-p1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/cogito-v1-preview-llama-70b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/cogito-v1-preview-qwen-32b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/cogito-v1-preview-qwen-14b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/cogito-v1-preview-llama-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/cogito-v1-preview-llama-3b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/dbrx-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/devstral-small-2505": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/dobby-mini-unhinged-plus-llama-3-1-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/dobby-unhinged-llama-3-3-70b-new": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/dolphin-2-9-2-qwen2-72b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/dolphin-2p6-mixtral-8x7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/ernie-4p5-300b-a47b-pt": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/ernie-4p5-21b-a3b-pt": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/fare-20b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/firefunction-v2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/firefunction-v1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/firellava-13b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/firesearch-ocr-v6": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/fireworks-asr-v2": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/fireworks-asr-large": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/flux-1-dev-fp8": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.0005,
+    "output_cost_per_mil_tokens": 0.0005,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/flux-1-schnell-fp8": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.00035,
+    "output_cost_per_mil_tokens": 0.00035,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/flux-1-dev": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/flux-1-dev-controlnet-union": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.001,
+    "output_cost_per_mil_tokens": 0.001,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/flux-1-schnell": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/flux-kontext-max": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.08,
+    "output_cost_per_mil_tokens": 0.08,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/flux-kontext-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.04,
+    "output_cost_per_mil_tokens": 0.04,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gpt-oss-120b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "input_cache_read_cost_per_mil_tokens": 0.015,
+    "displayName": "GPT-OSS (120B)",
+    "reasoning": true,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gpt-oss-safeguard-120b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gpt-oss-20b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.07,
+    "output_cost_per_mil_tokens": 0.3,
+    "input_cache_read_cost_per_mil_tokens": 0.035,
+    "displayName": "GPT-OSS (20B)",
+    "reasoning": true,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gpt-oss-safeguard-20b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/hermes-2-pro-mistral-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/internvl3-78b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/internvl3-38b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/internvl3-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/japanese-stable-diffusion-xl": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.00013,
+    "output_cost_per_mil_tokens": 0.00013,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/kat-coder": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/kat-dev-72b-exp": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/kat-dev-32b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-guard-3-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-guard-3-1b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-guard-2-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llamaguard-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llava-yi-34b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/ministral-3-14b-instruct-2512": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/ministral-3-8b-instruct-2512": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/ministral-3-3b-instruct-2512": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-large-3-fp8": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-nemo-base-2407": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-nemo-instruct-2407": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
   "accounts/fireworks/models/mistral-small-24b-instruct-2501": {
     "format": "openai",
     "flavor": "chat",
@@ -5326,62 +5388,1906 @@
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/qwq-32b": {
+  "accounts/fireworks/models/mythomax-l2-13b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nemotron-nano-v2-12b-vl": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nous-capybara-7b-v1p9": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nous-hermes-llama2-70b": {
     "format": "openai",
     "flavor": "chat",
     "input_cost_per_mil_tokens": 0.9,
     "output_cost_per_mil_tokens": 0.9,
-    "displayName": "Qwen QwQ 32B",
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nous-hermes-2-yi-34b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nous-hermes-llama2-13b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nous-hermes-2-mixtral-8x7b-dpo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nous-hermes-llama2-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nvidia-nemotron-nano-12b-v2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
     "max_input_tokens": 131072,
     "max_output_tokens": 131072,
     "available_providers": [
       "fireworks"
     ]
   },
-  "gemini-3.1-pro-preview": {
+  "accounts/fireworks/models/nvidia-nemotron-nano-9b-v2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/openchat-3p5-0106-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/openhermes-2-mistral-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/openhermes-2p5-mistral-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/openorca-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/phind-code-llama-34b-v2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/phind-code-llama-34b-python-v1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/phind-code-llama-34b-v1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/playground-v2-5-1024px-aesthetic": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.00013,
+    "output_cost_per_mil_tokens": 0.00013,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/playground-v2-1024px-aesthetic": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.00013,
+    "output_cost_per_mil_tokens": 0.00013,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/pythia-12b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 2048,
+    "max_output_tokens": 2048,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/rolm-ocr": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/snorkel-mistral-7b-pairrm-dpo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/SSD-1B": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.00013,
+    "output_cost_per_mil_tokens": 0.00013,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/stable-diffusion-xl-1024-v1-0": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.00013,
+    "output_cost_per_mil_tokens": 0.00013,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/stablecode-3b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/starcoder-16b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/starcoder-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/starcoder2-15b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/starcoder2-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/starcoder2-3b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/toppy-m-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/whisper-v3": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/whisper-v3-turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/yi-large": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 3,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/zephyr-7b-beta": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks_ai/nomic-ai/nomic-embed-text-v1.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.008,
+    "max_input_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks_ai/nomic-ai/nomic-embed-text-v1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.008,
+    "max_input_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks_ai/thenlper/gte-base": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.008,
+    "max_input_tokens": 512,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks_ai/thenlper/gte-large": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.016,
+    "max_input_tokens": 512,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks_ai/WhereIsAI/UAE-Large-V1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.016,
+    "max_input_tokens": 512,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks-ai-56b-to-176b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks-ai-moe-up-to-56b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks-ai-above-16b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks-ai-4.1b-to-16b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks-ai-up-to-4b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks-ai-default": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "gpt-oss-120b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.35,
+    "output_cost_per_mil_tokens": 0.75,
+    "displayName": "OpenAI GPT-OSS (120B)",
+    "reasoning": true,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 40960,
+    "available_providers": [
+      "cerebras"
+    ]
+  },
+  "zai-glm-4.7": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.25,
+    "output_cost_per_mil_tokens": 2.75,
+    "displayName": "Z.ai GLM 4.7",
+    "reasoning": true,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 40960,
+    "available_providers": [
+      "cerebras"
+    ]
+  },
+  "gemma-4-31b": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.99,
+    "output_cost_per_mil_tokens": 1.49,
+    "displayName": "Gemma 4 31B",
+    "reasoning": true,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 40960,
+    "available_providers": [
+      "cerebras"
+    ]
+  },
+  "openai/gpt-oss-120b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.5,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "displayName": "OpenAI GPT-OSS (120B)",
+    "reasoning": true,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "groq",
+      "together",
+      "baseten"
+    ]
+  },
+  "openai/gpt-oss-20b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.075,
+    "output_cost_per_mil_tokens": 0.3,
+    "input_cache_read_cost_per_mil_tokens": 0.0375,
+    "displayName": "OpenAI GPT-OSS (20B)",
+    "reasoning": true,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "groq",
+      "together"
+    ]
+  },
+  "openai/gpt-oss-safeguard-20b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.075,
+    "output_cost_per_mil_tokens": 0.3,
+    "displayName": "GPT-OSS Safeguard (20B)",
+    "experimental": true,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "groq"
+    ]
+  },
+  "meta-llama/llama-4-scout-17b-16e-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.11,
+    "output_cost_per_mil_tokens": 0.34,
+    "displayName": "Llama 4 Scout (17Bx16E)",
+    "experimental": true,
+    "deprecation_date": "2026-07-17",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "groq"
+    ]
+  },
+  "llama-3.3-70b-versatile": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.59,
+    "output_cost_per_mil_tokens": 0.79,
+    "displayName": "Llama 3.3 70B Versatile 128k",
+    "deprecation_date": "2026-08-16",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "groq"
+    ]
+  },
+  "llama-3.1-8b-instant": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.05,
+    "output_cost_per_mil_tokens": 0.08,
+    "displayName": "Llama 3.1 8B Instant 128k",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "groq"
+    ]
+  },
+  "qwen/qwen3.6-27b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 3,
+    "displayName": "Qwen 3.6 27B",
+    "experimental": true,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "groq"
+    ]
+  },
+  "qwen/qwen3-32b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.29,
+    "output_cost_per_mil_tokens": 0.59,
+    "displayName": "Qwen3-32B",
+    "reasoning": true,
+    "experimental": true,
+    "deprecation_date": "2026-07-17",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 40960,
+    "available_providers": [
+      "groq"
+    ]
+  },
+  "groq/compound": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "groq"
+    ]
+  },
+  "groq/compound-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "groq"
+    ]
+  },
+  "text-davinci-003": {
+    "format": "openai",
+    "flavor": "completion",
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 2,
+    "displayName": "Text Davinci 003",
+    "deprecated": true
+  },
+  "publishers/anthropic/models/claude-opus-4-5@20251101": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 10,
+    "displayName": "Claude Opus 4.5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000
+  },
+  "publishers/anthropic/models/claude-opus-4-1@20250805": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 15,
+    "output_cost_per_mil_tokens": 75,
+    "input_cache_read_cost_per_mil_tokens": 1.5,
+    "input_cache_write_cost_per_mil_tokens": 18.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 18.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 30,
+    "displayName": "Claude Opus 4.1",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 32000
+  },
+  "publishers/anthropic/models/claude-opus-4": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 15,
+    "output_cost_per_mil_tokens": 75,
+    "input_cache_read_cost_per_mil_tokens": 1.5,
+    "input_cache_write_cost_per_mil_tokens": 18.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 18.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 30,
+    "displayName": "Claude Opus 4",
+    "reasoning": true,
+    "reasoning_budget": true
+  },
+  "publishers/anthropic/models/claude-opus-4@20250514": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 15,
+    "output_cost_per_mil_tokens": 75,
+    "input_cache_read_cost_per_mil_tokens": 1.5,
+    "input_cache_write_cost_per_mil_tokens": 18.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 18.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 30,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "publishers/anthropic/models/claude-opus-4"
+  },
+  "claude-instant-1.2": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.163,
+    "output_cost_per_mil_tokens": 0.551,
+    "displayName": "Claude Instant 1.2",
+    "deprecated": true,
+    "max_input_tokens": 100000,
+    "max_output_tokens": 8191
+  },
+  "claude-instant-1": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.63,
+    "output_cost_per_mil_tokens": 5.51,
+    "displayName": "Claude Instant 1",
+    "deprecated": true,
+    "max_input_tokens": 100000,
+    "max_output_tokens": 8191
+  },
+  "claude-2.1": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 8,
+    "output_cost_per_mil_tokens": 24,
+    "displayName": "Claude 2.1",
+    "deprecated": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8191
+  },
+  "claude-2.0": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 8,
+    "output_cost_per_mil_tokens": 24,
+    "displayName": "Claude 2.0",
+    "deprecated": true
+  },
+  "claude-2": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 8,
+    "output_cost_per_mil_tokens": 24,
+    "displayName": "Claude 2",
+    "deprecated": true,
+    "max_input_tokens": 100000,
+    "max_output_tokens": 8191
+  },
+  "meta/llama-2-70b-chat": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.65,
+    "output_cost_per_mil_tokens": 2.75,
+    "displayName": "LLaMA 2 70b Chat"
+  },
+  "mistralai/Mistral-7B-Instruct-v0.3": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "displayName": "Mistral (7B) Instruct v0.3"
+  },
+  "mistralai/Mistral-7B-Instruct-v0.2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "displayName": "Mistral (7B) Instruct v0.2"
+  },
+  "mistral-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.07,
+    "output_cost_per_mil_tokens": 0.07,
+    "displayName": "Mistral 7B"
+  },
+  "mistral": {
+    "format": "openai",
+    "flavor": "chat"
+  },
+  "phi": {
+    "format": "openai",
+    "flavor": "chat",
+    "deprecated": true
+  },
+  "meta-llama/Llama-3.2-90B-Vision-Instruct-Turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "displayName": "Llama 3.2 90B Vision Instruct Turbo"
+  },
+  "meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.18,
+    "output_cost_per_mil_tokens": 0.18,
+    "displayName": "Llama 3.2 11B Vision Instruct Turbo"
+  },
+  "meta-llama/Llama-Vision-Free": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Llama Vision Free"
+  },
+  "meta-llama/Llama-3-70b-chat-hf": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "displayName": "Llama 3 70B Instruct Reference"
+  },
+  "meta-llama/Meta-Llama-3-70B-Instruct-Turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.88,
+    "output_cost_per_mil_tokens": 0.88,
+    "displayName": "Llama 3 70B Instruct Turbo"
+  },
+  "meta-llama/Meta-Llama-3-70B-Instruct-Lite": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.54,
+    "output_cost_per_mil_tokens": 0.54,
+    "displayName": "Llama 3 70B Instruct Lite"
+  },
+  "meta-llama/Llama-3-8b-chat-hf": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "displayName": "Llama 3 8B Instruct Reference"
+  },
+  "meta-llama/Meta-Llama-3-8B-Instruct-Lite": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "displayName": "Llama 3 8B Instruct Lite"
+  },
+  "google/gemma-2-27b-it": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.35,
+    "output_cost_per_mil_tokens": 1.05,
+    "displayName": "Gemma-2 Instruct (27B)",
+    "max_output_tokens": 8192
+  },
+  "google/gemma-2-9b-it": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.35,
+    "output_cost_per_mil_tokens": 1.05,
+    "displayName": "Gemma-2 Instruct (9B)",
+    "max_output_tokens": 8192
+  },
+  "google/gemma-2b-it": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "displayName": "Gemma Instruct (2B)"
+  },
+  "mistralai/Mixtral-8x22B-Instruct-v0.1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "displayName": "Mixtral 8x22B Instruct v0.1"
+  },
+  "mistralai/Mixtral-8x22B": {
+    "format": "openai",
+    "flavor": "completion",
+    "input_cost_per_mil_tokens": 1.08,
+    "output_cost_per_mil_tokens": 1.08,
+    "displayName": "Mixtral 8x22B",
+    "deprecated": true
+  },
+  "mixtral-8x7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "displayName": "Mixtral 8x7b"
+  },
+  "deepseek-ai/deepseek-llm-67b-chat": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "displayName": "DeepSeek LLM Chat (67B)"
+  },
+  "deepseek-ai/deepseek-coder-33b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.8,
+    "output_cost_per_mil_tokens": 0.8,
+    "displayName": "Deepseek Coder 33b Instruct",
+    "deprecated": true
+  },
+  "deepseek-ai/DeepSeek-R1-Distill-Llama-70B": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 2,
+    "displayName": "DeepSeek R1 Distill Llama 70B"
+  },
+  "deepseek-ai/DeepSeek-R1-Distill-Llama-70B-Free": {
+    "format": "openai",
+    "flavor": "chat",
+    "displayName": "DeepSeek R1 Distill Llama 70B Free"
+  },
+  "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.6,
+    "output_cost_per_mil_tokens": 1.6,
+    "displayName": "DeepSeek R1 Distill Qwen 14B"
+  },
+  "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.18,
+    "output_cost_per_mil_tokens": 0.18,
+    "displayName": "DeepSeek R1 Distill Qwen 1.5B"
+  },
+  "publishers/qwen/models/qwen3-235b-a22b-instruct-2507-maas": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.22,
+    "output_cost_per_mil_tokens": 0.88,
+    "displayName": "Qwen3 235B A22B Instruct 2507",
+    "locations": [
+      "global",
+      "us-south1"
+    ],
+    "max_input_tokens": 262144,
+    "max_output_tokens": 16384
+  },
+  "Qwen/Qwen2.5-Coder-32B-Instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.8,
+    "output_cost_per_mil_tokens": 0.8,
+    "displayName": "Qwen 2.5 Coder 32B Instruct"
+  },
+  "Qwen/Qwen2-72B-Instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "displayName": "Qwen 2 Instruct (72B)"
+  },
+  "Qwen/Qwen2-VL-72B-Instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "displayName": "Qwen-2VL (72B) Instruct"
+  },
+  "Qwen/QwQ-32B": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.8,
+    "output_cost_per_mil_tokens": 0.8,
+    "displayName": "Qwen QwQ 32B"
+  },
+  "nvidia/Llama-3.1-Nemotron-70B-Instruct-HF": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.88,
+    "output_cost_per_mil_tokens": 0.88,
+    "displayName": "Llama 3.1 Nemotron 70B Instruct HF"
+  },
+  "microsoft/WizardLM-2-8x22B": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "displayName": "WizardLM-2 (8x22B)"
+  },
+  "NousResearch/Nous-Hermes-2-Yi-34B": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.8,
+    "output_cost_per_mil_tokens": 0.8,
+    "displayName": "Nous Hermes 2 Yi 34B",
+    "deprecated": true
+  },
+  "nous-hermes-llama2-13b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.18,
+    "output_cost_per_mil_tokens": 0.18,
+    "displayName": "Nous: Hermes 13B"
+  },
+  "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "Nous Hermes 2 - Mixtral 8x7B-DPO"
+  },
+  "Gryphe/MythoMax-L2-13b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 0.3,
+    "displayName": "MythoMax-L2 (13B)"
+  },
+  "Gryphe/MythoMax-L2-13b-Lite": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "displayName": "Gryphe MythoMax L2 Lite (13B)"
+  },
+  "meta-llama/Meta-Llama-3-70B": {
+    "format": "openai",
+    "flavor": "completion",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "displayName": "Llama 3 70b",
+    "deprecated": true
+  },
+  "meta-llama/Llama-3-8b-hf": {
+    "format": "openai",
+    "flavor": "completion",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "displayName": "Llama 3 8b HF",
+    "deprecated": true
+  },
+  "meta-llama/Llama-2-70b-chat-hf": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "displayName": "Llama 2 70b Chat HF",
+    "deprecated": true
+  },
+  "Qwen/QwQ-32B-Preview": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.8,
+    "output_cost_per_mil_tokens": 0.8,
+    "displayName": "Qwen QwQ 32B Preview",
+    "deprecated": true
+  },
+  "mistral-small-2501": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.3,
+    "parent": "mistral-small-latest"
+  },
+  "ministral-8b-2410": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "parent": "ministral-8b-latest"
+  },
+  "ministral-3b-2410": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.04,
+    "output_cost_per_mil_tokens": 0.04,
+    "parent": "ministral-3b-latest"
+  },
+  "mistral-saba-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "Mistral Saba"
+  },
+  "mistral-saba-2502": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.6,
+    "parent": "mistral-saba-latest"
+  },
+  "llama3-3-70b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.8,
+    "output_cost_per_mil_tokens": 0.8,
+    "displayName": "Llama 3.3 70B"
+  },
+  "llama3-2-3b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.03,
+    "output_cost_per_mil_tokens": 0.03,
+    "displayName": "Llama 3.2 3B"
+  },
+  "llama3-2-1b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.01,
+    "output_cost_per_mil_tokens": 0.01,
+    "displayName": "Llama 3.2 1B"
+  },
+  "llama3-1-70b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.8,
+    "output_cost_per_mil_tokens": 0.8,
+    "displayName": "Llama 3.1 70B"
+  },
+  "llama3-1-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.07,
+    "output_cost_per_mil_tokens": 0.07,
+    "displayName": "Llama 3.1 8B"
+  },
+  "llama3-70b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.8,
+    "output_cost_per_mil_tokens": 0.8,
+    "displayName": "Llama 3 70B"
+  },
+  "llama3-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.07,
+    "output_cost_per_mil_tokens": 0.07,
+    "displayName": "Llama 3 8B"
+  },
+  "wizardlm-2-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.07,
+    "output_cost_per_mil_tokens": 0.07,
+    "displayName": "WizardLM-2 7B"
+  },
+  "wizardlm-2-8x22b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 1,
+    "displayName": "WizardLM-2 8x22B"
+  },
+  "dolphin-mixtral-8x7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "displayName": "Dolphin Mixtral 8x7b"
+  },
+  "gemini-1.5-flash-8b-latest": {
     "format": "google",
     "flavor": "chat",
     "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 12,
+    "input_cost_per_mil_tokens": 0.0375,
+    "output_cost_per_mil_tokens": 0.15,
+    "parent": "gemini-1.5-flash-8b"
+  },
+  "gemini-1.5-flash-8b-001": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.0375,
+    "output_cost_per_mil_tokens": 0.15,
+    "parent": "gemini-1.5-flash-8b"
+  },
+  "grok-4-fast-non-reasoning-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 2.5,
     "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Gemini 3.1 Pro (Preview)",
+    "displayName": "Grok 4 Fast (Non-Reasoning)",
+    "deprecated": true,
+    "deprecation_date": "2026-05-15",
+    "max_input_tokens": 2000000,
+    "max_output_tokens": 2000000
+  },
+  "grok-4-fast-reasoning-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 2.5,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "Grok 4 Fast",
+    "deprecated": true,
+    "deprecation_date": "2026-05-15",
+    "max_input_tokens": 2000000,
+    "max_output_tokens": 2000000
+  },
+  "publishers/google/models/gemini-1.0-pro-vision": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 1.0 Pro Vision"
+  },
+  "publishers/google/models/gemini-1.0-pro-vision-001": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "parent": "publishers/google/models/gemini-1.0-pro-vision"
+  },
+  "publishers/google/models/gemini-1.0-pro-002": {
+    "format": "google",
+    "flavor": "chat",
+    "parent": "publishers/google/models/gemini-1.0-pro"
+  },
+  "publishers/google/models/gemini-1.0-pro-001": {
+    "format": "google",
+    "flavor": "chat",
+    "parent": "publishers/google/models/gemini-1.0-pro"
+  },
+  "publishers/anthropic/models/claude-sonnet-4-5@20250929": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": true,
+    "parent": "publishers/anthropic/models/claude-sonnet-4-5"
+  },
+  "publishers/anthropic/models/claude-sonnet-4": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "displayName": "Claude Sonnet 4",
+    "reasoning": true,
+    "reasoning_budget": true
+  },
+  "publishers/anthropic/models/claude-sonnet-4@20250514": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": true,
+    "parent": "publishers/anthropic/models/claude-sonnet-4"
+  },
+  "publishers/anthropic/models/claude-3-7-sonnet": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "displayName": "Claude Sonnet 3.7",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "deprecation_date": "2026-02-19"
+  },
+  "publishers/anthropic/models/claude-3-7-sonnet@20250219": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": true,
+    "deprecation_date": "2026-02-19",
+    "parent": "publishers/anthropic/models/claude-3-7-sonnet"
+  },
+  "publishers/anthropic/models/claude-haiku-4-5@20251001": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 5,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "input_cache_write_cost_per_mil_tokens": 1.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 1.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 2,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "publishers/anthropic/models/claude-haiku-4-5",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000
+  },
+  "publishers/anthropic/models/claude-3-5-haiku": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.8,
+    "output_cost_per_mil_tokens": 4,
+    "input_cache_read_cost_per_mil_tokens": 0.08,
+    "input_cache_write_cost_per_mil_tokens": 1,
+    "input_cache_write_5m_cost_per_mil_tokens": 1,
+    "input_cache_write_1h_cost_per_mil_tokens": 1.6,
+    "displayName": "Claude Haiku 3.5",
+    "deprecation_date": "2026-02-19",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8192
+  },
+  "publishers/anthropic/models/claude-3-5-haiku@20241022": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.8,
+    "output_cost_per_mil_tokens": 4,
+    "input_cache_read_cost_per_mil_tokens": 0.08,
+    "input_cache_write_cost_per_mil_tokens": 1,
+    "input_cache_write_5m_cost_per_mil_tokens": 1,
+    "input_cache_write_1h_cost_per_mil_tokens": 1.6,
+    "deprecation_date": "2026-02-19",
+    "parent": "publishers/anthropic/models/claude-3-5-haiku",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8192
+  },
+  "publishers/anthropic/models/claude-3-5-sonnet-v2": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "displayName": "Claude Sonnet 3.5 v2"
+  },
+  "publishers/anthropic/models/claude-3-5-sonnet-v2@20241022": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "parent": "publishers/anthropic/models/claude-3-5-sonnet-v2"
+  },
+  "publishers/anthropic/models/claude-3-5-sonnet": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "displayName": "Claude Sonnet 3.5"
+  },
+  "publishers/anthropic/models/claude-3-5-sonnet@20240620": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "parent": "publishers/anthropic/models/claude-3-5-sonnet"
+  },
+  "publishers/anthropic/models/claude-3-opus": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 15,
+    "output_cost_per_mil_tokens": 75,
+    "input_cache_read_cost_per_mil_tokens": 1.5,
+    "input_cache_write_cost_per_mil_tokens": 18.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 18.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 30,
+    "displayName": "Claude Opus 3"
+  },
+  "publishers/anthropic/models/claude-3-opus@20240229": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 15,
+    "output_cost_per_mil_tokens": 75,
+    "input_cache_read_cost_per_mil_tokens": 1.5,
+    "input_cache_write_cost_per_mil_tokens": 18.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 18.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 30,
+    "parent": "publishers/anthropic/models/claude-3-opus"
+  },
+  "publishers/anthropic/models/claude-3-haiku": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 1.25,
+    "input_cache_read_cost_per_mil_tokens": 0.03,
+    "input_cache_write_cost_per_mil_tokens": 0.3,
+    "input_cache_write_5m_cost_per_mil_tokens": 0.3,
+    "input_cache_write_1h_cost_per_mil_tokens": 0.5,
+    "displayName": "Claude Haiku 3"
+  },
+  "publishers/anthropic/models/claude-3-haiku@20240307": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 1.25,
+    "input_cache_read_cost_per_mil_tokens": 0.03,
+    "input_cache_write_cost_per_mil_tokens": 0.3,
+    "input_cache_write_5m_cost_per_mil_tokens": 0.3,
+    "input_cache_write_1h_cost_per_mil_tokens": 0.5,
+    "parent": "publishers/anthropic/models/claude-3-haiku"
+  },
+  "publishers/meta/models/llama-3.1-401b-instruct-maas": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 16,
+    "displayName": "Llama 3.1 401B Instruct"
+  },
+  "publishers/mistralai/models/mistral-nemo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.15,
+    "displayName": "Mistral Nemo"
+  },
+  "publishers/meta/models/llama-3.3-70b-instruct-maas": {
+    "format": "openai",
+    "flavor": "chat",
+    "displayName": "Llama 3.3 70B Instruct",
+    "experimental": true
+  },
+  "publishers/meta/models/llama-3.2-90b-vision-instruct-maas": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Llama 3.2 90B Vision Instruct",
+    "experimental": true
+  },
+  "publishers/meta/models/llama-3.1-70b-instruct-maas": {
+    "format": "openai",
+    "flavor": "chat",
+    "displayName": "Llama 3.1 70B Instruct",
+    "experimental": true
+  },
+  "publishers/meta/models/llama-3.1-8b-instruct-maas": {
+    "format": "openai",
+    "flavor": "chat",
+    "displayName": "Llama 3.1 8B Instruct",
+    "experimental": true
+  },
+  "publishers/google/models/gemini-2.0-flash-lite-preview-02-05": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.075,
+    "output_cost_per_mil_tokens": 0.3,
+    "displayName": "Gemini 2.0 Flash-Lite",
+    "deprecated": true
+  },
+  "text-block": {
+    "format": "js",
+    "flavor": "completion",
+    "displayName": "Text-block"
+  },
+  "meta.llama4-scout-17b-instruct-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Llama 4 Scout",
+    "max_input_tokens": 10000000,
+    "max_output_tokens": 8000
+  },
+  "meta.llama4-maverick-17b-instruct-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Llama 4 Maverick",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8000
+  },
+  "claude-fable-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 10,
+    "output_cost_per_mil_tokens": 50,
+    "input_cache_read_cost_per_mil_tokens": 1,
+    "input_cache_write_cost_per_mil_tokens": 12.5,
+    "input_cache_write_5m_cost_per_mil_tokens": 12.5,
+    "input_cache_write_1h_cost_per_mil_tokens": 20,
+    "displayName": "Claude Fable 5",
     "reasoning": true,
     "reasoning_budget": true,
     "fallback_models": [
-      "publishers/google/models/gemini-3.1-pro-preview"
+      "anthropic.claude-fable-5",
+      "global.anthropic.claude-fable-5",
+      "publishers/anthropic/models/claude-fable-5"
     ],
-    "supported_regions": [
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "anthropic"
+    ]
+  },
+  "claude-opus-4-8": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 10,
+    "displayName": "Claude Opus 4.8",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "fallback_models": [
+      "anthropic.claude-opus-4-8",
+      "global.anthropic.claude-opus-4-8",
+      "publishers/anthropic/models/claude-opus-4-8",
+      "us.anthropic.claude-opus-4-8"
+    ],
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "anthropic"
+    ]
+  },
+  "claude-opus-4-7": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 10,
+    "displayName": "Claude Opus 4.7",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "fallback_models": [
+      "anthropic.claude-opus-4-7",
+      "global.anthropic.claude-opus-4-7",
+      "publishers/anthropic/models/claude-opus-4-7",
+      "us.anthropic.claude-opus-4-7"
+    ],
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "anthropic"
+    ]
+  },
+  "claude-opus-4-6": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 10,
+    "displayName": "Claude Opus 4.6",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "fallback_models": [
+      "publishers/anthropic/models/claude-opus-4-6"
+    ],
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "anthropic"
+    ]
+  },
+  "claude-opus-4-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 10,
+    "displayName": "Claude Opus 4.5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "anthropic"
+    ]
+  },
+  "claude-opus-4-5-20251101": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 10,
+    "displayName": "Claude Opus 4.5 (2025-11-01)",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "claude-opus-4-5",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "anthropic"
+    ]
+  },
+  "claude-opus-4-1": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 15,
+    "output_cost_per_mil_tokens": 75,
+    "input_cache_read_cost_per_mil_tokens": 1.5,
+    "input_cache_write_cost_per_mil_tokens": 18.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 18.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 30,
+    "displayName": "Claude Opus 4.1",
+    "reasoning": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 32000,
+    "available_providers": [
+      "anthropic"
+    ]
+  },
+  "claude-opus-4-1-20250805": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 15,
+    "output_cost_per_mil_tokens": 75,
+    "input_cache_read_cost_per_mil_tokens": 1.5,
+    "input_cache_write_cost_per_mil_tokens": 18.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 18.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 30,
+    "displayName": "Claude Opus 4.1 (2025-08-05)",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "deprecation_date": "2026-08-05",
+    "parent": "claude-opus-4-1",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 32000,
+    "available_providers": [
+      "anthropic"
+    ]
+  },
+  "claude-sonnet-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "input_cache_write_cost_per_mil_tokens": 2.5,
+    "input_cache_write_5m_cost_per_mil_tokens": 2.5,
+    "input_cache_write_1h_cost_per_mil_tokens": 4,
+    "displayName": "Claude Sonnet 5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "fallback_models": [
+      "anthropic.claude-sonnet-5",
+      "global.anthropic.claude-sonnet-5",
+      "publishers/anthropic/models/claude-sonnet-5",
+      "us.anthropic.claude-sonnet-5"
+    ],
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "anthropic"
+    ]
+  },
+  "claude-sonnet-4-6": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "displayName": "Claude Sonnet 4.6",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "fallback_models": [
+      "anthropic.claude-sonnet-4-6",
+      "global.anthropic.claude-sonnet-4-6",
+      "publishers/anthropic/models/claude-sonnet-4-6",
+      "us.anthropic.claude-sonnet-4-6"
+    ],
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "anthropic"
+    ]
+  },
+  "claude-sonnet-4-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "displayName": "Claude Sonnet 4.5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "fallback_models": [
+      "publishers/anthropic/models/claude-sonnet-4-5"
+    ],
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "anthropic"
+    ]
+  },
+  "claude-sonnet-4-5-20250929": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "displayName": "Claude Sonnet 4.5 (2025-09-29)",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "claude-sonnet-4-5",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "anthropic"
+    ]
+  },
+  "claude-haiku-4-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 5,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "input_cache_write_cost_per_mil_tokens": 1.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 1.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 2,
+    "displayName": "Claude Haiku 4.5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "fallback_models": [
+      "publishers/anthropic/models/claude-haiku-4-5"
+    ],
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "anthropic"
+    ]
+  },
+  "claude-haiku-4-5-20251001": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 5,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "input_cache_write_cost_per_mil_tokens": 1.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 1.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 2,
+    "displayName": "Claude Haiku 4.5 (2025-10-01)",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "claude-haiku-4-5",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "anthropic"
+    ]
+  },
+  "publishers/google/models/gemini-3.5-flash": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.5,
+    "output_cost_per_mil_tokens": 9,
+    "input_cache_read_cost_per_mil_tokens": 0.15,
+    "displayName": "Gemini 3.5 Flash",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "locations": [
+      "global"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-3.1-flash-image": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 3,
+    "displayName": "Gemini 3.1 Flash Image",
+    "locations": [
+      "global"
+    ],
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-3.1-flash-image-preview": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 3,
+    "displayName": "Gemini 3.1 Flash Image Preview",
+    "locations": [
+      "global"
+    ],
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-3.1-flash-lite": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 1.5,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "displayName": "Gemini 3.1 Flash-Lite",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "locations": [
       "global"
     ],
     "max_input_tokens": 1048576,
     "max_output_tokens": 65536,
     "available_providers": [
-      "google",
       "vertex"
     ]
   },
-  "gemini-3.1-pro-preview-customtools": {
+  "publishers/google/models/gemini-3.1-flash-lite-image": {
     "format": "google",
     "flavor": "chat",
     "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 12,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Gemini 3.1 Pro Custom Tools (Preview)",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "fallback_models": [
-      "publishers/google/models/gemini-3.1-pro-preview-customtools"
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 1.5,
+    "displayName": "Gemini 3.1 Flash-Lite Image",
+    "locations": [
+      "global"
     ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
+    "max_input_tokens": 65536,
+    "max_output_tokens": 4096,
     "available_providers": [
-      "google",
       "vertex"
     ]
   },
-  "gemini-3.1-flash-lite-preview": {
+  "publishers/google/models/gemini-3.1-flash-lite-preview": {
     "format": "google",
     "flavor": "chat",
     "multimodal": true,
@@ -5391,52 +7297,146 @@
     "displayName": "Gemini 3.1 Flash-Lite (Preview)",
     "reasoning": true,
     "reasoning_budget": true,
-    "fallback_models": [
-      "publishers/google/models/gemini-3.1-flash-lite-preview"
-    ],
-    "supported_regions": [
+    "locations": [
       "global"
     ],
     "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
+    "max_output_tokens": 65535,
     "available_providers": [
-      "google",
       "vertex"
     ]
   },
-  "gemini-3-pro-preview": {
+  "publishers/google/models/gemini-3.1-pro-preview": {
     "format": "google",
     "flavor": "chat",
     "multimodal": true,
     "input_cost_per_mil_tokens": 2,
     "output_cost_per_mil_tokens": 12,
     "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Gemini 3 Pro (Preview)",
+    "displayName": "Gemini 3.1 Pro Preview",
     "reasoning": true,
     "reasoning_budget": true,
-    "deprecation_date": "2026-03-09",
-    "fallback_models": [
-      "publishers/google/models/gemini-3-pro-preview"
+    "locations": [
+      "global"
     ],
     "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
+    "max_output_tokens": 65536,
     "available_providers": [
-      "google",
       "vertex"
     ]
   },
-  "gemini-3-flash-preview": {
+  "publishers/google/models/gemini-3.1-pro-preview-customtools": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 12,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "Gemini 3.1 Pro Custom Tools Preview",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "locations": [
+      "global"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-3-flash-preview": {
     "format": "google",
     "flavor": "chat",
     "multimodal": true,
     "input_cost_per_mil_tokens": 0.5,
     "output_cost_per_mil_tokens": 3,
     "input_cache_read_cost_per_mil_tokens": 0.05,
-    "displayName": "Gemini 3 Flash (Preview)",
+    "displayName": "Gemini 3 Flash Preview",
     "reasoning": true,
     "reasoning_budget": true,
+    "locations": [
+      "global"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-3-pro-image": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 12,
+    "displayName": "Gemini 3 Pro Image",
+    "locations": [
+      "global"
+    ],
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-3-pro-image-preview": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 12,
+    "displayName": "Gemini 3 Pro Image Preview",
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-3-pro-preview": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 12,
+    "input_cache_read_cost_per_mil_tokens": 0.3125,
+    "displayName": "Gemini 3 Pro Preview",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "locations": [
+      "global"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-computer-use-preview-10-2025": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "Gemini 2.5 Computer Use Preview (10-2025)",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-2.5-flash-lite-preview-09-2025": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "input_cache_read_cost_per_mil_tokens": 0.01,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": true,
+    "parent": "gemini-2.5-flash-lite",
     "fallback_models": [
-      "publishers/google/models/gemini-3-flash-preview"
+      "publishers/google/models/gemini-2.5-flash-lite-preview-09-2025"
     ],
     "supported_regions": [
       "global"
@@ -5444,117 +7444,6 @@
     "max_input_tokens": 1048576,
     "max_output_tokens": 65535,
     "available_providers": [
-      "google",
-      "vertex"
-    ]
-  },
-  "gemini-embedding-2": {
-    "format": "google",
-    "flavor": "embedding",
-    "multimodal": true,
-    "displayName": "Gemini embedding 2",
-    "fallback_models": [
-      "publishers/google/models/gemini-embedding-2"
-    ],
-    "available_providers": [
-      "google",
-      "vertex"
-    ]
-  },
-  "gemini-embedding-001": {
-    "format": "google",
-    "flavor": "embedding",
-    "displayName": "Gemini embedding 001",
-    "fallback_models": [
-      "publishers/google/models/gemini-embedding-001"
-    ],
-    "available_providers": [
-      "google",
-      "vertex"
-    ]
-  },
-  "gemini-2.5-flash": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 2.5,
-    "input_cache_read_cost_per_mil_tokens": 0.03,
-    "displayName": "Gemini 2.5 Flash",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "fallback_models": [
-      "publishers/google/models/gemini-2.5-flash"
-    ],
-    "supported_regions": [
-      "global",
-      "asia-northeast1",
-      "asia-northeast3",
-      "asia-south1",
-      "asia-southeast1",
-      "australia-southeast1",
-      "europe-central2",
-      "europe-north1",
-      "europe-southwest1",
-      "europe-west1",
-      "europe-west2",
-      "europe-west3",
-      "europe-west4",
-      "europe-west8",
-      "europe-west9",
-      "northamerica-northeast1",
-      "southamerica-east1",
-      "us-central1",
-      "us-east1",
-      "us-east4",
-      "us-east5",
-      "us-south1",
-      "us-west1",
-      "us-west4"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "google",
-      "vertex"
-    ]
-  },
-  "gemini-2.5-pro": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "Gemini 2.5 Pro",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "fallback_models": [
-      "publishers/google/models/gemini-2.5-pro"
-    ],
-    "supported_regions": [
-      "global",
-      "asia-northeast1",
-      "europe-central2",
-      "europe-north1",
-      "europe-southwest1",
-      "europe-west1",
-      "europe-west4",
-      "europe-west8",
-      "europe-west9",
-      "northamerica-northeast1",
-      "us-central1",
-      "us-east1",
-      "us-east4",
-      "us-east5",
-      "us-south1",
-      "us-west1",
-      "us-west4"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "google",
       "vertex"
     ]
   },
@@ -5575,6 +7464,90 @@
     "supported_regions": [
       "global"
     ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-flash-lite-preview-09-2025": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": true,
+    "parent": "publishers/google/models/gemini-2.5-flash-lite",
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-flash-preview-09-2025": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "publishers/google/models/gemini-2.5-flash",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-2.5-flash-lite-preview-06-17": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": true,
+    "deprecated": true,
+    "deprecation_date": "2025-11-18",
+    "parent": "gemini-2.5-flash-lite",
+    "fallback_models": [
+      "publishers/google/models/gemini-2.5-flash-lite-preview-06-17"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-flash-lite-preview-06-17": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": true,
+    "deprecated": true,
+    "parent": "publishers/google/models/gemini-2.5-flash-lite",
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-2.5-pro-preview-06-05": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": false,
+    "deprecated": true,
+    "parent": "gemini-2.5-pro",
     "max_input_tokens": 1048576,
     "max_output_tokens": 65535,
     "available_providers": [
@@ -5603,6 +7576,50 @@
       "vertex"
     ]
   },
+  "publishers/google/models/gemini-2.5-flash-preview-05-20": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "deprecated": true,
+    "parent": "publishers/google/models/gemini-2.5-flash",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-2.5-pro-preview-05-06": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": false,
+    "deprecated": true,
+    "deprecation_date": "2025-12-02",
+    "parent": "gemini-2.5-pro",
+    "fallback_models": [
+      "publishers/google/models/gemini-2.5-pro-preview-05-06"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-pro-preview-05-06": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "deprecated": true,
+    "parent": "publishers/google/models/gemini-2.5-pro",
+    "available_providers": [
+      "vertex"
+    ]
+  },
   "gemini-2.5-flash-preview-04-17": {
     "format": "google",
     "flavor": "chat",
@@ -5624,25 +7641,21 @@
       "vertex"
     ]
   },
-  "gemini-2.5-pro-preview-06-05": {
+  "publishers/google/models/gemini-2.5-flash-preview-04-17": {
     "format": "google",
     "flavor": "chat",
     "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
     "reasoning": true,
     "reasoning_budget": true,
-    "experimental": false,
     "deprecated": true,
-    "parent": "gemini-2.5-pro",
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
+    "parent": "publishers/google/models/gemini-2.5-flash",
     "available_providers": [
       "vertex"
     ]
   },
-  "gemini-2.5-pro-preview-05-06": {
+  "gemini-2.5-pro-exp-03-25": {
     "format": "google",
     "flavor": "chat",
     "multimodal": true,
@@ -5650,13 +7663,10 @@
     "output_cost_per_mil_tokens": 10,
     "input_cache_read_cost_per_mil_tokens": 0.125,
     "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": false,
-    "deprecated": true,
-    "deprecation_date": "2025-12-02",
+    "experimental": true,
     "parent": "gemini-2.5-pro",
     "fallback_models": [
-      "publishers/google/models/gemini-2.5-pro-preview-05-06"
+      "publishers/google/models/gemini-2.5-pro-exp-03-25"
     ],
     "max_input_tokens": 1048576,
     "max_output_tokens": 65535,
@@ -5686,304 +7696,85 @@
       "vertex"
     ]
   },
-  "gemini-2.5-pro-exp-03-25": {
+  "publishers/google/models/gemini-2.5-pro-exp-03-25": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 2.5 Pro Experimental",
+    "experimental": true,
+    "parent": "publishers/google/models/gemini-2.5-pro",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-pro-preview-03-25": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "deprecated": true,
+    "parent": "publishers/google/models/gemini-2.5-pro",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-flash": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 2.5,
+    "displayName": "Gemini 2.5 Flash",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-flash-image": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 2.5,
+    "displayName": "Gemini 2.5 Flash Image",
+    "locations": [
+      "global"
+    ],
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-flash-lite": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "displayName": "Gemini 2.5 Flash-Lite",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-pro": {
     "format": "google",
     "flavor": "chat",
     "multimodal": true,
     "input_cost_per_mil_tokens": 1.25,
     "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "reasoning": true,
-    "experimental": true,
-    "parent": "gemini-2.5-pro",
-    "fallback_models": [
-      "publishers/google/models/gemini-2.5-pro-exp-03-25"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-2.5-flash-lite-preview-09-2025": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "input_cache_read_cost_per_mil_tokens": 0.01,
+    "displayName": "Gemini 2.5 Pro",
     "reasoning": true,
     "reasoning_budget": true,
-    "experimental": true,
-    "parent": "gemini-2.5-flash-lite",
-    "fallback_models": [
-      "publishers/google/models/gemini-2.5-flash-lite-preview-09-2025"
-    ],
-    "supported_regions": [
-      "global"
-    ],
     "max_input_tokens": 1048576,
     "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-2.5-flash-lite-preview-06-17": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": true,
-    "deprecated": true,
-    "deprecation_date": "2025-11-18",
-    "parent": "gemini-2.5-flash-lite",
-    "fallback_models": [
-      "publishers/google/models/gemini-2.5-flash-lite-preview-06-17"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-2.5-flash-lite": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "input_cache_read_cost_per_mil_tokens": 0.01,
-    "displayName": "Gemini 2.5 Flash-Lite",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "fallback_models": [
-      "publishers/google/models/gemini-2.5-flash-lite"
-    ],
-    "supported_regions": [
-      "global",
-      "europe-central2",
-      "europe-north1",
-      "europe-southwest1",
-      "europe-west1",
-      "europe-west4",
-      "europe-west8",
-      "europe-west9",
-      "us-central1",
-      "us-east1",
-      "us-east4",
-      "us-east5",
-      "us-south1",
-      "us-west1",
-      "us-west4"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "google",
-      "vertex"
-    ]
-  },
-  "gemini-2.0-flash": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "displayName": "Gemini 2.0 Flash Latest",
-    "deprecation_date": "2026-06-01",
-    "fallback_models": [
-      "publishers/google/models/gemini-2.0-flash"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "google",
-      "vertex"
-    ]
-  },
-  "gemini-2.0-flash-001": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "deprecation_date": "2026-06-01",
-    "parent": "gemini-2.0-flash",
-    "fallback_models": [
-      "publishers/google/models/gemini-2.0-flash-001"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "google",
-      "vertex"
-    ]
-  },
-  "gemini-2.0-flash-lite": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.075,
-    "output_cost_per_mil_tokens": 0.3,
-    "input_cache_read_cost_per_mil_tokens": 0.01875,
-    "displayName": "Gemini 2.0 Flash-Lite",
-    "deprecation_date": "2026-06-01",
-    "fallback_models": [
-      "publishers/google/models/gemini-2.0-flash-lite"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "google",
-      "vertex"
-    ]
-  },
-  "gemini-2.0-flash-lite-001": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.075,
-    "output_cost_per_mil_tokens": 0.3,
-    "input_cache_read_cost_per_mil_tokens": 0.01875,
-    "deprecation_date": "2026-06-01",
-    "parent": "gemini-2.0-flash-lite",
-    "fallback_models": [
-      "publishers/google/models/gemini-2.0-flash-lite-001"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "google",
-      "vertex"
-    ]
-  },
-  "gemini-3-pro-image-preview": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 12,
-    "displayName": "Gemini 3 Pro Image Preview",
-    "fallback_models": [
-      "publishers/google/models/gemini-3-pro-image-preview"
-    ],
-    "supported_regions": [
-      "global"
-    ],
-    "max_input_tokens": 65536,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "google",
-      "vertex"
-    ]
-  },
-  "gemini-1.5-flash-001": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.075,
-    "output_cost_per_mil_tokens": 0.3,
-    "input_cache_read_cost_per_mil_tokens": 0.01875,
-    "input_cache_write_cost_per_mil_tokens": 1,
-    "deprecation_date": "2025-05-24",
-    "parent": "gemini-1.5-flash",
-    "fallback_models": [
-      "publishers/google/models/gemini-1.5-flash-001"
-    ],
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-1.5-flash-002": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.075,
-    "output_cost_per_mil_tokens": 0.3,
-    "input_cache_read_cost_per_mil_tokens": 0.01875,
-    "input_cache_write_cost_per_mil_tokens": 1,
-    "deprecation_date": "2025-09-24",
-    "parent": "gemini-1.5-flash",
-    "fallback_models": [
-      "publishers/google/models/gemini-1.5-flash-002"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-1.5-flash-8b-latest": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.0375,
-    "output_cost_per_mil_tokens": 0.15,
-    "parent": "gemini-1.5-flash-8b"
-  },
-  "gemini-1.5-flash-8b-001": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.0375,
-    "output_cost_per_mil_tokens": 0.15,
-    "parent": "gemini-1.5-flash-8b"
-  },
-  "gemini-1.5-pro": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 5,
-    "displayName": "Gemini 1.5 Pro",
-    "deprecation_date": "2025-09-29",
-    "fallback_models": [
-      "publishers/google/models/gemini-1.5-pro"
-    ],
-    "max_input_tokens": 2097152,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-1.5-pro-001": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 5,
-    "deprecation_date": "2025-05-24",
-    "parent": "gemini-1.5-pro",
-    "fallback_models": [
-      "publishers/google/models/gemini-1.5-pro-001"
-    ],
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-1.5-pro-002": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 5,
-    "deprecation_date": "2025-09-24",
-    "parent": "gemini-1.5-pro",
-    "fallback_models": [
-      "publishers/google/models/gemini-1.5-pro-002"
-    ],
-    "max_input_tokens": 2097152,
-    "max_output_tokens": 8192,
     "available_providers": [
       "vertex"
     ]
@@ -5999,21 +7790,6 @@
     "deprecated": true,
     "parent": "gemini-2.5-pro",
     "max_input_tokens": 2097152,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-2.0-flash-exp": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "input_cache_read_cost_per_mil_tokens": 0.0375,
-    "experimental": true,
-    "parent": "gemini-2.0-flash",
-    "max_input_tokens": 1048576,
     "max_output_tokens": 8192,
     "available_providers": [
       "vertex"
@@ -6038,6 +7814,224 @@
       "vertex"
     ]
   },
+  "publishers/google/models/gemini-2.0-flash-thinking-exp-01-21": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 2.0 Flash Thinking Mode",
+    "experimental": true,
+    "deprecated": true,
+    "parent": "publishers/google/models/gemini-2.0-flash",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.0-flash-001": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "deprecation_date": "2026-03-31",
+    "parent": "publishers/google/models/gemini-2.0-flash",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.0-flash-lite-001": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.075,
+    "output_cost_per_mil_tokens": 0.3,
+    "deprecation_date": "2026-03-31",
+    "parent": "publishers/google/models/gemini-2.0-flash-lite",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-2.0-flash-exp": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "input_cache_read_cost_per_mil_tokens": 0.0375,
+    "experimental": true,
+    "parent": "gemini-2.0-flash",
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.0-flash": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "Gemini 2.0 Flash",
+    "deprecation_date": "2026-03-31",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.0-flash-lite": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.075,
+    "output_cost_per_mil_tokens": 0.3,
+    "displayName": "Gemini 2.0 Flash-Lite",
+    "deprecation_date": "2026-03-31",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-1.5-flash-002": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.075,
+    "output_cost_per_mil_tokens": 0.3,
+    "input_cache_read_cost_per_mil_tokens": 0.01875,
+    "input_cache_write_cost_per_mil_tokens": 1,
+    "deprecation_date": "2025-09-24",
+    "parent": "gemini-1.5-flash",
+    "fallback_models": [
+      "publishers/google/models/gemini-1.5-flash-002"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-1.5-pro-002": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 5,
+    "deprecation_date": "2025-09-24",
+    "parent": "gemini-1.5-pro",
+    "fallback_models": [
+      "publishers/google/models/gemini-1.5-pro-002"
+    ],
+    "max_input_tokens": 2097152,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-1.5-flash-002": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "parent": "publishers/google/models/gemini-1.5-flash",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-1.5-pro-002": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "parent": "publishers/google/models/gemini-1.5-pro",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-1.5-flash-001": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.075,
+    "output_cost_per_mil_tokens": 0.3,
+    "input_cache_read_cost_per_mil_tokens": 0.01875,
+    "input_cache_write_cost_per_mil_tokens": 1,
+    "deprecation_date": "2025-05-24",
+    "parent": "gemini-1.5-flash",
+    "fallback_models": [
+      "publishers/google/models/gemini-1.5-flash-001"
+    ],
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-1.5-pro-001": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 5,
+    "deprecation_date": "2025-05-24",
+    "parent": "gemini-1.5-pro",
+    "fallback_models": [
+      "publishers/google/models/gemini-1.5-pro-001"
+    ],
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-1.5-flash-001": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "parent": "publishers/google/models/gemini-1.5-flash",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-1.5-pro-001": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "parent": "publishers/google/models/gemini-1.5-pro",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-1.5-pro": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 5,
+    "displayName": "Gemini 1.5 Pro",
+    "deprecation_date": "2025-09-29",
+    "fallback_models": [
+      "publishers/google/models/gemini-1.5-pro"
+    ],
+    "max_input_tokens": 2097152,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-1.5-flash": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 1.5 Flash",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-1.5-pro": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 1.5 Pro",
+    "available_providers": [
+      "vertex"
+    ]
+  },
   "gemini-1.0-pro": {
     "format": "google",
     "flavor": "chat",
@@ -6050,6 +8044,14 @@
     ],
     "max_input_tokens": 32760,
     "max_output_tokens": 8192,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-1.0-pro": {
+    "format": "google",
+    "flavor": "chat",
+    "displayName": "Gemini 1.0 Pro",
     "available_providers": [
       "vertex"
     ]
@@ -6067,650 +8069,281 @@
       "vertex"
     ]
   },
-  "gemini-3.1-flash-image-preview": {
-    "format": "google",
+  "publishers/anthropic/models/claude-fable-5": {
+    "format": "anthropic",
     "flavor": "chat",
     "multimodal": true,
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 3,
-    "displayName": "Gemini 3.1 Flash Image Preview",
-    "fallback_models": [
-      "publishers/google/models/gemini-3.1-flash-image-preview"
-    ],
-    "supported_regions": [
-      "global"
-    ],
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "google",
-      "vertex"
-    ]
-  },
-  "gemini-2.5-flash-image": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 2.5,
-    "displayName": "Gemini 2.5 Flash Image",
-    "fallback_models": [
-      "publishers/google/models/gemini-2.5-flash-image"
-    ],
-    "supported_regions": [
-      "global",
-      "europe-central2",
-      "europe-north1",
-      "europe-southwest1",
-      "europe-west1",
-      "europe-west4",
-      "europe-west8",
-      "us-central1",
-      "us-east1",
-      "us-east4",
-      "us-east5",
-      "us-south1",
-      "us-west1",
-      "us-west4"
-    ],
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "google",
-      "vertex"
-    ]
-  },
-  "gemini-3.1-flash-lite": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 1.5,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "displayName": "Gemini 3.1 Flash-Lite",
+    "input_cost_per_mil_tokens": 10,
+    "output_cost_per_mil_tokens": 50,
+    "input_cache_read_cost_per_mil_tokens": 1,
+    "input_cache_write_cost_per_mil_tokens": 12.5,
+    "displayName": "Claude Fable 5",
     "reasoning": true,
     "reasoning_budget": true,
-    "fallback_models": [
-      "publishers/google/models/gemini-3.1-flash-lite"
-    ],
-    "supported_regions": [
-      "global"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
     "available_providers": [
-      "google",
       "vertex"
     ]
   },
-  "gemini-3.5-flash": {
-    "format": "google",
+  "publishers/anthropic/models/claude-opus-4-8": {
+    "format": "anthropic",
     "flavor": "chat",
     "multimodal": true,
-    "input_cost_per_mil_tokens": 1.5,
-    "output_cost_per_mil_tokens": 9,
-    "input_cache_read_cost_per_mil_tokens": 0.15,
-    "displayName": "Gemini 3.5 Flash",
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "displayName": "Claude Opus 4.8",
     "reasoning": true,
     "reasoning_budget": true,
-    "fallback_models": [
-      "publishers/google/models/gemini-3.5-flash"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
     "available_providers": [
-      "google",
       "vertex"
     ]
   },
-  "grok-4-0709": {
-    "format": "openai",
+  "publishers/anthropic/models/claude-opus-4-7": {
+    "format": "anthropic",
     "flavor": "chat",
     "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "deprecated": true,
-    "deprecation_date": "2026-05-15",
-    "parent": "grok-4",
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-4-1-fast": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.5,
-    "input_cache_read_cost_per_mil_tokens": 0.05,
-    "displayName": "Grok 4.1 Fast",
-    "deprecated": true,
-    "deprecation_date": "2026-05-15",
-    "parent": "grok-4-1-fast",
-    "max_input_tokens": 2000000,
-    "max_output_tokens": 2000000,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-4-1-fast-non-reasoning": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 2.5,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Grok 4.1 Fast (Non-Reasoning)",
-    "deprecated": true,
-    "deprecation_date": "2026-05-15",
-    "parent": "grok-4-1-fast-non-reasoning-latest",
-    "max_input_tokens": 2000000,
-    "max_output_tokens": 2000000,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-4-1-fast-non-reasoning-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 2.5,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Grok 4.1 Fast (Non-Reasoning)",
-    "deprecated": true,
-    "deprecation_date": "2026-05-15",
-    "max_input_tokens": 2000000,
-    "max_output_tokens": 2000000,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-4-1-fast-reasoning": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 2.5,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Grok 4.1 Fast (Reasoning)",
-    "deprecated": true,
-    "deprecation_date": "2026-05-15",
-    "parent": "grok-4-1-fast-reasoning-latest",
-    "max_input_tokens": 2000000,
-    "max_output_tokens": 2000000,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-4-1-fast-reasoning-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 2.5,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Grok 4.1 Fast",
-    "deprecated": true,
-    "deprecation_date": "2026-05-15",
-    "max_input_tokens": 2000000,
-    "max_output_tokens": 2000000,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-4.20-0309-reasoning": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 2.5,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Grok 4.20 Reasoning (0309)",
-    "reasoning": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 2000000,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-4.20-beta-0309-non-reasoning": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 2.5,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Grok 4.20 Beta (Non-Reasoning)",
-    "parent": "grok-4.20-0309-non-reasoning",
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 2000000,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-4.20-beta-0309-reasoning": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 2.5,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Grok 4.20 Beta Reasoning (0309)",
-    "reasoning": true,
-    "parent": "grok-4.20-0309-reasoning",
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 2000000,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-4.20-multi-agent-beta-0309": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 2.5,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Grok 4.20 Multi-Agent Beta (0309)",
-    "reasoning": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 2000000,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-4.3": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 2.5,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Grok 4.3 (Latest)",
-    "reasoning": true,
-    "parent": "grok-4.3-latest",
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 1000000,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-4.3-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 2.5,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Grok 4.3",
-    "reasoning": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 1000000,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-4": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "displayName": "Grok 4",
-    "deprecated": true,
-    "deprecation_date": "2026-05-15",
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-4-fast-non-reasoning": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 2.5,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Grok 4 Fast (Non-Reasoning)",
-    "deprecated": true,
-    "deprecation_date": "2026-05-15",
-    "parent": "grok-4-fast-non-reasoning-latest",
-    "max_input_tokens": 2000000,
-    "max_output_tokens": 2000000,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-4-fast-non-reasoning-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 2.5,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Grok 4 Fast (Non-Reasoning)",
-    "deprecated": true,
-    "deprecation_date": "2026-05-15",
-    "max_input_tokens": 2000000,
-    "max_output_tokens": 2000000
-  },
-  "grok-4-fast-reasoning": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 2.5,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Grok 4 Fast (Reasoning)",
-    "deprecated": true,
-    "deprecation_date": "2026-05-15",
-    "parent": "grok-4-fast-reasoning-latest",
-    "max_input_tokens": 2000000,
-    "max_output_tokens": 2000000,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-4-fast-reasoning-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 2.5,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Grok 4 Fast",
-    "deprecated": true,
-    "deprecation_date": "2026-05-15",
-    "max_input_tokens": 2000000,
-    "max_output_tokens": 2000000
-  },
-  "grok-4-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "parent": "grok-4",
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.75,
-    "deprecated": true,
-    "deprecation_date": "2026-05-15",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-3-beta": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.75,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-3-fast-beta": {
-    "format": "openai",
-    "flavor": "chat",
     "input_cost_per_mil_tokens": 5,
     "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-3-fast-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-3-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.75,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-3-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 0.5,
-    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 10,
+    "displayName": "Claude Opus 4.7",
     "reasoning": true,
-    "deprecation_date": "2026-02-28",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
     "available_providers": [
-      "xAI"
+      "vertex"
     ]
   },
-  "grok-3-mini-beta": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 0.5,
-    "input_cache_read_cost_per_mil_tokens": 0.075,
-    "reasoning": true,
-    "deprecation_date": "2026-02-28",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-3-mini-fast": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 4,
-    "input_cache_read_cost_per_mil_tokens": 0.15,
-    "reasoning": true,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-3-mini-fast-beta": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 4,
-    "input_cache_read_cost_per_mil_tokens": 0.15,
-    "reasoning": true,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-3-mini-fast-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 4,
-    "input_cache_read_cost_per_mil_tokens": 0.15,
-    "reasoning": true,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-3-mini-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 0.5,
-    "input_cache_read_cost_per_mil_tokens": 0.075,
-    "reasoning": true,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-code-fast-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 1.5,
-    "input_cache_read_cost_per_mil_tokens": 0.02,
-    "reasoning": true,
-    "deprecated": true,
-    "deprecation_date": "2026-05-15",
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-code-fast-1-0825": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 1.5,
-    "input_cache_read_cost_per_mil_tokens": 0.02,
-    "displayName": "Grok Code Fast 1 (0825)",
-    "reasoning": true,
-    "deprecation_date": "2026-05-15",
-    "parent": "grok-code-fast-1",
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-code-fast": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 1.5,
-    "input_cache_read_cost_per_mil_tokens": 0.02,
-    "reasoning": true,
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-4.20-0309-non-reasoning": {
-    "format": "openai",
+  "publishers/anthropic/models/claude-opus-4-6": {
+    "format": "anthropic",
     "flavor": "chat",
     "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 2.5,
-    "displayName": "Grok 4.20 (Non-Reasoning)",
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 10,
+    "displayName": "Claude Opus 4.6",
+    "reasoning": true,
+    "reasoning_budget": true,
     "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
     "available_providers": [
-      "xAI"
+      "vertex"
     ]
   },
-  "grok-build-0.1": {
-    "format": "openai",
+  "publishers/anthropic/models/claude-sonnet-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "displayName": "Claude Sonnet 5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-sonnet-4-6": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "displayName": "Claude Sonnet 4.6",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-sonnet-4-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "displayName": "Claude Sonnet 4.5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-haiku-4-5": {
+    "format": "anthropic",
     "flavor": "chat",
     "multimodal": true,
     "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 2,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 5,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "input_cache_write_cost_per_mil_tokens": 1.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 1.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 2,
+    "displayName": "Claude Haiku 4.5",
     "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/mistralai/models/mistral-large-2411": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 6,
+    "displayName": "Mistral Large (24.11)",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/mistralai/models/codestral-2501": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 0.9,
+    "displayName": "Codestral (25.01)",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-embedding-2": {
+    "format": "google",
+    "flavor": "embedding",
+    "multimodal": true,
+    "displayName": "Gemini embedding 2",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-embedding-001": {
+    "format": "google",
+    "flavor": "embedding",
+    "displayName": "Gemini embedding 001",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "mistral.mixtral-8x7b-instruct-v0:1": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.45,
+    "output_cost_per_mil_tokens": 0.7,
+    "displayName": "Mixtral 8x7B",
+    "max_input_tokens": 32000,
+    "max_output_tokens": 8191,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "mistral.mistral-7b-instruct-v0:2": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.2,
+    "displayName": "Mistral 7B",
+    "max_input_tokens": 32000,
+    "max_output_tokens": 8191,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "mistral.mistral-large-2402-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 8,
+    "output_cost_per_mil_tokens": 24,
+    "displayName": "Mistral Large 24.02",
+    "max_input_tokens": 32000,
+    "max_output_tokens": 8191,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "mistral.mistral-small-2402-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 3,
+    "displayName": "Mistral Small 24.02",
+    "max_input_tokens": 32000,
+    "max_output_tokens": 8191,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "mistral.mistral-large-3-675b-instruct": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 1.5,
+    "displayName": "Mistral Large 3 (675B)",
     "max_input_tokens": 256000,
+    "max_output_tokens": 32000,
     "available_providers": [
-      "xAI"
+      "bedrock"
     ]
   },
-  "grok-latest": {
-    "format": "openai",
+  "deepseek.v3.2": {
+    "format": "converse",
     "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 2.5,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Grok Latest",
-    "reasoning": true,
-    "parent": "grok-4.3-latest",
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 1000000,
+    "input_cost_per_mil_tokens": 0.62,
+    "output_cost_per_mil_tokens": 1.85,
+    "displayName": "DeepSeek V3.2",
+    "max_input_tokens": 164000,
+    "max_output_tokens": 8000,
     "available_providers": [
-      "xAI"
+      "bedrock"
     ]
   },
-  "grok-4.5": {
-    "format": "openai",
+  "deepseek.v3-v1:0": {
+    "format": "converse",
     "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 6,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "displayName": "Grok 4.5",
-    "reasoning": true,
-    "max_input_tokens": 500000,
-    "max_output_tokens": 500000,
+    "displayName": "DeepSeek V3.1",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8000,
     "available_providers": [
-      "xAI"
+      "bedrock"
     ]
   },
-  "grok-4.5-latest": {
-    "format": "openai",
+  "deepseek.r1-v1:0": {
+    "format": "converse",
     "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 6,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "displayName": "Grok 4.5 (Latest)",
+    "displayName": "DeepSeek R1",
     "reasoning": true,
-    "parent": "grok-4.5",
-    "max_input_tokens": 500000,
-    "max_output_tokens": 500000,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8000,
     "available_providers": [
-      "xAI"
-    ]
-  },
-  "grok-build-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 6,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "displayName": "Grok Build (Latest)",
-    "reasoning": true,
-    "max_input_tokens": 500000,
-    "available_providers": [
-      "xAI"
+      "bedrock"
     ]
   },
   "amazon.nova-pro-v1:0": {
@@ -7765,3463 +9398,6 @@
       "bedrock"
     ]
   },
-  "publishers/google/models/gemini-3.1-pro-preview": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 12,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Gemini 3.1 Pro Preview",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-3.1-pro-preview-customtools": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 12,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Gemini 3.1 Pro Custom Tools Preview",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-3.1-flash-image-preview": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 3,
-    "displayName": "Gemini 3.1 Flash Image Preview",
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-3.1-flash-lite-preview": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 1.5,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "displayName": "Gemini 3.1 Flash-Lite (Preview)",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-3.1-flash-lite": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 1.5,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "displayName": "Gemini 3.1 Flash-Lite",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-3-pro-preview": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 12,
-    "input_cache_read_cost_per_mil_tokens": 0.3125,
-    "displayName": "Gemini 3 Pro Preview",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-3.5-flash": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.5,
-    "output_cost_per_mil_tokens": 9,
-    "input_cache_read_cost_per_mil_tokens": 0.15,
-    "displayName": "Gemini 3.5 Flash",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-3-flash-preview": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 3,
-    "input_cache_read_cost_per_mil_tokens": 0.05,
-    "displayName": "Gemini 3 Flash Preview",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-3-pro-image-preview": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 12,
-    "displayName": "Gemini 3 Pro Image Preview",
-    "max_input_tokens": 65536,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.0-flash": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "Gemini 2.0 Flash",
-    "deprecation_date": "2026-03-31",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.0-flash-001": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "deprecation_date": "2026-03-31",
-    "parent": "publishers/google/models/gemini-2.0-flash",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.0-flash-lite": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.075,
-    "output_cost_per_mil_tokens": 0.3,
-    "displayName": "Gemini 2.0 Flash-Lite",
-    "deprecation_date": "2026-03-31",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.0-flash-lite-001": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.075,
-    "output_cost_per_mil_tokens": 0.3,
-    "deprecation_date": "2026-03-31",
-    "parent": "publishers/google/models/gemini-2.0-flash-lite",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-1.5-pro": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 1.5 Pro",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-1.5-pro-002": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "parent": "publishers/google/models/gemini-1.5-pro",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-1.5-pro-001": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "parent": "publishers/google/models/gemini-1.5-pro",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-1.5-flash": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 1.5 Flash",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-1.5-flash-002": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "parent": "publishers/google/models/gemini-1.5-flash",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-1.5-flash-001": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "parent": "publishers/google/models/gemini-1.5-flash",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-1.0-pro-vision": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 1.0 Pro Vision"
-  },
-  "publishers/google/models/gemini-1.0-pro-vision-001": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "parent": "publishers/google/models/gemini-1.0-pro-vision"
-  },
-  "publishers/google/models/gemini-1.0-pro": {
-    "format": "google",
-    "flavor": "chat",
-    "displayName": "Gemini 1.0 Pro",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-1.0-pro-002": {
-    "format": "google",
-    "flavor": "chat",
-    "parent": "publishers/google/models/gemini-1.0-pro"
-  },
-  "publishers/google/models/gemini-1.0-pro-001": {
-    "format": "google",
-    "flavor": "chat",
-    "parent": "publishers/google/models/gemini-1.0-pro"
-  },
-  "publishers/anthropic/models/claude-sonnet-4-6": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "displayName": "Claude Sonnet 4.6",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-sonnet-4-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "displayName": "Claude Sonnet 4.5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-sonnet-4-5@20250929": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": true,
-    "parent": "publishers/anthropic/models/claude-sonnet-4-5"
-  },
-  "publishers/anthropic/models/claude-sonnet-4": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "displayName": "Claude Sonnet 4",
-    "reasoning": true,
-    "reasoning_budget": true
-  },
-  "publishers/anthropic/models/claude-sonnet-4@20250514": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": true,
-    "parent": "publishers/anthropic/models/claude-sonnet-4"
-  },
-  "publishers/anthropic/models/claude-3-7-sonnet": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "displayName": "Claude Sonnet 3.7",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "deprecation_date": "2026-02-19"
-  },
-  "publishers/anthropic/models/claude-3-7-sonnet@20250219": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": true,
-    "deprecation_date": "2026-02-19",
-    "parent": "publishers/anthropic/models/claude-3-7-sonnet"
-  },
-  "publishers/anthropic/models/claude-haiku-4-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 5,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "input_cache_write_cost_per_mil_tokens": 1.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 1.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 2,
-    "displayName": "Claude Haiku 4.5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-haiku-4-5@20251001": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 5,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "input_cache_write_cost_per_mil_tokens": 1.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 1.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 2,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "publishers/anthropic/models/claude-haiku-4-5",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000
-  },
-  "publishers/anthropic/models/claude-3-5-haiku": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.8,
-    "output_cost_per_mil_tokens": 4,
-    "input_cache_read_cost_per_mil_tokens": 0.08,
-    "input_cache_write_cost_per_mil_tokens": 1,
-    "input_cache_write_5m_cost_per_mil_tokens": 1,
-    "input_cache_write_1h_cost_per_mil_tokens": 1.6,
-    "displayName": "Claude Haiku 3.5",
-    "deprecation_date": "2026-02-19",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 8192
-  },
-  "publishers/anthropic/models/claude-3-5-haiku@20241022": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.8,
-    "output_cost_per_mil_tokens": 4,
-    "input_cache_read_cost_per_mil_tokens": 0.08,
-    "input_cache_write_cost_per_mil_tokens": 1,
-    "input_cache_write_5m_cost_per_mil_tokens": 1,
-    "input_cache_write_1h_cost_per_mil_tokens": 1.6,
-    "deprecation_date": "2026-02-19",
-    "parent": "publishers/anthropic/models/claude-3-5-haiku",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 8192
-  },
-  "publishers/anthropic/models/claude-3-5-sonnet-v2": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "displayName": "Claude Sonnet 3.5 v2"
-  },
-  "publishers/anthropic/models/claude-3-5-sonnet-v2@20241022": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "parent": "publishers/anthropic/models/claude-3-5-sonnet-v2"
-  },
-  "publishers/anthropic/models/claude-3-5-sonnet": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "displayName": "Claude Sonnet 3.5"
-  },
-  "publishers/anthropic/models/claude-3-5-sonnet@20240620": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "parent": "publishers/anthropic/models/claude-3-5-sonnet"
-  },
-  "publishers/anthropic/models/claude-3-opus": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 15,
-    "output_cost_per_mil_tokens": 75,
-    "input_cache_read_cost_per_mil_tokens": 1.5,
-    "input_cache_write_cost_per_mil_tokens": 18.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 18.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 30,
-    "displayName": "Claude Opus 3"
-  },
-  "publishers/anthropic/models/claude-3-opus@20240229": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 15,
-    "output_cost_per_mil_tokens": 75,
-    "input_cache_read_cost_per_mil_tokens": 1.5,
-    "input_cache_write_cost_per_mil_tokens": 18.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 18.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 30,
-    "parent": "publishers/anthropic/models/claude-3-opus"
-  },
-  "publishers/anthropic/models/claude-3-haiku": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 1.25,
-    "input_cache_read_cost_per_mil_tokens": 0.03,
-    "input_cache_write_cost_per_mil_tokens": 0.3,
-    "input_cache_write_5m_cost_per_mil_tokens": 0.3,
-    "input_cache_write_1h_cost_per_mil_tokens": 0.5,
-    "displayName": "Claude Haiku 3"
-  },
-  "publishers/anthropic/models/claude-3-haiku@20240307": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 1.25,
-    "input_cache_read_cost_per_mil_tokens": 0.03,
-    "input_cache_write_cost_per_mil_tokens": 0.3,
-    "input_cache_write_5m_cost_per_mil_tokens": 0.3,
-    "input_cache_write_1h_cost_per_mil_tokens": 0.5,
-    "parent": "publishers/anthropic/models/claude-3-haiku"
-  },
-  "publishers/meta/models/llama-3.1-401b-instruct-maas": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 16,
-    "displayName": "Llama 3.1 401B Instruct"
-  },
-  "publishers/mistralai/models/mistral-nemo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.15,
-    "displayName": "Mistral Nemo"
-  },
-  "accounts/fireworks/models/mistral-nemo-base-2407": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mistral-nemo-instruct-2407": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "publishers/mistralai/models/codestral-2501": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 0.9,
-    "displayName": "Codestral (25.01)",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-pro": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "Gemini 2.5 Pro",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-pro-preview-05-06": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "deprecated": true,
-    "parent": "publishers/google/models/gemini-2.5-pro",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-pro-preview-03-25": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "deprecated": true,
-    "parent": "publishers/google/models/gemini-2.5-pro",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-pro-exp-03-25": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 2.5 Pro Experimental",
-    "experimental": true,
-    "parent": "publishers/google/models/gemini-2.5-pro",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-embedding-2": {
-    "format": "google",
-    "flavor": "embedding",
-    "multimodal": true,
-    "displayName": "Gemini embedding 2",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-embedding-001": {
-    "format": "google",
-    "flavor": "embedding",
-    "displayName": "Gemini embedding 001",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-flash": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 2.5,
-    "displayName": "Gemini 2.5 Flash",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-flash-image": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 2.5,
-    "displayName": "Gemini 2.5 Flash Image",
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-flash-preview-09-2025": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "publishers/google/models/gemini-2.5-flash",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-flash-preview-05-20": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "deprecated": true,
-    "parent": "publishers/google/models/gemini-2.5-flash",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-flash-preview-04-17": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "deprecated": true,
-    "parent": "publishers/google/models/gemini-2.5-flash",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-flash-lite-preview-09-2025": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": true,
-    "parent": "publishers/google/models/gemini-2.5-flash-lite",
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-flash-lite-preview-06-17": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": true,
-    "deprecated": true,
-    "parent": "publishers/google/models/gemini-2.5-flash-lite",
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-flash-lite": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "displayName": "Gemini 2.5 Flash-Lite",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.0-flash-thinking-exp-01-21": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 2.0 Flash Thinking Mode",
-    "experimental": true,
-    "deprecated": true,
-    "parent": "publishers/google/models/gemini-2.0-flash",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/meta/models/llama-3.3-70b-instruct-maas": {
-    "format": "openai",
-    "flavor": "chat",
-    "displayName": "Llama 3.3 70B Instruct",
-    "experimental": true
-  },
-  "publishers/meta/models/llama-3.2-90b-vision-instruct-maas": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Llama 3.2 90B Vision Instruct",
-    "experimental": true
-  },
-  "publishers/meta/models/llama-3.1-70b-instruct-maas": {
-    "format": "openai",
-    "flavor": "chat",
-    "displayName": "Llama 3.1 70B Instruct",
-    "experimental": true
-  },
-  "publishers/meta/models/llama-3.1-8b-instruct-maas": {
-    "format": "openai",
-    "flavor": "chat",
-    "displayName": "Llama 3.1 8B Instruct",
-    "experimental": true
-  },
-  "publishers/google/models/gemini-2.0-flash-lite-preview-02-05": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.075,
-    "output_cost_per_mil_tokens": 0.3,
-    "displayName": "Gemini 2.0 Flash-Lite",
-    "deprecated": true
-  },
-  "publishers/anthropic/models/claude-opus-4-8": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "displayName": "Claude Opus 4.8",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-fable-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 10,
-    "output_cost_per_mil_tokens": 50,
-    "input_cache_read_cost_per_mil_tokens": 1,
-    "input_cache_write_cost_per_mil_tokens": 12.5,
-    "displayName": "Claude Fable 5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "databricks-claude-3-7-sonnet": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2.99999,
-    "output_cost_per_mil_tokens": 15.00002,
-    "displayName": "Claude Sonnet 3.7",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "deprecation_date": "2026-02-19",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-meta-llama-3-3-70b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.50001,
-    "output_cost_per_mil_tokens": 1.50003,
-    "displayName": "Llama 3.3 70B Instruct",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-meta-llama-3-1-405b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 5.00003,
-    "output_cost_per_mil_tokens": 15.00002,
-    "displayName": "Llama 3.1 405B Instruct",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-meta-llama-3-1-8b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15001,
-    "output_cost_per_mil_tokens": 0.45003,
-    "displayName": "Llama 3.1 8B Instruct",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-opus-4-8": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Opus 4.8",
-    "reasoning": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-oss-120b": {
-    "format": "openai",
-    "flavor": "chat",
-    "displayName": "GPT-OSS 120B",
-    "reasoning": true,
-    "max_input_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-llama-4-maverick": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Llama 4 Maverick",
-    "max_input_tokens": 1000000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "text-block": {
-    "format": "js",
-    "flavor": "completion",
-    "displayName": "Text-block"
-  },
-  "fireworks_ai/nomic-ai/nomic-embed-text-v1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.008,
-    "max_input_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks_ai/nomic-ai/nomic-embed-text-v1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.008,
-    "max_input_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks_ai/thenlper/gte-base": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.008,
-    "max_input_tokens": 512,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks_ai/thenlper/gte-large": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.016,
-    "max_input_tokens": 512,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks_ai/WhereIsAI/UAE-Large-V1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.016,
-    "max_input_tokens": 512,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks-ai-4.1b-to-16b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks-ai-56b-to-176b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks-ai-above-16b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks-ai-default": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks-ai-moe-up-to-56b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks-ai-up-to-4b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/chronos-hermes-13b-v2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-70b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-70b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-70b-python": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-34b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-34b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-34b-python": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-13b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-13b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-13b-python": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-7b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-7b-python": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-qwen-1p5-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 65536,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/codegemma-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/codegemma-2b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/cogito-671b-v2-p1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/cogito-v1-preview-llama-70b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/cogito-v1-preview-qwen-32b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/cogito-v1-preview-qwen-14b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/cogito-v1-preview-llama-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/cogito-v1-preview-llama-3b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/dobby-mini-unhinged-plus-llama-3-1-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/dobby-unhinged-llama-3-3-70b-new": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/dolphin-2-9-2-qwen2-72b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/dolphin-2p6-mixtral-8x7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/ernie-4p5-300b-a47b-pt": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/ernie-4p5-21b-a3b-pt": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/fare-20b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/firefunction-v2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/firefunction-v1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/firellava-13b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/firesearch-ocr-v6": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/fireworks-asr-v2": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/fireworks-asr-large": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/flux-1-dev-fp8": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.0005,
-    "output_cost_per_mil_tokens": 0.0005,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/flux-1-schnell-fp8": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.00035,
-    "output_cost_per_mil_tokens": 0.00035,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/flux-1-dev": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/flux-1-dev-controlnet-union": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.001,
-    "output_cost_per_mil_tokens": 0.001,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/flux-1-schnell": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/flux-kontext-max": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.08,
-    "output_cost_per_mil_tokens": 0.08,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/flux-kontext-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.04,
-    "output_cost_per_mil_tokens": 0.04,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/glm-5p2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.4,
-    "output_cost_per_mil_tokens": 4.4,
-    "input_cache_read_cost_per_mil_tokens": 0.14,
-    "displayName": "GLM 5.2",
-    "reasoning": true,
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "zai-org/GLM-5.2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.4,
-    "output_cost_per_mil_tokens": 4.4,
-    "input_cache_read_cost_per_mil_tokens": 0.26,
-    "displayName": "GLM 5.2",
-    "reasoning": true,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "baseten",
-      "together"
-    ]
-  },
-  "accounts/fireworks/models/glm-5p1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.4,
-    "output_cost_per_mil_tokens": 4.4,
-    "input_cache_read_cost_per_mil_tokens": 0.26,
-    "displayName": "GLM 5.1",
-    "reasoning": true,
-    "max_input_tokens": 202800,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "zai-org/GLM-5.1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.3,
-    "output_cost_per_mil_tokens": 4.3,
-    "input_cache_read_cost_per_mil_tokens": 0.26,
-    "displayName": "GLM 5.1",
-    "reasoning": true,
-    "max_input_tokens": 202752,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "baseten",
-      "together"
-    ]
-  },
-  "accounts/fireworks/models/glm-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 3.2,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "GLM 5",
-    "max_input_tokens": 202752,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "zai-org/GLM-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.95,
-    "output_cost_per_mil_tokens": 3.15,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "available_providers": [
-      "baseten",
-      "together"
-    ]
-  },
-  "accounts/fireworks/models/glm-4p7": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.2,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "reasoning": true,
-    "max_input_tokens": 202800,
-    "max_output_tokens": 202800,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "zai-org/GLM-4.7": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.2,
-    "input_cache_read_cost_per_mil_tokens": 0.12,
-    "available_providers": [
-      "baseten"
-    ]
-  },
-  "accounts/fireworks/models/glm-4p6": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.55,
-    "output_cost_per_mil_tokens": 2.19,
-    "reasoning": true,
-    "max_input_tokens": 202800,
-    "max_output_tokens": 202800,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/glm-4p5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.55,
-    "output_cost_per_mil_tokens": 2.19,
-    "reasoning": true,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 96000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/glm-4p5-air": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.22,
-    "output_cost_per_mil_tokens": 0.88,
-    "reasoning": true,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 96000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/glm-4p5v": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "reasoning": true,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "zai-glm-4.7": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.25,
-    "output_cost_per_mil_tokens": 2.75,
-    "displayName": "Z.ai GLM 4.7",
-    "reasoning": true,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 40960,
-    "available_providers": [
-      "cerebras"
-    ]
-  },
-  "accounts/fireworks/models/hermes-2-pro-mistral-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/internvl3-78b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/internvl3-38b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/internvl3-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/japanese-stable-diffusion-xl": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.00013,
-    "output_cost_per_mil_tokens": 0.00013,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/kat-coder": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/kat-dev-72b-exp": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/kat-dev-32b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llamaguard-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llava-yi-34b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "MiniMaxAI/MiniMax-M2.7": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 1.2,
-    "input_cache_read_cost_per_mil_tokens": 0.06,
-    "displayName": "MiniMax M2.7",
-    "max_input_tokens": 202752,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "MiniMaxAI/MiniMax-M3": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 1.2,
-    "input_cache_read_cost_per_mil_tokens": 0.06,
-    "displayName": "MiniMax M3",
-    "max_input_tokens": 524288,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "accounts/fireworks/models/minimax-m2p1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 1.2,
-    "input_cache_read_cost_per_mil_tokens": 0.03,
-    "max_input_tokens": 204800,
-    "max_output_tokens": 204800,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/minimax-m2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/minimax-m1-80k": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nemotron-nano-v2-12b-vl": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nous-capybara-7b-v1p9": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nvidia-nemotron-nano-12b-v2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nvidia-nemotron-nano-9b-v2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/openchat-3p5-0106-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/openhermes-2-mistral-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/openhermes-2p5-mistral-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/openorca-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/phind-code-llama-34b-v2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/phind-code-llama-34b-python-v1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/phind-code-llama-34b-v1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/playground-v2-5-1024px-aesthetic": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.00013,
-    "output_cost_per_mil_tokens": 0.00013,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/playground-v2-1024px-aesthetic": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.00013,
-    "output_cost_per_mil_tokens": 0.00013,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/pythia-12b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 2048,
-    "max_output_tokens": 2048,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/rolm-ocr": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/snorkel-mistral-7b-pairrm-dpo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/SSD-1B": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.00013,
-    "output_cost_per_mil_tokens": 0.00013,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/stable-diffusion-xl-1024-v1-0": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.00013,
-    "output_cost_per_mil_tokens": 0.00013,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/stablecode-3b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/starcoder-16b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/starcoder-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/starcoder2-15b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/starcoder2-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/starcoder2-3b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/toppy-m-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/whisper-v3": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/whisper-v3-turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/yi-34b-200k-capybara": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 200000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/yi-34b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/yi-34b-chat": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/yi-6b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/yi-large": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 3,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/zephyr-7b-beta": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/minimax-m2p7": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 1.2,
-    "input_cache_read_cost_per_mil_tokens": 0.06,
-    "displayName": "MiniMax M2.7",
-    "max_input_tokens": 196608,
-    "max_output_tokens": 196608,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/minimax-m2p5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 1.2,
-    "input_cache_read_cost_per_mil_tokens": 0.03,
-    "displayName": "MiniMax M2.5",
-    "max_input_tokens": 196608,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/qwen3p7-plus": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.4,
-    "output_cost_per_mil_tokens": 1.6,
-    "input_cache_read_cost_per_mil_tokens": 0.08,
-    "displayName": "Qwen3.7 Plus",
-    "max_input_tokens": 262144,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/minimax-m3": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 1.2,
-    "input_cache_read_cost_per_mil_tokens": 0.06,
-    "displayName": "MiniMax M3",
-    "max_input_tokens": 512000,
-    "max_output_tokens": 512000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "dall-e-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "hd/1024-x-1024/dall-e-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "hd/1024-x-1792/dall-e-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "hd/1792-x-1024/dall-e-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "standard/1024-x-1024/dall-e-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "standard/1024-x-1792/dall-e-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "standard/1792-x-1024/dall-e-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "1024-x-1024/dall-e-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "256-x-256/dall-e-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "512-x-512/dall-e-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "dall-e-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-image-2-2026-04-21": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "displayName": "GPT Image 2 (2026-04-21)",
-    "parent": "gpt-image-2",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-image-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "displayName": "GPT Image 2",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "1024-x-1024/gpt-image-1.5-2025-12-16": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Square (2025-12-16)",
-    "parent": "1024-x-1024/gpt-image-1.5",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "1024-x-1536/gpt-image-1.5-2025-12-16": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Portrait (2025-12-16)",
-    "parent": "1024-x-1536/gpt-image-1.5",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "1536-x-1024/gpt-image-1.5-2025-12-16": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Landscape (2025-12-16)",
-    "parent": "1536-x-1024/gpt-image-1.5",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-image-1.5-2025-12-16": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "displayName": "GPT Image 1.5 (2025-12-16)",
-    "parent": "gpt-image-1.5",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "high/1024-x-1024/gpt-image-1.5-2025-12-16": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 High Square (2025-12-16)",
-    "parent": "high/1024-x-1024/gpt-image-1.5",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "high/1024-x-1536/gpt-image-1.5-2025-12-16": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 High Portrait (2025-12-16)",
-    "parent": "high/1024-x-1536/gpt-image-1.5",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "high/1536-x-1024/gpt-image-1.5-2025-12-16": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 High Landscape (2025-12-16)",
-    "parent": "high/1536-x-1024/gpt-image-1.5",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "low/1024-x-1024/gpt-image-1.5-2025-12-16": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Low Square (2025-12-16)",
-    "parent": "low/1024-x-1024/gpt-image-1.5",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "low/1024-x-1536/gpt-image-1.5-2025-12-16": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Low Portrait (2025-12-16)",
-    "parent": "low/1024-x-1536/gpt-image-1.5",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "low/1536-x-1024/gpt-image-1.5-2025-12-16": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Low Landscape (2025-12-16)",
-    "parent": "low/1536-x-1024/gpt-image-1.5",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "medium/1024-x-1024/gpt-image-1.5-2025-12-16": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Medium Square (2025-12-16)",
-    "parent": "medium/1024-x-1024/gpt-image-1.5",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "medium/1024-x-1536/gpt-image-1.5-2025-12-16": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Medium Portrait (2025-12-16)",
-    "parent": "medium/1024-x-1536/gpt-image-1.5",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "medium/1536-x-1024/gpt-image-1.5-2025-12-16": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Medium Landscape (2025-12-16)",
-    "parent": "medium/1536-x-1024/gpt-image-1.5",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "standard/1024-x-1024/gpt-image-1.5-2025-12-16": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Standard Square (2025-12-16)",
-    "parent": "standard/1024-x-1024/gpt-image-1.5",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "standard/1024-x-1536/gpt-image-1.5-2025-12-16": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Standard Portrait (2025-12-16)",
-    "parent": "standard/1024-x-1536/gpt-image-1.5",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "standard/1536-x-1024/gpt-image-1.5-2025-12-16": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Standard Landscape (2025-12-16)",
-    "parent": "standard/1536-x-1024/gpt-image-1.5",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "1024-x-1024/gpt-image-1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Square",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "1024-x-1536/gpt-image-1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Portrait",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "1536-x-1024/gpt-image-1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Landscape",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-image-1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "displayName": "GPT Image 1.5",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "high/1024-x-1024/gpt-image-1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 High Square",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "high/1024-x-1536/gpt-image-1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 High Portrait",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "high/1536-x-1024/gpt-image-1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 High Landscape",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "low/1024-x-1024/gpt-image-1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Low Square",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "low/1024-x-1536/gpt-image-1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Low Portrait",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "low/1536-x-1024/gpt-image-1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Low Landscape",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "medium/1024-x-1024/gpt-image-1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Medium Square",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "medium/1024-x-1536/gpt-image-1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Medium Portrait",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "medium/1536-x-1024/gpt-image-1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Medium Landscape",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "standard/1024-x-1024/gpt-image-1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Standard Square",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "standard/1024-x-1536/gpt-image-1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Standard Portrait",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "standard/1536-x-1024/gpt-image-1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT Image 1.5 Standard Landscape",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-image-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 5,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-image-1-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "high/1024-x-1024/gpt-image-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "high/1024-x-1536/gpt-image-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "high/1536-x-1024/gpt-image-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "low/1024-x-1024/gpt-image-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "low/1024-x-1024/gpt-image-1-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "low/1024-x-1536/gpt-image-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "low/1024-x-1536/gpt-image-1-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "low/1536-x-1024/gpt-image-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "low/1536-x-1024/gpt-image-1-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "medium/1024-x-1024/gpt-image-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "medium/1024-x-1024/gpt-image-1-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "medium/1024-x-1536/gpt-image-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "medium/1024-x-1536/gpt-image-1-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "medium/1536-x-1024/gpt-image-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "medium/1536-x-1024/gpt-image-1-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "chatgpt-image-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 5,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "chat-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 30,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "displayName": "GPT Chat Latest",
-    "reasoning": true,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "ft:gpt-4o-2024-11-20": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3.75,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_write_cost_per_mil_tokens": 1.875,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "ft:gpt-4o-2024-08-06": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3.75,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 1.875,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "ft:gpt-4o-mini-2024-07-18": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 1.2,
-    "input_cache_read_cost_per_mil_tokens": 0.15,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "ft:o4-mini-2025-04-16": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 4,
-    "output_cost_per_mil_tokens": 16,
-    "input_cache_read_cost_per_mil_tokens": 1,
-    "reasoning": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "ft:gpt-4.1-2025-04-14": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 12,
-    "input_cache_read_cost_per_mil_tokens": 0.75,
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "ft:gpt-4.1-mini-2025-04-14": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.8,
-    "output_cost_per_mil_tokens": 3.2,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "ft:gpt-4.1-nano-2025-04-14": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.8,
-    "input_cache_read_cost_per_mil_tokens": 0.05,
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "ft:gpt-4-0613": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 30,
-    "output_cost_per_mil_tokens": 60,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "ft:gpt-3.5-turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 6,
-    "max_input_tokens": 16385,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "ft:gpt-3.5-turbo-1106": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 6,
-    "max_input_tokens": 16385,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "ft:gpt-3.5-turbo-0613": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 6,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "ft:gpt-3.5-turbo-0125": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 6,
-    "max_input_tokens": 16385,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "ft:babbage-002": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.6,
-    "output_cost_per_mil_tokens": 1.6,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "ft:davinci-002": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 12,
-    "output_cost_per_mil_tokens": 12,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-audio-2025-08-28": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "GPT Audio (2025-08-28)",
-    "parent": "gpt-audio",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-audio-1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-audio-mini-2025-12-15": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "displayName": "GPT Audio mini (2025-12-15)",
-    "parent": "gpt-audio-mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-audio-mini-2025-10-06": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "displayName": "GPT Audio mini (2025-10-06)",
-    "parent": "gpt-audio-mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-audio": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "GPT Audio",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-audio-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "displayName": "GPT Audio mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-realtime-2025-08-28": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 4,
-    "output_cost_per_mil_tokens": 16,
-    "input_cache_read_cost_per_mil_tokens": 0.4,
-    "displayName": "GPT Realtime (2025-08-28)",
-    "parent": "gpt-realtime",
-    "max_input_tokens": 32000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-realtime-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 4,
-    "output_cost_per_mil_tokens": 16,
-    "input_cache_read_cost_per_mil_tokens": 0.4,
-    "displayName": "GPT Realtime 2",
-    "max_input_tokens": 32000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-realtime-1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 4,
-    "output_cost_per_mil_tokens": 16,
-    "input_cache_read_cost_per_mil_tokens": 0.4,
-    "max_input_tokens": 32000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-realtime-mini-2025-12-15": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "input_cache_read_cost_per_mil_tokens": 0.06,
-    "displayName": "GPT Realtime mini (2025-12-15)",
-    "parent": "gpt-realtime-mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-realtime-mini-2025-10-06": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "input_cache_read_cost_per_mil_tokens": 0.06,
-    "displayName": "GPT Realtime mini (2025-10-06)",
-    "parent": "gpt-realtime-mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-realtime": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 4,
-    "output_cost_per_mil_tokens": 16,
-    "input_cache_read_cost_per_mil_tokens": 0.4,
-    "displayName": "GPT Realtime",
-    "max_input_tokens": 32000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-realtime-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "displayName": "GPT Realtime mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "omni-moderation-2024-09-26": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "omni-moderation-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "openai/container": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "openai/sora-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "openai/sora-2-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "openai/sora-2-pro-high-res": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "sora-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "sora-2-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "sora-2-pro-high-res": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "text-moderation-007": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "text-moderation-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "text-moderation-stable": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "tts-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "tts-1-hd": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "tts-1-1106": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "tts-1-hd-1106": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "whisper-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "babbage-002": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.4,
-    "output_cost_per_mil_tokens": 0.4,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "davinci-002": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "nvidia/Nemotron-120B-A12B": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 0.75,
-    "input_cache_read_cost_per_mil_tokens": 0.06,
-    "available_providers": [
-      "baseten"
-    ]
-  },
-  "LiquidAI/LFM2-24B-A2B": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.03,
-    "output_cost_per_mil_tokens": 0.12,
-    "displayName": "LFM2 24B A2B",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "LiquidAI/LFM2.5-8B-A1B": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.03,
-    "output_cost_per_mil_tokens": 0.12,
-    "displayName": "LFM2.5 8B A1B",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "deepcogito/cogito-v2-1-671b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 1.25,
-    "displayName": "Cogito v2.1 671B",
-    "max_input_tokens": 163840,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "essentialai/rnj-1-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.15,
-    "displayName": "RNJ-1 Instruct",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta.llama4-scout-17b-instruct-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Llama 4 Scout",
-    "max_input_tokens": 10000000,
-    "max_output_tokens": 8000
-  },
-  "meta.llama4-maverick-17b-instruct-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Llama 4 Maverick",
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8000
-  },
   "us.meta.llama4-scout-17b-instruct-v1:0": {
     "format": "converse",
     "flavor": "chat",
@@ -11441,32 +9617,6 @@
       "bedrock"
     ]
   },
-  "nvidia/nemotron-3-ultra-550b-a55b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 3.6,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "NVIDIA Nemotron 3 Ultra 550B",
-    "reasoning": true,
-    "max_input_tokens": 512300,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "input_cache_read_cost_per_mil_tokens": 0.12,
-    "displayName": "NVIDIA Nemotron 3 Ultra 550B",
-    "reasoning": true,
-    "max_input_tokens": 202800,
-    "available_providers": [
-      "baseten"
-    ]
-  },
   "mistral.devstral-2-123b": {
     "format": "converse",
     "flavor": "chat",
@@ -11526,19 +9676,6 @@
     "max_output_tokens": 16384,
     "available_providers": [
       "bedrock"
-    ]
-  },
-  "qwen/qwen3.6-27b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 3,
-    "displayName": "Qwen 3.6 27B",
-    "experimental": true,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "groq"
     ]
   },
   "moonshotai.kimi-k2.5": {
@@ -11616,459 +9753,6 @@
       "bedrock"
     ]
   },
-  "gemini-2.5-computer-use-preview-10-2025": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "Gemini 2.5 Computer Use Preview (10-2025)",
-    "fallback_models": [
-      "publishers/google/models/gemini-2.5-computer-use-preview-10-2025"
-    ],
-    "max_input_tokens": 128000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "google"
-    ]
-  },
-  "gemini-3-pro-image": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 12,
-    "displayName": "Gemini 3 Pro Image",
-    "fallback_models": [
-      "publishers/google/models/gemini-3-pro-image"
-    ],
-    "supported_regions": [
-      "global"
-    ],
-    "max_input_tokens": 65536,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "google",
-      "vertex"
-    ]
-  },
-  "gemini-3.1-flash-image": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 3,
-    "displayName": "Gemini 3.1 Flash Image",
-    "fallback_models": [
-      "publishers/google/models/gemini-3.1-flash-image"
-    ],
-    "supported_regions": [
-      "global"
-    ],
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "google",
-      "vertex"
-    ]
-  },
-  "gemini-3.1-flash-lite-image": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 1.5,
-    "displayName": "Gemini 3.1 Flash-Lite Image",
-    "fallback_models": [
-      "publishers/google/models/gemini-3.1-flash-lite-image"
-    ],
-    "supported_regions": [
-      "global"
-    ],
-    "max_input_tokens": 65536,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "google",
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-computer-use-preview-10-2025": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "Gemini 2.5 Computer Use Preview (10-2025)",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-3-pro-image": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 12,
-    "displayName": "Gemini 3 Pro Image",
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 65536,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-3.1-flash-image": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 3,
-    "displayName": "Gemini 3.1 Flash Image",
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "databricks-qwen35-122b-a10b": {
-    "format": "openai",
-    "flavor": "chat",
-    "displayName": "Qwen 3.5 122B-A10B",
-    "reasoning": true,
-    "experimental": true,
-    "max_input_tokens": 256000,
-    "max_output_tokens": 8000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-qwen3-next-80b-a3b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "displayName": "Qwen 3-Next 80B-A3B Instruct",
-    "experimental": true,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gemini-3-flash": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 3 Flash",
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gemini-3-1-flash-lite": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 3.1 Flash-Lite",
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-oss-20b": {
-    "format": "openai",
-    "flavor": "chat",
-    "displayName": "GPT-OSS 20B",
-    "reasoning": true,
-    "max_input_tokens": 131072,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-nano": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5 nano",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.1",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5 mini",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-haiku-4-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Haiku 4.5",
-    "max_input_tokens": 200000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-opus-4-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Opus 4.5",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 32000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-opus-4-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Opus 4.1",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 32000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gemini-3-1-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 3.1 Pro",
-    "max_input_tokens": 1000000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gemini-2-5-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 2.5 Pro",
-    "max_input_tokens": 1000000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gemini-2-5-flash": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 2.5 Flash",
-    "max_input_tokens": 1000000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-4": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.4",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-4-nano": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.4 nano",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.2",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-sonnet-4-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Sonnet 4.5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-opus-4-6": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Opus 4.6",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-sonnet-4": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Sonnet 4",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-opus-4-7": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Opus 4.7",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-sonnet-4-6": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Sonnet 4.6",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.5",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-fable-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Fable 5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-6-sol": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.6 Sol",
-    "reasoning": true,
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-6-terra": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.6 Terra",
-    "reasoning": true,
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-6-luna": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.6 Luna",
-    "reasoning": true,
-    "max_input_tokens": 400000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-sonnet-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Sonnet 5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
   "mistral.pixtral-large-2502-v1:0": {
     "format": "converse",
     "flavor": "chat",
@@ -12117,21 +9801,6 @@
     "max_output_tokens": 8192,
     "available_providers": [
       "bedrock"
-    ]
-  },
-  "mistral-medium-2604": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.5,
-    "output_cost_per_mil_tokens": 7.5,
-    "displayName": "Mistral Medium 3.5 (2604)",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "mistral-medium-latest",
-    "max_input_tokens": 256000,
-    "available_providers": [
-      "mistral"
     ]
   },
   "us.mistral.pixtral-large-2502-v1:0": {
@@ -12187,54 +9856,6 @@
       "bedrock"
     ]
   },
-  "voxtral-small-2507": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "max_input_tokens": 32000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "voxtral-small-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "displayName": "Voxtral Small",
-    "max_input_tokens": 32000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "claude-sonnet-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "input_cache_write_cost_per_mil_tokens": 2.5,
-    "input_cache_write_5m_cost_per_mil_tokens": 2.5,
-    "input_cache_write_1h_cost_per_mil_tokens": 4,
-    "displayName": "Claude Sonnet 5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "fallback_models": [
-      "anthropic.claude-sonnet-5",
-      "global.anthropic.claude-sonnet-5",
-      "publishers/anthropic/models/claude-sonnet-5",
-      "us.anthropic.claude-sonnet-5"
-    ],
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "anthropic"
-    ]
-  },
   "anthropic.claude-sonnet-5": {
     "format": "anthropic",
     "flavor": "chat",
@@ -12250,93 +9871,6 @@
     "max_output_tokens": 128000,
     "available_providers": [
       "bedrock"
-    ]
-  },
-  "publishers/anthropic/models/claude-sonnet-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "displayName": "Claude Sonnet 5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-3.1-flash-lite-image": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 1.5,
-    "displayName": "Gemini 3.1 Flash-Lite Image",
-    "locations": [
-      "global"
-    ],
-    "max_input_tokens": 65536,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemma-4-31b": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.99,
-    "output_cost_per_mil_tokens": 1.49,
-    "displayName": "Gemma 4 31B",
-    "reasoning": true,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 40960,
-    "available_providers": [
-      "cerebras"
-    ]
-  },
-  "pearl-ai/gemma-4-31b-it": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.28,
-    "output_cost_per_mil_tokens": 0.86,
-    "displayName": "Gemma 4 31B IT (Pearl)",
-    "max_input_tokens": 32000,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "groq/compound": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "groq"
-    ]
-  },
-  "groq/compound-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "groq"
-    ]
-  },
-  "labs-leanstral-1-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "displayName": "Leanstral 1.5",
-    "max_input_tokens": 256000,
-    "available_providers": [
-      "mistral"
     ]
   },
   "google.gemma-4-31b": {
@@ -12370,6 +9904,2472 @@
     "max_input_tokens": 128000,
     "available_providers": [
       "bedrock"
+    ]
+  },
+  "deepseek-ai/DeepSeek-V4-Pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.74,
+    "output_cost_per_mil_tokens": 3.48,
+    "input_cache_read_cost_per_mil_tokens": 0.145,
+    "displayName": "DeepSeek V4 Pro",
+    "max_input_tokens": 512000,
+    "available_providers": [
+      "together",
+      "baseten"
+    ]
+  },
+  "deepseek-ai/DeepSeek-V3": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 1.25,
+    "displayName": "DeepSeek V3",
+    "max_input_tokens": 65536,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "deepseek-ai/DeepSeek-R1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 7,
+    "displayName": "DeepSeek R1",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 20480,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "Qwen/Qwen3.7-Max": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 3.75,
+    "input_cache_read_cost_per_mil_tokens": 0.13,
+    "displayName": "Qwen3.7 Max",
+    "reasoning": true,
+    "max_input_tokens": 1000000,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "Qwen/Qwen3.7-Plus": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.32,
+    "output_cost_per_mil_tokens": 1.28,
+    "displayName": "Qwen 3.7 Plus",
+    "max_input_tokens": 1000000,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "Qwen/Qwen3.6-Plus": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 3,
+    "displayName": "Qwen3.6 Plus",
+    "max_input_tokens": 1000000,
+    "supports_streaming": true,
+    "streaming_only": true,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 3.6,
+    "input_cache_read_cost_per_mil_tokens": 0.35,
+    "displayName": "Qwen3.5 397B A17B",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "Qwen/Qwen3.5-9B": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.17,
+    "output_cost_per_mil_tokens": 0.25,
+    "displayName": "Qwen3.5 9B",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "Qwen/Qwen3-235B-A22B-Instruct-2507-tput": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "Qwen3 235B A22B Instruct 2507 (Throughput)",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "Qwen/Qwen3-Coder-Next-FP8": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 1.2,
+    "displayName": "Qwen3 Coder Next FP8",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "Qwen/Qwen2.5-72B-Instruct-Turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "displayName": "Qwen 2.5 72B Instruct Turbo",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "Qwen/Qwen2.5-7B-Instruct-Turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 0.3,
+    "displayName": "Qwen 2.5 7B Instruct Turbo",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "moonshotai/Kimi-K2.7-Code": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.95,
+    "output_cost_per_mil_tokens": 4,
+    "input_cache_read_cost_per_mil_tokens": 0.16,
+    "displayName": "Kimi K2.7 Code",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "together",
+      "baseten"
+    ]
+  },
+  "moonshotai/Kimi-K2-Instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 3,
+    "displayName": "Kimi K2 Instruct",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.27,
+    "output_cost_per_mil_tokens": 0.85,
+    "displayName": "Llama 4 Maverick Instruct (17Bx128E)",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.18,
+    "output_cost_per_mil_tokens": 0.59,
+    "displayName": "Llama 4 Scout Instruct (17Bx16E)",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "meta-llama/Llama-3.3-70B-Instruct-Turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.04,
+    "output_cost_per_mil_tokens": 1.04,
+    "displayName": "Llama 3.3 70B Instruct Turbo",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "meta-llama/Llama-3.3-70B-Instruct-Turbo-Free": {
+    "format": "openai",
+    "flavor": "chat",
+    "displayName": "Llama 3.3 70B Instruct Turbo Free",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "meta-llama/Llama-3.2-3B-Instruct-Turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.06,
+    "output_cost_per_mil_tokens": 0.06,
+    "displayName": "Llama 3.2 3B Instruct Turbo",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3.5,
+    "output_cost_per_mil_tokens": 3.5,
+    "displayName": "Llama 3.1 405B Instruct Turbo",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.88,
+    "output_cost_per_mil_tokens": 0.88,
+    "displayName": "Llama 3.1 70B Instruct Turbo",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.18,
+    "output_cost_per_mil_tokens": 0.18,
+    "displayName": "Llama 3.1 8B Instruct Turbo",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "MiniMaxAI/MiniMax-M3": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 1.2,
+    "input_cache_read_cost_per_mil_tokens": 0.06,
+    "displayName": "MiniMax M3",
+    "max_input_tokens": 524288,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "MiniMaxAI/MiniMax-M2.7": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 1.2,
+    "input_cache_read_cost_per_mil_tokens": 0.06,
+    "displayName": "MiniMax M2.7",
+    "max_input_tokens": 202752,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "mistralai/Mistral-7B-Instruct-v0.1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "displayName": "Mistral (7B) Instruct",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "google/gemma-4-31B-it": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.39,
+    "output_cost_per_mil_tokens": 0.97,
+    "displayName": "Gemma 4 31B IT",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "pearl-ai/gemma-4-31b-it": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.28,
+    "output_cost_per_mil_tokens": 0.86,
+    "displayName": "Gemma 4 31B IT (Pearl)",
+    "max_input_tokens": 32000,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "google/gemma-3n-E4B-it": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.06,
+    "output_cost_per_mil_tokens": 0.12,
+    "displayName": "Gemma 3n E4B IT",
+    "max_input_tokens": 32768,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "LiquidAI/LFM2-24B-A2B": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.03,
+    "output_cost_per_mil_tokens": 0.12,
+    "displayName": "LFM2 24B A2B",
+    "max_input_tokens": 32768,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "LiquidAI/LFM2.5-8B-A1B": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.03,
+    "output_cost_per_mil_tokens": 0.12,
+    "displayName": "LFM2.5 8B A1B",
+    "max_input_tokens": 32768,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "deepcogito/cogito-v2-1-671b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 1.25,
+    "displayName": "Cogito v2.1 671B",
+    "max_input_tokens": 163840,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "essentialai/rnj-1-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.15,
+    "displayName": "RNJ-1 Instruct",
+    "max_input_tokens": 32768,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "mistralai/Mistral-Small-24B-Instruct-2501": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.8,
+    "output_cost_per_mil_tokens": 0.8,
+    "displayName": "Mistral Small (24B) Instruct 25.01",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "mistralai/Mixtral-8x7B-Instruct-v0.1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "Mixtral 8x7B Instruct v0.1",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "nvidia/nemotron-3-ultra-550b-a55b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 3.6,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "NVIDIA Nemotron 3 Ultra 550B",
+    "reasoning": true,
+    "max_input_tokens": 512300,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "sonar-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "displayName": "Sonar Pro",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8000,
+    "available_providers": [
+      "perplexity"
+    ]
+  },
+  "sonar-reasoning-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 8,
+    "displayName": "Sonar Reasoning Pro",
+    "max_input_tokens": 128000,
+    "available_providers": [
+      "perplexity"
+    ]
+  },
+  "sonar-deep-research": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 8,
+    "displayName": "Sonar Deep Research",
+    "max_input_tokens": 128000,
+    "available_providers": [
+      "perplexity"
+    ]
+  },
+  "sonar": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 1,
+    "displayName": "Sonar",
+    "max_input_tokens": 128000,
+    "available_providers": [
+      "perplexity"
+    ]
+  },
+  "deepseek-ai/DeepSeek-V3.1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 1.5,
+    "available_providers": [
+      "baseten"
+    ]
+  },
+  "zai-org/GLM-5.2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.4,
+    "output_cost_per_mil_tokens": 4.4,
+    "input_cache_read_cost_per_mil_tokens": 0.26,
+    "displayName": "GLM 5.2",
+    "reasoning": true,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "baseten",
+      "together"
+    ]
+  },
+  "zai-org/GLM-5.1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.3,
+    "output_cost_per_mil_tokens": 4.3,
+    "input_cache_read_cost_per_mil_tokens": 0.26,
+    "displayName": "GLM 5.1",
+    "reasoning": true,
+    "max_input_tokens": 202752,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "baseten",
+      "together"
+    ]
+  },
+  "zai-org/GLM-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.95,
+    "output_cost_per_mil_tokens": 3.15,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "available_providers": [
+      "baseten",
+      "together"
+    ]
+  },
+  "zai-org/GLM-4.7": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.2,
+    "input_cache_read_cost_per_mil_tokens": 0.12,
+    "available_providers": [
+      "baseten"
+    ]
+  },
+  "moonshotai/Kimi-K2.6": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.95,
+    "output_cost_per_mil_tokens": 4,
+    "input_cache_read_cost_per_mil_tokens": 0.16,
+    "displayName": "Kimi K2.6",
+    "available_providers": [
+      "baseten",
+      "together"
+    ]
+  },
+  "moonshotai/Kimi-K2.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 3,
+    "input_cache_read_cost_per_mil_tokens": 0.12,
+    "available_providers": [
+      "baseten",
+      "together"
+    ]
+  },
+  "nvidia/Nemotron-120B-A12B": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 0.75,
+    "input_cache_read_cost_per_mil_tokens": 0.06,
+    "available_providers": [
+      "baseten"
+    ]
+  },
+  "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "input_cache_read_cost_per_mil_tokens": 0.12,
+    "displayName": "NVIDIA Nemotron 3 Ultra 550B",
+    "reasoning": true,
+    "max_input_tokens": 202800,
+    "available_providers": [
+      "baseten"
+    ]
+  },
+  "mistral-large-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 1.5,
+    "displayName": "Mistral Large",
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-large-2512": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 1.5,
+    "displayName": "Mistral Large (2512)",
+    "parent": "mistral-large-latest",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-medium-3.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.5,
+    "output_cost_per_mil_tokens": 7.5,
+    "displayName": "Mistral Medium 3.5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 256000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-medium-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.5,
+    "output_cost_per_mil_tokens": 7.5,
+    "displayName": "Mistral Medium 3",
+    "parent": "mistral-medium-3.5",
+    "max_input_tokens": 256000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-medium": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.7,
+    "output_cost_per_mil_tokens": 8.1,
+    "displayName": "Mistral Medium",
+    "deprecated": true,
+    "max_input_tokens": 32000,
+    "max_output_tokens": 8191,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-medium-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.5,
+    "output_cost_per_mil_tokens": 7.5,
+    "displayName": "Mistral Medium 3.5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 256000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-medium-2604": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.5,
+    "output_cost_per_mil_tokens": 7.5,
+    "displayName": "Mistral Medium 3.5 (2604)",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "mistral-medium-latest",
+    "max_input_tokens": 256000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-medium-2508": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.4,
+    "output_cost_per_mil_tokens": 2,
+    "displayName": "Mistral Medium (2508)",
+    "deprecation_date": "2026-05-22",
+    "parent": "mistral-medium-latest",
+    "max_input_tokens": 128000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-medium-2505": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.4,
+    "output_cost_per_mil_tokens": 2,
+    "deprecation_date": "2026-05-22",
+    "parent": "mistral-medium-latest",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 8191,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "magistral-medium-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 5,
+    "displayName": "Magistral Medium Latest",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 40000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "magistral-medium-2509": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 5,
+    "displayName": "Magistral Medium (2509)",
+    "deprecation_date": "2026-07-31",
+    "parent": "magistral-medium-latest",
+    "max_input_tokens": 128000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "codestral-2508": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 0.9,
+    "displayName": "Codestral 2508",
+    "parent": "codestral-latest",
+    "max_input_tokens": 256000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "codestral-2501": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 0.9,
+    "parent": "codestral-latest",
+    "fallback_models": [
+      "publishers/mistralai/models/codestral-2501"
+    ],
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "codestral-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 0.9,
+    "displayName": "Codestral",
+    "max_input_tokens": 128000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "devstral-medium-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.4,
+    "output_cost_per_mil_tokens": 2,
+    "displayName": "Devstral Medium Latest",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "devstral-2512": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.4,
+    "output_cost_per_mil_tokens": 2,
+    "displayName": "Devstral 2512",
+    "deprecation_date": "2026-07-31",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "devstral-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.4,
+    "output_cost_per_mil_tokens": 2,
+    "displayName": "Devstral Latest",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "devstral-small-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.3,
+    "displayName": "Devstral Small Latest",
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-small": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.3,
+    "displayName": "Mistral Small",
+    "deprecated": true,
+    "max_input_tokens": 32000,
+    "max_output_tokens": 8191,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-small-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "Mistral Small",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-small-2603": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "Mistral Small (2603)",
+    "parent": "mistral-small-latest",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "magistral-small-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 1.5,
+    "displayName": "Magistral Small Latest",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 40000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "magistral-small-2509": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 1.5,
+    "displayName": "Magistral Small (2509)",
+    "deprecation_date": "2026-07-31",
+    "parent": "magistral-small-latest",
+    "max_input_tokens": 128000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "pixtral-12b-2409": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.15,
+    "displayName": "Pixtral 12B",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "voxtral-small-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "displayName": "Voxtral Small",
+    "max_input_tokens": 32000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "voxtral-small-2507": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "max_input_tokens": 32000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "ministral-14b-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "displayName": "Ministral 14B",
+    "max_input_tokens": 256000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "ministral-14b-2512": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "displayName": "Ministral 14B 2512",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "ministral-8b-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.15,
+    "displayName": "Ministral 8B",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "ministral-8b-2512": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.15,
+    "displayName": "Ministral 8B (2512)",
+    "parent": "ministral-8b-latest",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "ministral-3b-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "displayName": "Ministral 3B",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "ministral-3b-2512": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "displayName": "Ministral 3B (2512)",
+    "parent": "ministral-3b-latest",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-tiny": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 0.25,
+    "displayName": "Mistral Tiny",
+    "deprecated": true,
+    "max_input_tokens": 32000,
+    "max_output_tokens": 8191,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "open-mistral-nemo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.15,
+    "displayName": "Mistral NeMo",
+    "deprecation_date": "2026-07-31",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "open-mistral-nemo-2407": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.15,
+    "deprecation_date": "2026-07-31",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "open-mixtral-8x22b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 6,
+    "displayName": "Mixtral 8x22B",
+    "deprecated": true,
+    "max_input_tokens": 65336,
+    "max_output_tokens": 8191,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "labs-leanstral-1-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "displayName": "Leanstral 1.5",
+    "max_input_tokens": 256000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "gemini-3.5-flash": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.5,
+    "output_cost_per_mil_tokens": 9,
+    "input_cache_read_cost_per_mil_tokens": 0.15,
+    "displayName": "Gemini 3.5 Flash",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "fallback_models": [
+      "publishers/google/models/gemini-3.5-flash"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-3.1-flash-image": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 3,
+    "displayName": "Gemini 3.1 Flash Image",
+    "fallback_models": [
+      "publishers/google/models/gemini-3.1-flash-image"
+    ],
+    "supported_regions": [
+      "global"
+    ],
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-3.1-flash-image-preview": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 3,
+    "displayName": "Gemini 3.1 Flash Image Preview",
+    "fallback_models": [
+      "publishers/google/models/gemini-3.1-flash-image-preview"
+    ],
+    "supported_regions": [
+      "global"
+    ],
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-3.1-flash-lite": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 1.5,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "displayName": "Gemini 3.1 Flash-Lite",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "fallback_models": [
+      "publishers/google/models/gemini-3.1-flash-lite"
+    ],
+    "supported_regions": [
+      "global"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-3.1-flash-lite-image": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 1.5,
+    "displayName": "Gemini 3.1 Flash-Lite Image",
+    "fallback_models": [
+      "publishers/google/models/gemini-3.1-flash-lite-image"
+    ],
+    "supported_regions": [
+      "global"
+    ],
+    "max_input_tokens": 65536,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-3.1-flash-lite-preview": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 1.5,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "displayName": "Gemini 3.1 Flash-Lite (Preview)",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "fallback_models": [
+      "publishers/google/models/gemini-3.1-flash-lite-preview"
+    ],
+    "supported_regions": [
+      "global"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-3.1-pro-preview": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 12,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "Gemini 3.1 Pro (Preview)",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "fallback_models": [
+      "publishers/google/models/gemini-3.1-pro-preview"
+    ],
+    "supported_regions": [
+      "global"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-3.1-pro-preview-customtools": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 12,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "Gemini 3.1 Pro Custom Tools (Preview)",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "fallback_models": [
+      "publishers/google/models/gemini-3.1-pro-preview-customtools"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-3-flash-preview": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 3,
+    "input_cache_read_cost_per_mil_tokens": 0.05,
+    "displayName": "Gemini 3 Flash (Preview)",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "fallback_models": [
+      "publishers/google/models/gemini-3-flash-preview"
+    ],
+    "supported_regions": [
+      "global"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-3-pro-image": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 12,
+    "displayName": "Gemini 3 Pro Image",
+    "fallback_models": [
+      "publishers/google/models/gemini-3-pro-image"
+    ],
+    "supported_regions": [
+      "global"
+    ],
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-3-pro-image-preview": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 12,
+    "displayName": "Gemini 3 Pro Image Preview",
+    "fallback_models": [
+      "publishers/google/models/gemini-3-pro-image-preview"
+    ],
+    "supported_regions": [
+      "global"
+    ],
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-3-pro-preview": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 12,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "Gemini 3 Pro (Preview)",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "deprecation_date": "2026-03-09",
+    "fallback_models": [
+      "publishers/google/models/gemini-3-pro-preview"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-2.5-computer-use-preview-10-2025": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "Gemini 2.5 Computer Use Preview (10-2025)",
+    "fallback_models": [
+      "publishers/google/models/gemini-2.5-computer-use-preview-10-2025"
+    ],
+    "max_input_tokens": 128000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "google"
+    ]
+  },
+  "gemini-2.5-flash": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 2.5,
+    "input_cache_read_cost_per_mil_tokens": 0.03,
+    "displayName": "Gemini 2.5 Flash",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "fallback_models": [
+      "publishers/google/models/gemini-2.5-flash"
+    ],
+    "supported_regions": [
+      "global",
+      "asia-northeast1",
+      "asia-northeast3",
+      "asia-south1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-central2",
+      "europe-north1",
+      "europe-southwest1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "europe-west8",
+      "europe-west9",
+      "northamerica-northeast1",
+      "southamerica-east1",
+      "us-central1",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-south1",
+      "us-west1",
+      "us-west4"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-2.5-flash-image": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 2.5,
+    "displayName": "Gemini 2.5 Flash Image",
+    "fallback_models": [
+      "publishers/google/models/gemini-2.5-flash-image"
+    ],
+    "supported_regions": [
+      "global",
+      "europe-central2",
+      "europe-north1",
+      "europe-southwest1",
+      "europe-west1",
+      "europe-west4",
+      "europe-west8",
+      "us-central1",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-south1",
+      "us-west1",
+      "us-west4"
+    ],
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-2.5-flash-lite": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "input_cache_read_cost_per_mil_tokens": 0.01,
+    "displayName": "Gemini 2.5 Flash-Lite",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "fallback_models": [
+      "publishers/google/models/gemini-2.5-flash-lite"
+    ],
+    "supported_regions": [
+      "global",
+      "europe-central2",
+      "europe-north1",
+      "europe-southwest1",
+      "europe-west1",
+      "europe-west4",
+      "europe-west8",
+      "europe-west9",
+      "us-central1",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-south1",
+      "us-west1",
+      "us-west4"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-2.5-pro": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "Gemini 2.5 Pro",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "fallback_models": [
+      "publishers/google/models/gemini-2.5-pro"
+    ],
+    "supported_regions": [
+      "global",
+      "asia-northeast1",
+      "europe-central2",
+      "europe-north1",
+      "europe-southwest1",
+      "europe-west1",
+      "europe-west4",
+      "europe-west8",
+      "europe-west9",
+      "northamerica-northeast1",
+      "us-central1",
+      "us-east1",
+      "us-east4",
+      "us-east5",
+      "us-south1",
+      "us-west1",
+      "us-west4"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-2.0-flash-001": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "deprecation_date": "2026-06-01",
+    "parent": "gemini-2.0-flash",
+    "fallback_models": [
+      "publishers/google/models/gemini-2.0-flash-001"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-2.0-flash-lite-001": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.075,
+    "output_cost_per_mil_tokens": 0.3,
+    "input_cache_read_cost_per_mil_tokens": 0.01875,
+    "deprecation_date": "2026-06-01",
+    "parent": "gemini-2.0-flash-lite",
+    "fallback_models": [
+      "publishers/google/models/gemini-2.0-flash-lite-001"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-2.0-flash": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "displayName": "Gemini 2.0 Flash Latest",
+    "deprecation_date": "2026-06-01",
+    "fallback_models": [
+      "publishers/google/models/gemini-2.0-flash"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-2.0-flash-lite": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.075,
+    "output_cost_per_mil_tokens": 0.3,
+    "input_cache_read_cost_per_mil_tokens": 0.01875,
+    "displayName": "Gemini 2.0 Flash-Lite",
+    "deprecation_date": "2026-06-01",
+    "fallback_models": [
+      "publishers/google/models/gemini-2.0-flash-lite"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-embedding-2": {
+    "format": "google",
+    "flavor": "embedding",
+    "multimodal": true,
+    "displayName": "Gemini embedding 2",
+    "fallback_models": [
+      "publishers/google/models/gemini-embedding-2"
+    ],
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-embedding-001": {
+    "format": "google",
+    "flavor": "embedding",
+    "displayName": "Gemini embedding 001",
+    "fallback_models": [
+      "publishers/google/models/gemini-embedding-001"
+    ],
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "grok-4-0709": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "deprecated": true,
+    "deprecation_date": "2026-05-15",
+    "parent": "grok-4",
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-4-1-fast": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.5,
+    "input_cache_read_cost_per_mil_tokens": 0.05,
+    "displayName": "Grok 4.1 Fast",
+    "deprecated": true,
+    "deprecation_date": "2026-05-15",
+    "parent": "grok-4-1-fast",
+    "max_input_tokens": 2000000,
+    "max_output_tokens": 2000000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-4-1-fast-non-reasoning": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 2.5,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "Grok 4.1 Fast (Non-Reasoning)",
+    "deprecated": true,
+    "deprecation_date": "2026-05-15",
+    "parent": "grok-4-1-fast-non-reasoning-latest",
+    "max_input_tokens": 2000000,
+    "max_output_tokens": 2000000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-4-1-fast-non-reasoning-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 2.5,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "Grok 4.1 Fast (Non-Reasoning)",
+    "deprecated": true,
+    "deprecation_date": "2026-05-15",
+    "max_input_tokens": 2000000,
+    "max_output_tokens": 2000000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-4-1-fast-reasoning": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 2.5,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "Grok 4.1 Fast (Reasoning)",
+    "deprecated": true,
+    "deprecation_date": "2026-05-15",
+    "parent": "grok-4-1-fast-reasoning-latest",
+    "max_input_tokens": 2000000,
+    "max_output_tokens": 2000000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-4-1-fast-reasoning-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 2.5,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "Grok 4.1 Fast",
+    "deprecated": true,
+    "deprecation_date": "2026-05-15",
+    "max_input_tokens": 2000000,
+    "max_output_tokens": 2000000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-4.20-0309-non-reasoning": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 2.5,
+    "displayName": "Grok 4.20 (Non-Reasoning)",
+    "max_input_tokens": 1000000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-4.20-0309-reasoning": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 2.5,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "Grok 4.20 Reasoning (0309)",
+    "reasoning": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 2000000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-4.20-beta-0309-non-reasoning": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 2.5,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "Grok 4.20 Beta (Non-Reasoning)",
+    "parent": "grok-4.20-0309-non-reasoning",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 2000000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-4.20-beta-0309-reasoning": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 2.5,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "Grok 4.20 Beta Reasoning (0309)",
+    "reasoning": true,
+    "parent": "grok-4.20-0309-reasoning",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 2000000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-4.20-multi-agent-beta-0309": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 2.5,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "Grok 4.20 Multi-Agent Beta (0309)",
+    "reasoning": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 2000000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-4.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 6,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "Grok 4.5",
+    "reasoning": true,
+    "max_input_tokens": 500000,
+    "max_output_tokens": 500000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-4.5-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 6,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "Grok 4.5 (Latest)",
+    "reasoning": true,
+    "parent": "grok-4.5",
+    "max_input_tokens": 500000,
+    "max_output_tokens": 500000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-4.3": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 2.5,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "Grok 4.3 (Latest)",
+    "reasoning": true,
+    "parent": "grok-4.3-latest",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 1000000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-4.3-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 2.5,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "Grok 4.3",
+    "reasoning": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 1000000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-4": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "displayName": "Grok 4",
+    "deprecated": true,
+    "deprecation_date": "2026-05-15",
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-4-fast-non-reasoning": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 2.5,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "Grok 4 Fast (Non-Reasoning)",
+    "deprecated": true,
+    "deprecation_date": "2026-05-15",
+    "parent": "grok-4-fast-non-reasoning-latest",
+    "max_input_tokens": 2000000,
+    "max_output_tokens": 2000000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-4-fast-reasoning": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 2.5,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "Grok 4 Fast (Reasoning)",
+    "deprecated": true,
+    "deprecation_date": "2026-05-15",
+    "parent": "grok-4-fast-reasoning-latest",
+    "max_input_tokens": 2000000,
+    "max_output_tokens": 2000000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-4-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "parent": "grok-4",
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.75,
+    "deprecated": true,
+    "deprecation_date": "2026-05-15",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-3-beta": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.75,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-3-fast-beta": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-3-fast-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-3-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.75,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-3-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 0.5,
+    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "reasoning": true,
+    "deprecation_date": "2026-02-28",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-3-mini-beta": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 0.5,
+    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "reasoning": true,
+    "deprecation_date": "2026-02-28",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-3-mini-fast": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 4,
+    "input_cache_read_cost_per_mil_tokens": 0.15,
+    "reasoning": true,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-3-mini-fast-beta": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 4,
+    "input_cache_read_cost_per_mil_tokens": 0.15,
+    "reasoning": true,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-3-mini-fast-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 4,
+    "input_cache_read_cost_per_mil_tokens": 0.15,
+    "reasoning": true,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-3-mini-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 0.5,
+    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "reasoning": true,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-code-fast-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 1.5,
+    "input_cache_read_cost_per_mil_tokens": 0.02,
+    "reasoning": true,
+    "deprecated": true,
+    "deprecation_date": "2026-05-15",
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-code-fast-1-0825": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 1.5,
+    "input_cache_read_cost_per_mil_tokens": 0.02,
+    "displayName": "Grok Code Fast 1 (0825)",
+    "reasoning": true,
+    "deprecation_date": "2026-05-15",
+    "parent": "grok-code-fast-1",
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-build-0.1": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 2,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "reasoning": true,
+    "max_input_tokens": 256000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-build-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 6,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "Grok Build (Latest)",
+    "reasoning": true,
+    "max_input_tokens": 500000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-code-fast": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 1.5,
+    "input_cache_read_cost_per_mil_tokens": 0.02,
+    "reasoning": true,
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "grok-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 2.5,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "Grok Latest",
+    "reasoning": true,
+    "parent": "grok-4.3-latest",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 1000000,
+    "available_providers": [
+      "xAI"
+    ]
+  },
+  "databricks-claude-fable-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Fable 5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-sonnet-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Sonnet 5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-opus-4-8": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Opus 4.8",
+    "reasoning": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-opus-4-7": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Opus 4.7",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-opus-4-6": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Opus 4.6",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-sonnet-4-6": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Sonnet 4.6",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-haiku-4-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Haiku 4.5",
+    "max_input_tokens": 200000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-opus-4-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Opus 4.5",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 32000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-sonnet-4-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Sonnet 4.5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-opus-4-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Opus 4.1",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 32000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-sonnet-4": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Sonnet 4",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-3-7-sonnet": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.99999,
+    "output_cost_per_mil_tokens": 15.00002,
+    "displayName": "Claude Sonnet 3.7",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "deprecation_date": "2026-02-19",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-oss-120b": {
+    "format": "openai",
+    "flavor": "chat",
+    "displayName": "GPT-OSS 120B",
+    "reasoning": true,
+    "max_input_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-oss-20b": {
+    "format": "openai",
+    "flavor": "chat",
+    "displayName": "GPT-OSS 20B",
+    "reasoning": true,
+    "max_input_tokens": 131072,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-6-luna": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.6 Luna",
+    "reasoning": true,
+    "max_input_tokens": 400000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-6-sol": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.6 Sol",
+    "reasoning": true,
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-6-terra": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.6 Terra",
+    "reasoning": true,
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.5",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-4": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.4",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-4-nano": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.4 nano",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.2",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.1",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5 mini",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-nano": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5 nano",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gemini-3-1-flash-lite": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 3.1 Flash-Lite",
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gemini-3-1-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 3.1 Pro",
+    "max_input_tokens": 1000000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gemini-3-flash": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 3 Flash",
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gemini-2-5-flash": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 2.5 Flash",
+    "max_input_tokens": 1000000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gemini-2-5-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 2.5 Pro",
+    "max_input_tokens": 1000000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-meta-llama-3-3-70b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.50001,
+    "output_cost_per_mil_tokens": 1.50003,
+    "displayName": "Llama 3.3 70B Instruct",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-meta-llama-3-1-405b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 5.00003,
+    "output_cost_per_mil_tokens": 15.00002,
+    "displayName": "Llama 3.1 405B Instruct",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-meta-llama-3-1-8b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15001,
+    "output_cost_per_mil_tokens": 0.45003,
+    "displayName": "Llama 3.1 8B Instruct",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-llama-4-maverick": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Llama 4 Maverick",
+    "max_input_tokens": 1000000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-qwen35-122b-a10b": {
+    "format": "openai",
+    "flavor": "chat",
+    "displayName": "Qwen 3.5 122B-A10B",
+    "reasoning": true,
+    "experimental": true,
+    "max_input_tokens": 256000,
+    "max_output_tokens": 8000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-qwen3-next-80b-a3b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "displayName": "Qwen 3-Next 80B-A3B Instruct",
+    "experimental": true,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "databricks"
     ]
   }
 }

--- a/packages/proxy/schema/model_list.json
+++ b/packages/proxy/schema/model_list.json
@@ -8252,433 +8252,7 @@
       "vertex"
     ]
   },
-  "mistral.mixtral-8x7b-instruct-v0:1": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.45,
-    "output_cost_per_mil_tokens": 0.7,
-    "displayName": "Mixtral 8x7B",
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8191,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "mistral.mistral-7b-instruct-v0:2": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.2,
-    "displayName": "Mistral 7B",
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8191,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "mistral.mistral-large-2402-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 8,
-    "output_cost_per_mil_tokens": 24,
-    "displayName": "Mistral Large 24.02",
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8191,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "mistral.mistral-small-2402-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 3,
-    "displayName": "Mistral Small 24.02",
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8191,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "mistral.mistral-large-3-675b-instruct": {
-    "format": "converse",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 1.5,
-    "displayName": "Mistral Large 3 (675B)",
-    "max_input_tokens": 256000,
-    "max_output_tokens": 32000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "deepseek.v3.2": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.62,
-    "output_cost_per_mil_tokens": 1.85,
-    "displayName": "DeepSeek V3.2",
-    "max_input_tokens": 164000,
-    "max_output_tokens": 8000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "deepseek.v3-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "displayName": "DeepSeek V3.1",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "deepseek.r1-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "displayName": "DeepSeek R1",
-    "reasoning": true,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "amazon.nova-pro-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.8,
-    "output_cost_per_mil_tokens": 3.2,
-    "displayName": "Nova Pro",
-    "max_input_tokens": 300000,
-    "max_output_tokens": 10000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.amazon.nova-pro-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.8,
-    "output_cost_per_mil_tokens": 3.2,
-    "displayName": "US Nova Pro",
-    "parent": "amazon.nova-pro-v1:0",
-    "max_input_tokens": 300000,
-    "max_output_tokens": 10000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "amazon.nova-micro-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.035,
-    "output_cost_per_mil_tokens": 0.14,
-    "displayName": "Nova Micro",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 10000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.amazon.nova-micro-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.035,
-    "output_cost_per_mil_tokens": 0.14,
-    "displayName": "US Nova Micro",
-    "parent": "amazon.nova-micro-v1:0",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 10000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "amazon.nova-lite-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.06,
-    "output_cost_per_mil_tokens": 0.24,
-    "displayName": "Nova Lite",
-    "max_input_tokens": 300000,
-    "max_output_tokens": 10000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "amazon.nova-premier-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Nova Premier",
-    "reasoning": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 25000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "amazon.nova-2-lite-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Nova 2 Lite",
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.amazon.nova-lite-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.06,
-    "output_cost_per_mil_tokens": 0.24,
-    "displayName": "US Nova Lite",
-    "parent": "amazon.nova-lite-v1:0",
-    "max_input_tokens": 300000,
-    "max_output_tokens": 10000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.anthropic.claude-sonnet-4-6": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3.3,
-    "output_cost_per_mil_tokens": 16.5,
-    "input_cache_read_cost_per_mil_tokens": 0.33,
-    "input_cache_write_cost_per_mil_tokens": 4.125,
-    "displayName": "US Claude 4.6 Sonnet",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "anthropic.claude-sonnet-4-6",
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "global.anthropic.claude-sonnet-4-6": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "displayName": "Global Claude 4.6 Sonnet",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "anthropic.claude-sonnet-4-6",
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "anthropic.claude-sonnet-4-6": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "displayName": "Claude Sonnet 4.6",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "anthropic.claude-sonnet-4-5-20250929-v1:0": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "displayName": "Claude Sonnet 4.5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3.3,
-    "output_cost_per_mil_tokens": 16.5,
-    "input_cache_read_cost_per_mil_tokens": 0.33,
-    "input_cache_write_cost_per_mil_tokens": 4.125,
-    "displayName": "US Claude 4.5 Sonnet",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "anthropic.claude-sonnet-4-5-20250929-v1:0",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "displayName": "Global Claude 4.5 Sonnet",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "anthropic.claude-sonnet-4-5-20250929-v1:0",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "anthropic.claude-sonnet-4-20250514-v1:0": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "displayName": "Claude Sonnet 4",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.anthropic.claude-sonnet-4-20250514-v1:0": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "displayName": "US Claude 4 Sonnet",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "anthropic.claude-sonnet-4-20250514-v1:0",
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "anthropic.claude-haiku-4-5-20251001-v1:0": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 5,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "input_cache_write_cost_per_mil_tokens": 1.25,
-    "displayName": "Claude Haiku 4.5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.anthropic.claude-haiku-4-5-20251001-v1:0": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.1,
-    "output_cost_per_mil_tokens": 5.5,
-    "input_cache_read_cost_per_mil_tokens": 0.11,
-    "input_cache_write_cost_per_mil_tokens": 1.375,
-    "displayName": "US Claude 4.5 Haiku",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "anthropic.claude-haiku-4-5-20251001-v1:0",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "global.anthropic.claude-haiku-4-5-20251001-v1:0": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 5,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "input_cache_write_cost_per_mil_tokens": 1.25,
-    "displayName": "Global Claude 4.5 Haiku",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "anthropic.claude-haiku-4-5-20251001-v1:0",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "global.anthropic.claude-opus-4-7": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "displayName": "Global Claude 4.7 Opus",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "anthropic.claude-opus-4-7",
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "global.anthropic.claude-opus-4-8": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "displayName": "Global Claude 4.8 Opus",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "anthropic.claude-opus-4-8",
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "global.anthropic.claude-fable-5": {
+  "anthropic.claude-fable-5": {
     "format": "anthropic",
     "flavor": "chat",
     "multimodal": true,
@@ -8686,17 +8260,16 @@
     "output_cost_per_mil_tokens": 50,
     "input_cache_read_cost_per_mil_tokens": 1,
     "input_cache_write_cost_per_mil_tokens": 12.5,
-    "displayName": "Global Claude Fable 5",
+    "displayName": "Claude Fable 5",
     "reasoning": true,
     "reasoning_budget": true,
-    "parent": "anthropic.claude-fable-5",
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
     "available_providers": [
       "bedrock"
     ]
   },
-  "global.anthropic.claude-opus-4-6-v1": {
+  "anthropic.claude-opus-4-8": {
     "format": "anthropic",
     "flavor": "chat",
     "multimodal": true,
@@ -8704,141 +8277,7 @@
     "output_cost_per_mil_tokens": 25,
     "input_cache_read_cost_per_mil_tokens": 0.5,
     "input_cache_write_cost_per_mil_tokens": 6.25,
-    "displayName": "Global Claude 4.6 Opus",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "anthropic.claude-opus-4-6-v1",
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "global.anthropic.claude-sonnet-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "displayName": "Global Claude Sonnet 5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "anthropic.claude-sonnet-5",
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "anthropic.claude-3-5-sonnet-20241022-v2:0": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "displayName": "Claude Sonnet 3.5 v2",
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "apac.anthropic.claude-3-5-sonnet-20241022-v2:0": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "displayName": "APAC Claude 3.5 Sonnet v2",
-    "parent": "anthropic.claude-3-5-sonnet-20241022-v2:0",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "anthropic.claude-3-5-sonnet-20240620-v1:0": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "displayName": "Claude Sonnet 3.5",
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "apac.anthropic.claude-3-5-sonnet-20240620-v1:0": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "displayName": "APAC Claude 3.5 Sonnet",
-    "parent": "anthropic.claude-3-5-sonnet-20240620-v1:0",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.anthropic.claude-opus-4-5-20251101-v1:0": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5.5,
-    "output_cost_per_mil_tokens": 27.5,
-    "input_cache_read_cost_per_mil_tokens": 0.55,
-    "input_cache_write_cost_per_mil_tokens": 6.875,
-    "displayName": "US Claude 4.5 Opus",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "anthropic.claude-opus-4-5-20251101-v1:0",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.anthropic.claude-opus-4-6-v1": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "displayName": "US Claude 4.6 Opus",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "anthropic.claude-opus-4-6-v1",
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "anthropic.claude-opus-4-6-v1": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "displayName": "Claude Opus 4.6",
+    "displayName": "Claude Opus 4.8",
     "reasoning": true,
     "reasoning_budget": true,
     "max_input_tokens": 1000000,
@@ -8856,6 +8295,23 @@
     "input_cache_read_cost_per_mil_tokens": 0.5,
     "input_cache_write_cost_per_mil_tokens": 6.25,
     "displayName": "Claude Opus 4.7",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "anthropic.claude-opus-4-6-v1": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "displayName": "Claude Opus 4.6",
     "reasoning": true,
     "reasoning_budget": true,
     "max_input_tokens": 1000000,
@@ -8897,25 +8353,24 @@
       "bedrock"
     ]
   },
-  "us.anthropic.claude-opus-4-1-20250805-v1:0": {
+  "anthropic.claude-sonnet-5": {
     "format": "anthropic",
     "flavor": "chat",
     "multimodal": true,
-    "input_cost_per_mil_tokens": 15,
-    "output_cost_per_mil_tokens": 75,
-    "input_cache_read_cost_per_mil_tokens": 1.5,
-    "input_cache_write_cost_per_mil_tokens": 18.75,
-    "displayName": "US Claude 4.1 Opus",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "displayName": "Claude Sonnet 5",
     "reasoning": true,
     "reasoning_budget": true,
-    "parent": "anthropic.claude-opus-4-1-20250805-v1:0",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 32000,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
     "available_providers": [
       "bedrock"
     ]
   },
-  "anthropic.claude-3-sonnet-20240229-v1:0": {
+  "anthropic.claude-sonnet-4-6": {
     "format": "anthropic",
     "flavor": "chat",
     "multimodal": true,
@@ -8923,16 +8378,16 @@
     "output_cost_per_mil_tokens": 15,
     "input_cache_read_cost_per_mil_tokens": 0.3,
     "input_cache_write_cost_per_mil_tokens": 3.75,
-    "displayName": "Claude Sonnet 3",
-    "deprecated": true,
-    "deprecation_date": "2025-07-21",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 4096,
+    "displayName": "Claude Sonnet 4.6",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
     "available_providers": [
       "bedrock"
     ]
   },
-  "us.anthropic.claude-3-sonnet-20240229-v1:0": {
+  "anthropic.claude-sonnet-4-5-20250929-v1:0": {
     "format": "anthropic",
     "flavor": "chat",
     "multimodal": true,
@@ -8940,17 +8395,16 @@
     "output_cost_per_mil_tokens": 15,
     "input_cache_read_cost_per_mil_tokens": 0.3,
     "input_cache_write_cost_per_mil_tokens": 3.75,
-    "displayName": "US Claude 3 Sonnet",
-    "deprecated": true,
-    "deprecation_date": "2025-07-21",
-    "parent": "anthropic.claude-3-sonnet-20240229-v1:0",
+    "displayName": "Claude Sonnet 4.5",
+    "reasoning": true,
+    "reasoning_budget": true,
     "max_input_tokens": 200000,
-    "max_output_tokens": 4096,
+    "max_output_tokens": 64000,
     "available_providers": [
       "bedrock"
     ]
   },
-  "apac.anthropic.claude-3-sonnet-20240229-v1:0": {
+  "anthropic.claude-sonnet-4-20250514-v1:0": {
     "format": "anthropic",
     "flavor": "chat",
     "multimodal": true,
@@ -8958,17 +8412,33 @@
     "output_cost_per_mil_tokens": 15,
     "input_cache_read_cost_per_mil_tokens": 0.3,
     "input_cache_write_cost_per_mil_tokens": 3.75,
-    "displayName": "APAC Claude 3 Sonnet",
-    "deprecated": true,
-    "deprecation_date": "2025-07-21",
-    "parent": "anthropic.claude-3-sonnet-20240229-v1:0",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 4096,
+    "displayName": "Claude Sonnet 4",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
     "available_providers": [
       "bedrock"
     ]
   },
-  "eu.anthropic.claude-3-sonnet-20240229-v1:0": {
+  "anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 5,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "input_cache_write_cost_per_mil_tokens": 1.25,
+    "displayName": "Claude Haiku 4.5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "anthropic.claude-3-5-sonnet-20241022-v2:0": {
     "format": "anthropic",
     "flavor": "chat",
     "multimodal": true,
@@ -8976,11 +8446,23 @@
     "output_cost_per_mil_tokens": 15,
     "input_cache_read_cost_per_mil_tokens": 0.3,
     "input_cache_write_cost_per_mil_tokens": 3.75,
-    "displayName": "EU Claude 3 Sonnet",
-    "deprecated": true,
-    "deprecation_date": "2025-07-21",
-    "parent": "anthropic.claude-3-sonnet-20240229-v1:0",
-    "max_input_tokens": 200000,
+    "displayName": "Claude Sonnet 3.5 v2",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "anthropic.claude-3-5-sonnet-20240620-v1:0": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "displayName": "Claude Sonnet 3.5",
+    "max_input_tokens": 1000000,
     "max_output_tokens": 4096,
     "available_providers": [
       "bedrock"
@@ -9003,95 +8485,7 @@
       "bedrock"
     ]
   },
-  "anthropic.claude-opus-4-8": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "displayName": "Claude Opus 4.8",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "anthropic.claude-fable-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 10,
-    "output_cost_per_mil_tokens": 50,
-    "input_cache_read_cost_per_mil_tokens": 1,
-    "input_cache_write_cost_per_mil_tokens": 12.5,
-    "displayName": "Claude Fable 5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.anthropic.claude-3-haiku-20240307-v1:0": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 1.25,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "input_cache_write_cost_per_mil_tokens": 0.3125,
-    "displayName": "US Claude 3 Haiku",
-    "deprecated": true,
-    "deprecation_date": "2026-04-20",
-    "parent": "anthropic.claude-3-haiku-20240307-v1:0",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.anthropic.claude-opus-4-7": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5.5,
-    "output_cost_per_mil_tokens": 27.5,
-    "input_cache_read_cost_per_mil_tokens": 0.55,
-    "input_cache_write_cost_per_mil_tokens": 6.875,
-    "displayName": "US Claude 4.7 Opus",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "anthropic.claude-opus-4-7",
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.anthropic.claude-opus-4-8": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5.5,
-    "output_cost_per_mil_tokens": 27.5,
-    "input_cache_read_cost_per_mil_tokens": 0.55,
-    "input_cache_write_cost_per_mil_tokens": 6.875,
-    "displayName": "US Claude 4.8 Opus",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "anthropic.claude-opus-4-8",
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.anthropic.claude-sonnet-5": {
+  "anthropic.claude-3-sonnet-20240229-v1:0": {
     "format": "anthropic",
     "flavor": "chat",
     "multimodal": true,
@@ -9099,277 +8493,11 @@
     "output_cost_per_mil_tokens": 15,
     "input_cache_read_cost_per_mil_tokens": 0.3,
     "input_cache_write_cost_per_mil_tokens": 3.75,
-    "displayName": "US Claude Sonnet 5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "anthropic.claude-sonnet-5",
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "apac.anthropic.claude-3-haiku-20240307-v1:0": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 1.25,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "input_cache_write_cost_per_mil_tokens": 0.3125,
-    "displayName": "APAC Claude 3 Haiku",
+    "displayName": "Claude Sonnet 3",
     "deprecated": true,
-    "deprecation_date": "2026-04-20",
-    "parent": "anthropic.claude-3-haiku-20240307-v1:0",
+    "deprecation_date": "2025-07-21",
     "max_input_tokens": 200000,
     "max_output_tokens": 4096,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "eu.anthropic.claude-3-haiku-20240307-v1:0": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 1.25,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "input_cache_write_cost_per_mil_tokens": 0.3125,
-    "displayName": "EU Claude 3 Haiku",
-    "deprecated": true,
-    "deprecation_date": "2026-04-20",
-    "parent": "anthropic.claude-3-haiku-20240307-v1:0",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "meta.llama3-3-70b-instruct-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.72,
-    "output_cost_per_mil_tokens": 0.72,
-    "displayName": "Llama 3.3 70B Instruct",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.meta.llama3-3-70b-instruct-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.72,
-    "output_cost_per_mil_tokens": 0.72,
-    "displayName": "US Llama 3.3 70B Instruct",
-    "parent": "meta.llama3-3-70b-instruct-v1:0",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "meta.llama3-2-90b-instruct-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 2,
-    "displayName": "Llama 3.2 90B Vision Instruct",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.meta.llama3-2-90b-instruct-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 2,
-    "displayName": "US Llama 3.2 90B Vision Instruct",
-    "parent": "meta.llama3-2-90b-instruct-v1:0",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "meta.llama3-2-11b-instruct-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.35,
-    "output_cost_per_mil_tokens": 0.35,
-    "displayName": "Llama 3.2 11B Vision Instruct",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.meta.llama3-2-11b-instruct-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.35,
-    "output_cost_per_mil_tokens": 0.35,
-    "displayName": "US Llama 3.2 11B Vision Instruct",
-    "parent": "meta.llama3-2-11b-instruct-v1:0",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "meta.llama3-2-3b-instruct-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.15,
-    "displayName": "Llama 3.2 3B Instruct",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.meta.llama3-2-3b-instruct-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.15,
-    "displayName": "US Llama 3.2 3B Instruct",
-    "parent": "meta.llama3-2-3b-instruct-v1:0",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "eu.meta.llama3-2-3b-instruct-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.19,
-    "output_cost_per_mil_tokens": 0.19,
-    "displayName": "EU Llama 3.2 3B Instruct",
-    "parent": "meta.llama3-2-3b-instruct-v1:0",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "meta.llama3-2-1b-instruct-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "displayName": "Llama 3.2 1B Instruct",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.meta.llama3-2-1b-instruct-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "displayName": "US Llama 3.2 1B Instruct",
-    "parent": "meta.llama3-2-1b-instruct-v1:0",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "eu.meta.llama3-2-1b-instruct-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.13,
-    "output_cost_per_mil_tokens": 0.13,
-    "displayName": "EU Llama 3.2 1B Instruct",
-    "parent": "meta.llama3-2-1b-instruct-v1:0",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "meta.llama3-1-70b-instruct-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.99,
-    "output_cost_per_mil_tokens": 0.99,
-    "displayName": "Llama 3.1 70B Instruct",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 2048,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.meta.llama3-1-70b-instruct-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.99,
-    "output_cost_per_mil_tokens": 0.99,
-    "displayName": "US Llama 3.1 70B Instruct",
-    "parent": "meta.llama3-1-70b-instruct-v1:0",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 2048,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "meta.llama3-1-8b-instruct-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.22,
-    "output_cost_per_mil_tokens": 0.22,
-    "displayName": "Llama 3.1 8B Instruct",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 2048,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.meta.llama3-1-8b-instruct-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.22,
-    "output_cost_per_mil_tokens": 0.22,
-    "displayName": "US Llama 3.1 8B Instruct",
-    "parent": "meta.llama3-1-8b-instruct-v1:0",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 2048,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "meta.llama3-70b-instruct-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.65,
-    "output_cost_per_mil_tokens": 3.5,
-    "displayName": "Llama 3 70B Instruct",
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "meta.llama3-8b-instruct-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "Llama 3 8B Instruct",
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
     "available_providers": [
       "bedrock"
     ]
@@ -9398,85 +8526,47 @@
       "bedrock"
     ]
   },
-  "us.meta.llama4-scout-17b-instruct-v1:0": {
+  "mistral.devstral-2-123b": {
     "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.4,
+    "output_cost_per_mil_tokens": 2,
+    "displayName": "Devstral 2 123B",
+    "max_input_tokens": 256000,
+    "max_output_tokens": 32000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "google.gemma-4-31b": {
+    "format": "openai",
     "flavor": "chat",
     "multimodal": true,
-    "displayName": "US Llama 4 Scout",
-    "parent": "meta.llama4-scout-17b-instruct-v1:0",
-    "max_input_tokens": 10000000,
-    "max_output_tokens": 8000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.meta.llama4-maverick-17b-instruct-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "US Llama 4 Maverick",
-    "parent": "meta.llama4-maverick-17b-instruct-v1:0",
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "qwen.qwen3-32b-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "multimodal": false,
-    "displayName": "Qwen3 32B",
-    "reasoning": true,
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "qwen.qwen3-next-80b-a3b": {
-    "format": "converse",
-    "flavor": "chat",
-    "multimodal": false,
-    "displayName": "Qwen3 Next 80B A3B",
+    "displayName": "Gemma 4 31B",
     "reasoning": true,
     "max_input_tokens": 256000,
-    "max_output_tokens": 8000,
     "available_providers": [
       "bedrock"
     ]
   },
-  "qwen.qwen3-vl-235b-a22b": {
-    "format": "converse",
+  "google.gemma-4-26b-a4b": {
+    "format": "openai",
     "flavor": "chat",
     "multimodal": true,
-    "displayName": "Qwen3 VL 235B A22B",
+    "displayName": "Gemma 4 26B A4B",
+    "reasoning": true,
     "max_input_tokens": 256000,
-    "max_output_tokens": 8000,
     "available_providers": [
       "bedrock"
     ]
   },
-  "qwen.qwen3-coder-next": {
-    "format": "converse",
+  "google.gemma-4-e2b": {
+    "format": "openai",
     "flavor": "chat",
-    "multimodal": false,
-    "displayName": "Qwen3 Coder Next",
-    "max_input_tokens": 256000,
-    "max_output_tokens": 16000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "minimax.minimax-m2.5": {
-    "format": "converse",
-    "flavor": "chat",
-    "multimodal": false,
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 1.2,
-    "displayName": "MiniMax M2.5",
-    "max_input_tokens": 196000,
-    "max_output_tokens": 98000,
+    "multimodal": true,
+    "displayName": "Gemma 4 E2B",
+    "reasoning": true,
+    "max_input_tokens": 128000,
     "available_providers": [
       "bedrock"
     ]
@@ -9520,62 +8610,6 @@
       "bedrock"
     ]
   },
-  "nvidia.nemotron-super-3-120b": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.65,
-    "displayName": "NVIDIA Nemotron 3 Super 120B",
-    "max_input_tokens": 256000,
-    "max_output_tokens": 32000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "openai.gpt-oss-120b-1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "displayName": "OpenAI GPT-OSS (120B)",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "openai.gpt-oss-20b-1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "displayName": "OpenAI GPT-OSS (20B)",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "openai.gpt-oss-safeguard-120b": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "OpenAI GPT-OSS Safeguard (120B)",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "openai.gpt-oss-safeguard-20b": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.07,
-    "output_cost_per_mil_tokens": 0.2,
-    "displayName": "OpenAI GPT-OSS Safeguard (20B)",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
   "openai.gpt-5.5": {
     "format": "openai",
     "flavor": "chat",
@@ -9604,27 +8638,198 @@
       "bedrock"
     ]
   },
-  "nvidia.nemotron-nano-3-30b": {
+  "openai.gpt-oss-120b-1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "displayName": "OpenAI GPT-OSS (120B)",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "openai.gpt-oss-safeguard-120b": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "OpenAI GPT-OSS Safeguard (120B)",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "openai.gpt-oss-20b-1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "displayName": "OpenAI GPT-OSS (20B)",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "openai.gpt-oss-safeguard-20b": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.07,
+    "output_cost_per_mil_tokens": 0.2,
+    "displayName": "OpenAI GPT-OSS Safeguard (20B)",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "xai.grok-4.3": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 2.5,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "Grok 4.3",
+    "reasoning": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "moonshotai.kimi-k2.5": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 3,
+    "displayName": "Kimi K2.5",
+    "max_input_tokens": 256000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "moonshot.kimi-k2-thinking": {
     "format": "converse",
     "flavor": "chat",
     "multimodal": false,
-    "input_cost_per_mil_tokens": 0.06,
-    "output_cost_per_mil_tokens": 0.24,
-    "displayName": "NVIDIA Nemotron 3 Nano 30B",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.5,
+    "displayName": "Kimi K2 Thinking",
+    "reasoning": true,
     "max_input_tokens": 256000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "meta.llama3-70b-instruct-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.65,
+    "output_cost_per_mil_tokens": 3.5,
+    "displayName": "Llama 3 70B Instruct",
+    "max_input_tokens": 8192,
     "max_output_tokens": 8192,
     "available_providers": [
       "bedrock"
     ]
   },
-  "mistral.devstral-2-123b": {
+  "meta.llama3-8b-instruct-v1:0": {
     "format": "converse",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.4,
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "Llama 3 8B Instruct",
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "meta.llama3-3-70b-instruct-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.72,
+    "output_cost_per_mil_tokens": 0.72,
+    "displayName": "Llama 3.3 70B Instruct",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "meta.llama3-2-90b-instruct-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
     "output_cost_per_mil_tokens": 2,
-    "displayName": "Devstral 2 123B",
-    "max_input_tokens": 256000,
-    "max_output_tokens": 32000,
+    "displayName": "Llama 3.2 90B Vision Instruct",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "meta.llama3-2-11b-instruct-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.35,
+    "output_cost_per_mil_tokens": 0.35,
+    "displayName": "Llama 3.2 11B Vision Instruct",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "meta.llama3-2-3b-instruct-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.15,
+    "displayName": "Llama 3.2 3B Instruct",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "meta.llama3-2-1b-instruct-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "displayName": "Llama 3.2 1B Instruct",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "meta.llama3-1-70b-instruct-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.99,
+    "output_cost_per_mil_tokens": 0.99,
+    "displayName": "Llama 3.1 70B Instruct",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 2048,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "meta.llama3-1-8b-instruct-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.22,
+    "output_cost_per_mil_tokens": 0.22,
+    "displayName": "Llama 3.1 8B Instruct",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 2048,
     "available_providers": [
       "bedrock"
     ]
@@ -9643,123 +8848,15 @@
       "bedrock"
     ]
   },
-  "qwen.qwen3-235b-a22b-2507-v1:0": {
+  "minimax.minimax-m2.5": {
     "format": "converse",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.22,
-    "output_cost_per_mil_tokens": 0.88,
-    "displayName": "Qwen3 235B A22B (2507)",
-    "reasoning": true,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "qwen.qwen3-coder-480b-a35b-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "displayName": "Qwen3 Coder 480B A35B",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "qwen.qwen3-coder-30b-a3b-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "Qwen3 Coder 30B A3B",
-    "max_input_tokens": 262144,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "moonshotai.kimi-k2.5": {
-    "format": "converse",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 3,
-    "displayName": "Kimi K2.5",
-    "max_input_tokens": 256000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "writer.palmyra-x4-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "Palmyra X4",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "writer.palmyra-x5-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 6,
-    "displayName": "Palmyra X5",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.writer.palmyra-x4-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "US Palmyra X4",
-    "parent": "writer.palmyra-x4-v1:0",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.writer.palmyra-x5-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 6,
-    "displayName": "US Palmyra X5",
-    "parent": "writer.palmyra-x5-v1:0",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "us.deepseek.r1-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "displayName": "US DeepSeek R1",
-    "reasoning": true,
-    "parent": "deepseek.r1-v1:0",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "mistral.pixtral-large-2502-v1:0": {
-    "format": "converse",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Pixtral Large (2502)",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16000,
+    "multimodal": false,
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 1.2,
+    "displayName": "MiniMax M2.5",
+    "max_input_tokens": 196000,
+    "max_output_tokens": 98000,
     "available_providers": [
       "bedrock"
     ]
@@ -9803,6 +8900,702 @@
       "bedrock"
     ]
   },
+  "mistral.mistral-7b-instruct-v0:2": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.2,
+    "displayName": "Mistral 7B",
+    "max_input_tokens": 32000,
+    "max_output_tokens": 8191,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "mistral.mistral-large-3-675b-instruct": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 1.5,
+    "displayName": "Mistral Large 3 (675B)",
+    "max_input_tokens": 256000,
+    "max_output_tokens": 32000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "mistral.mistral-large-2402-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 8,
+    "output_cost_per_mil_tokens": 24,
+    "displayName": "Mistral Large 24.02",
+    "max_input_tokens": 32000,
+    "max_output_tokens": 8191,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "mistral.mistral-small-2402-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 3,
+    "displayName": "Mistral Small 24.02",
+    "max_input_tokens": 32000,
+    "max_output_tokens": 8191,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "mistral.mixtral-8x7b-instruct-v0:1": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.45,
+    "output_cost_per_mil_tokens": 0.7,
+    "displayName": "Mixtral 8x7B",
+    "max_input_tokens": 32000,
+    "max_output_tokens": 8191,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "nvidia.nemotron-nano-3-30b": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": false,
+    "input_cost_per_mil_tokens": 0.06,
+    "output_cost_per_mil_tokens": 0.24,
+    "displayName": "NVIDIA Nemotron 3 Nano 30B",
+    "max_input_tokens": 256000,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "nvidia.nemotron-super-3-120b": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.65,
+    "displayName": "NVIDIA Nemotron 3 Super 120B",
+    "max_input_tokens": 256000,
+    "max_output_tokens": 32000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "amazon.nova-2-lite-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Nova 2 Lite",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "amazon.nova-lite-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.06,
+    "output_cost_per_mil_tokens": 0.24,
+    "displayName": "Nova Lite",
+    "max_input_tokens": 300000,
+    "max_output_tokens": 10000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "amazon.nova-micro-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.035,
+    "output_cost_per_mil_tokens": 0.14,
+    "displayName": "Nova Micro",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 10000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "amazon.nova-premier-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Nova Premier",
+    "reasoning": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 25000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "amazon.nova-pro-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.8,
+    "output_cost_per_mil_tokens": 3.2,
+    "displayName": "Nova Pro",
+    "max_input_tokens": 300000,
+    "max_output_tokens": 10000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "writer.palmyra-x5-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 6,
+    "displayName": "Palmyra X5",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "writer.palmyra-x4-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "Palmyra X4",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "mistral.pixtral-large-2502-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Pixtral Large (2502)",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "qwen.qwen3-coder-480b-a35b-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "displayName": "Qwen3 Coder 480B A35B",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "qwen.qwen3-235b-a22b-2507-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.22,
+    "output_cost_per_mil_tokens": 0.88,
+    "displayName": "Qwen3 235B A22B (2507)",
+    "reasoning": true,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "qwen.qwen3-vl-235b-a22b": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Qwen3 VL 235B A22B",
+    "max_input_tokens": 256000,
+    "max_output_tokens": 8000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "qwen.qwen3-next-80b-a3b": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": false,
+    "displayName": "Qwen3 Next 80B A3B",
+    "reasoning": true,
+    "max_input_tokens": 256000,
+    "max_output_tokens": 8000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "qwen.qwen3-32b-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": false,
+    "displayName": "Qwen3 32B",
+    "reasoning": true,
+    "max_input_tokens": 32000,
+    "max_output_tokens": 8000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "qwen.qwen3-coder-30b-a3b-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "Qwen3 Coder 30B A3B",
+    "max_input_tokens": 262144,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "qwen.qwen3-coder-next": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": false,
+    "displayName": "Qwen3 Coder Next",
+    "max_input_tokens": 256000,
+    "max_output_tokens": 16000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "deepseek.r1-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "displayName": "DeepSeek R1",
+    "reasoning": true,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "deepseek.v3.2": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.62,
+    "output_cost_per_mil_tokens": 1.85,
+    "displayName": "DeepSeek V3.2",
+    "max_input_tokens": 164000,
+    "max_output_tokens": 8000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "deepseek.v3-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "displayName": "DeepSeek V3.1",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.anthropic.claude-opus-4-8": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5.5,
+    "output_cost_per_mil_tokens": 27.5,
+    "input_cache_read_cost_per_mil_tokens": 0.55,
+    "input_cache_write_cost_per_mil_tokens": 6.875,
+    "displayName": "US Claude 4.8 Opus",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "anthropic.claude-opus-4-8",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.anthropic.claude-opus-4-7": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5.5,
+    "output_cost_per_mil_tokens": 27.5,
+    "input_cache_read_cost_per_mil_tokens": 0.55,
+    "input_cache_write_cost_per_mil_tokens": 6.875,
+    "displayName": "US Claude 4.7 Opus",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "anthropic.claude-opus-4-7",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.anthropic.claude-opus-4-6-v1": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "displayName": "US Claude 4.6 Opus",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "anthropic.claude-opus-4-6-v1",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.anthropic.claude-opus-4-5-20251101-v1:0": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5.5,
+    "output_cost_per_mil_tokens": 27.5,
+    "input_cache_read_cost_per_mil_tokens": 0.55,
+    "input_cache_write_cost_per_mil_tokens": 6.875,
+    "displayName": "US Claude 4.5 Opus",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "anthropic.claude-opus-4-5-20251101-v1:0",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.anthropic.claude-opus-4-1-20250805-v1:0": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 15,
+    "output_cost_per_mil_tokens": 75,
+    "input_cache_read_cost_per_mil_tokens": 1.5,
+    "input_cache_write_cost_per_mil_tokens": 18.75,
+    "displayName": "US Claude 4.1 Opus",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "anthropic.claude-opus-4-1-20250805-v1:0",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 32000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.anthropic.claude-sonnet-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "displayName": "US Claude Sonnet 5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "anthropic.claude-sonnet-5",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.anthropic.claude-sonnet-4-6": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3.3,
+    "output_cost_per_mil_tokens": 16.5,
+    "input_cache_read_cost_per_mil_tokens": 0.33,
+    "input_cache_write_cost_per_mil_tokens": 4.125,
+    "displayName": "US Claude 4.6 Sonnet",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "anthropic.claude-sonnet-4-6",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3.3,
+    "output_cost_per_mil_tokens": 16.5,
+    "input_cache_read_cost_per_mil_tokens": 0.33,
+    "input_cache_write_cost_per_mil_tokens": 4.125,
+    "displayName": "US Claude 4.5 Sonnet",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.anthropic.claude-sonnet-4-20250514-v1:0": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "displayName": "US Claude 4 Sonnet",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "anthropic.claude-sonnet-4-20250514-v1:0",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.1,
+    "output_cost_per_mil_tokens": 5.5,
+    "input_cache_read_cost_per_mil_tokens": 0.11,
+    "input_cache_write_cost_per_mil_tokens": 1.375,
+    "displayName": "US Claude 4.5 Haiku",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "anthropic.claude-haiku-4-5-20251001-v1:0",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.anthropic.claude-3-haiku-20240307-v1:0": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 1.25,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "input_cache_write_cost_per_mil_tokens": 0.3125,
+    "displayName": "US Claude 3 Haiku",
+    "deprecated": true,
+    "deprecation_date": "2026-04-20",
+    "parent": "anthropic.claude-3-haiku-20240307-v1:0",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.anthropic.claude-3-sonnet-20240229-v1:0": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "displayName": "US Claude 3 Sonnet",
+    "deprecated": true,
+    "deprecation_date": "2025-07-21",
+    "parent": "anthropic.claude-3-sonnet-20240229-v1:0",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.meta.llama4-maverick-17b-instruct-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "US Llama 4 Maverick",
+    "parent": "meta.llama4-maverick-17b-instruct-v1:0",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.meta.llama4-scout-17b-instruct-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "US Llama 4 Scout",
+    "parent": "meta.llama4-scout-17b-instruct-v1:0",
+    "max_input_tokens": 10000000,
+    "max_output_tokens": 8000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.meta.llama3-3-70b-instruct-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.72,
+    "output_cost_per_mil_tokens": 0.72,
+    "displayName": "US Llama 3.3 70B Instruct",
+    "parent": "meta.llama3-3-70b-instruct-v1:0",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.meta.llama3-2-90b-instruct-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 2,
+    "displayName": "US Llama 3.2 90B Vision Instruct",
+    "parent": "meta.llama3-2-90b-instruct-v1:0",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.meta.llama3-2-11b-instruct-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.35,
+    "output_cost_per_mil_tokens": 0.35,
+    "displayName": "US Llama 3.2 11B Vision Instruct",
+    "parent": "meta.llama3-2-11b-instruct-v1:0",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.meta.llama3-2-3b-instruct-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.15,
+    "displayName": "US Llama 3.2 3B Instruct",
+    "parent": "meta.llama3-2-3b-instruct-v1:0",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.meta.llama3-2-1b-instruct-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "displayName": "US Llama 3.2 1B Instruct",
+    "parent": "meta.llama3-2-1b-instruct-v1:0",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.meta.llama3-1-70b-instruct-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.99,
+    "output_cost_per_mil_tokens": 0.99,
+    "displayName": "US Llama 3.1 70B Instruct",
+    "parent": "meta.llama3-1-70b-instruct-v1:0",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 2048,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.meta.llama3-1-8b-instruct-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.22,
+    "output_cost_per_mil_tokens": 0.22,
+    "displayName": "US Llama 3.1 8B Instruct",
+    "parent": "meta.llama3-1-8b-instruct-v1:0",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 2048,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.amazon.nova-lite-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.06,
+    "output_cost_per_mil_tokens": 0.24,
+    "displayName": "US Nova Lite",
+    "parent": "amazon.nova-lite-v1:0",
+    "max_input_tokens": 300000,
+    "max_output_tokens": 10000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.amazon.nova-micro-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.035,
+    "output_cost_per_mil_tokens": 0.14,
+    "displayName": "US Nova Micro",
+    "parent": "amazon.nova-micro-v1:0",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 10000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.amazon.nova-pro-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.8,
+    "output_cost_per_mil_tokens": 3.2,
+    "displayName": "US Nova Pro",
+    "parent": "amazon.nova-pro-v1:0",
+    "max_input_tokens": 300000,
+    "max_output_tokens": 10000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.writer.palmyra-x5-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 6,
+    "displayName": "US Palmyra X5",
+    "parent": "writer.palmyra-x5-v1:0",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "us.writer.palmyra-x4-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "US Palmyra X4",
+    "parent": "writer.palmyra-x4-v1:0",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
   "us.mistral.pixtral-large-2502-v1:0": {
     "format": "converse",
     "flavor": "chat",
@@ -9815,6 +9608,292 @@
       "bedrock"
     ]
   },
+  "us.deepseek.r1-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "displayName": "US DeepSeek R1",
+    "reasoning": true,
+    "parent": "deepseek.r1-v1:0",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "global.anthropic.claude-fable-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 10,
+    "output_cost_per_mil_tokens": 50,
+    "input_cache_read_cost_per_mil_tokens": 1,
+    "input_cache_write_cost_per_mil_tokens": 12.5,
+    "displayName": "Global Claude Fable 5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "anthropic.claude-fable-5",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "global.anthropic.claude-opus-4-8": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "displayName": "Global Claude 4.8 Opus",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "anthropic.claude-opus-4-8",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "global.anthropic.claude-opus-4-7": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "displayName": "Global Claude 4.7 Opus",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "anthropic.claude-opus-4-7",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "global.anthropic.claude-opus-4-6-v1": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "displayName": "Global Claude 4.6 Opus",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "anthropic.claude-opus-4-6-v1",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "global.anthropic.claude-sonnet-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "displayName": "Global Claude Sonnet 5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "anthropic.claude-sonnet-5",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "global.anthropic.claude-sonnet-4-6": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "displayName": "Global Claude 4.6 Sonnet",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "anthropic.claude-sonnet-4-6",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "displayName": "Global Claude 4.5 Sonnet",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "global.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 5,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "input_cache_write_cost_per_mil_tokens": 1.25,
+    "displayName": "Global Claude 4.5 Haiku",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "anthropic.claude-haiku-4-5-20251001-v1:0",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "apac.anthropic.claude-3-5-sonnet-20241022-v2:0": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "displayName": "APAC Claude 3.5 Sonnet v2",
+    "parent": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "apac.anthropic.claude-3-5-sonnet-20240620-v1:0": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "displayName": "APAC Claude 3.5 Sonnet",
+    "parent": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "apac.anthropic.claude-3-haiku-20240307-v1:0": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 1.25,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "input_cache_write_cost_per_mil_tokens": 0.3125,
+    "displayName": "APAC Claude 3 Haiku",
+    "deprecated": true,
+    "deprecation_date": "2026-04-20",
+    "parent": "anthropic.claude-3-haiku-20240307-v1:0",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "apac.anthropic.claude-3-sonnet-20240229-v1:0": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "displayName": "APAC Claude 3 Sonnet",
+    "deprecated": true,
+    "deprecation_date": "2025-07-21",
+    "parent": "anthropic.claude-3-sonnet-20240229-v1:0",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "eu.anthropic.claude-3-haiku-20240307-v1:0": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 1.25,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "input_cache_write_cost_per_mil_tokens": 0.3125,
+    "displayName": "EU Claude 3 Haiku",
+    "deprecated": true,
+    "deprecation_date": "2026-04-20",
+    "parent": "anthropic.claude-3-haiku-20240307-v1:0",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "eu.anthropic.claude-3-sonnet-20240229-v1:0": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "displayName": "EU Claude 3 Sonnet",
+    "deprecated": true,
+    "deprecation_date": "2025-07-21",
+    "parent": "anthropic.claude-3-sonnet-20240229-v1:0",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "eu.meta.llama3-2-3b-instruct-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.19,
+    "output_cost_per_mil_tokens": 0.19,
+    "displayName": "EU Llama 3.2 3B Instruct",
+    "parent": "meta.llama3-2-3b-instruct-v1:0",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
+  "eu.meta.llama3-2-1b-instruct-v1:0": {
+    "format": "converse",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.13,
+    "output_cost_per_mil_tokens": 0.13,
+    "displayName": "EU Llama 3.2 1B Instruct",
+    "parent": "meta.llama3-2-1b-instruct-v1:0",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "bedrock"
+    ]
+  },
   "eu.mistral.pixtral-large-2502-v1:0": {
     "format": "converse",
     "flavor": "chat",
@@ -9823,85 +9902,6 @@
     "parent": "mistral.pixtral-large-2502-v1:0",
     "max_input_tokens": 128000,
     "max_output_tokens": 16000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "moonshot.kimi-k2-thinking": {
-    "format": "converse",
-    "flavor": "chat",
-    "multimodal": false,
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.5,
-    "displayName": "Kimi K2 Thinking",
-    "reasoning": true,
-    "max_input_tokens": 256000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "xai.grok-4.3": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 2.5,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "Grok 4.3",
-    "reasoning": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "anthropic.claude-sonnet-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "displayName": "Claude Sonnet 5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "google.gemma-4-31b": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemma 4 31B",
-    "reasoning": true,
-    "max_input_tokens": 256000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "google.gemma-4-26b-a4b": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemma 4 26B A4B",
-    "reasoning": true,
-    "max_input_tokens": 256000,
-    "available_providers": [
-      "bedrock"
-    ]
-  },
-  "google.gemma-4-e2b": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemma 4 E2B",
-    "reasoning": true,
-    "max_input_tokens": 128000,
     "available_providers": [
       "bedrock"
     ]

--- a/packages/proxy/schema/model_list.json
+++ b/packages/proxy/schema/model_list.json
@@ -17,6 +17,300 @@
       "azure"
     ]
   },
+  "o4-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.1,
+    "output_cost_per_mil_tokens": 4.4,
+    "input_cache_read_cost_per_mil_tokens": 0.275,
+    "displayName": "o4-mini",
+    "reasoning": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o4-mini-2025-04-16": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.1,
+    "output_cost_per_mil_tokens": 4.4,
+    "input_cache_read_cost_per_mil_tokens": 0.275,
+    "displayName": "o4-mini (2025-04-16)",
+    "reasoning": true,
+    "deprecation_date": "2026-10-23",
+    "parent": "o4-mini",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-audio-2025-08-28": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "GPT Audio (2025-08-28)",
+    "parent": "gpt-audio",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-audio": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "GPT Audio",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-realtime-2025-08-28": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 4,
+    "output_cost_per_mil_tokens": 16,
+    "input_cache_read_cost_per_mil_tokens": 0.4,
+    "displayName": "GPT Realtime (2025-08-28)",
+    "parent": "gpt-realtime",
+    "max_input_tokens": 32000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-realtime": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 4,
+    "output_cost_per_mil_tokens": 16,
+    "input_cache_read_cost_per_mil_tokens": 0.4,
+    "displayName": "GPT Realtime",
+    "max_input_tokens": 32000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-image-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "displayName": "GPT Image 2",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-image-2-2026-04-21": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "displayName": "GPT Image 2 (2026-04-21)",
+    "parent": "gpt-image-2",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "chatgpt-image-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 5,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "dall-e-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "hd/1024-x-1024/dall-e-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "hd/1024-x-1792/dall-e-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "hd/1792-x-1024/dall-e-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "standard/1024-x-1024/dall-e-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "standard/1024-x-1792/dall-e-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "standard/1792-x-1024/dall-e-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "openai/sora-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "sora-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "tts-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "whisper-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "omni-moderation-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "text-moderation-007": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "babbage-002": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.4,
+    "output_cost_per_mil_tokens": 0.4,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "davinci-002": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "ft:gpt-4.1-2025-04-14": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 12,
+    "input_cache_read_cost_per_mil_tokens": 0.75,
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "openai/container": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "chat-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 30,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "GPT Chat Latest",
+    "reasoning": true,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
   "gpt-5.6-luna": {
     "format": "openai",
     "flavor": "chat",
@@ -29,1329 +323,6 @@
     "reasoning": true,
     "max_input_tokens": 1050000,
     "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.6-sol": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 30,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "displayName": "GPT-5.6 Sol",
-    "reasoning": true,
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.6-terra": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.25,
-    "input_cache_write_cost_per_mil_tokens": 3.125,
-    "displayName": "GPT-5.6 Terra",
-    "reasoning": true,
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 30,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "displayName": "GPT-5.5",
-    "reasoning": true,
-    "fallback_models": [
-      "openai.gpt-5.5"
-    ],
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.5-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 30,
-    "output_cost_per_mil_tokens": 180,
-    "input_cache_read_cost_per_mil_tokens": 3,
-    "displayName": "GPT-5.5 Pro",
-    "reasoning": true,
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.5-2026-04-23": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 30,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "displayName": "GPT-5.5 (2026-04-23)",
-    "reasoning": true,
-    "parent": "gpt-5.5",
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.5-pro-2026-04-23": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 30,
-    "output_cost_per_mil_tokens": 180,
-    "input_cache_read_cost_per_mil_tokens": 3,
-    "displayName": "GPT-5.5 Pro (2026-04-23)",
-    "reasoning": true,
-    "parent": "gpt-5.5-pro",
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.4": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.25,
-    "displayName": "GPT-5.4",
-    "reasoning": true,
-    "fallback_models": [
-      "openai.gpt-5.4"
-    ],
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.4-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.75,
-    "output_cost_per_mil_tokens": 4.5,
-    "input_cache_read_cost_per_mil_tokens": 0.075,
-    "displayName": "GPT-5.4 mini",
-    "reasoning": true,
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.4-nano": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 1.25,
-    "input_cache_read_cost_per_mil_tokens": 0.02,
-    "displayName": "GPT-5.4 nano",
-    "reasoning": true,
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.4-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 30,
-    "output_cost_per_mil_tokens": 180,
-    "input_cache_read_cost_per_mil_tokens": 3,
-    "displayName": "GPT-5.4 Pro",
-    "reasoning": true,
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.4-mini-2026-03-17": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.75,
-    "output_cost_per_mil_tokens": 4.5,
-    "input_cache_read_cost_per_mil_tokens": 0.075,
-    "displayName": "GPT-5.4 mini (2026-03-17)",
-    "reasoning": true,
-    "parent": "gpt-5.4-mini",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.4-nano-2026-03-17": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 1.25,
-    "input_cache_read_cost_per_mil_tokens": 0.02,
-    "displayName": "GPT-5.4 nano (2026-03-17)",
-    "reasoning": true,
-    "parent": "gpt-5.4-nano",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.4-2026-03-05": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.25,
-    "displayName": "GPT-5.4 (2026-03-05)",
-    "reasoning": true,
-    "parent": "gpt-5.4",
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.4-pro-2026-03-05": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 30,
-    "output_cost_per_mil_tokens": 180,
-    "input_cache_read_cost_per_mil_tokens": 3,
-    "displayName": "GPT-5.4 Pro (2026-03-05)",
-    "reasoning": true,
-    "parent": "gpt-5.4-pro",
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.3-chat-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.75,
-    "output_cost_per_mil_tokens": 14,
-    "input_cache_read_cost_per_mil_tokens": 0.175,
-    "displayName": "GPT-5.3 chat",
-    "reasoning": true,
-    "deprecation_date": "2026-08-10",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.3-codex": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.75,
-    "output_cost_per_mil_tokens": 14,
-    "input_cache_read_cost_per_mil_tokens": 0.175,
-    "displayName": "GPT-5.3 Codex",
-    "reasoning": true,
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.2": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.75,
-    "output_cost_per_mil_tokens": 14,
-    "input_cache_read_cost_per_mil_tokens": 0.175,
-    "displayName": "GPT-5.2",
-    "reasoning": true,
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.2-chat-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.75,
-    "output_cost_per_mil_tokens": 14,
-    "input_cache_read_cost_per_mil_tokens": 0.175,
-    "displayName": "GPT-5.2 chat",
-    "reasoning": true,
-    "deprecation_date": "2026-08-10",
-    "parent": "gpt-5.2",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.2-codex": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.75,
-    "output_cost_per_mil_tokens": 14,
-    "input_cache_read_cost_per_mil_tokens": 0.175,
-    "displayName": "GPT-5.2 Codex",
-    "reasoning": true,
-    "deprecation_date": "2026-07-23",
-    "parent": "gpt-5.2",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.2-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 21,
-    "output_cost_per_mil_tokens": 168,
-    "displayName": "GPT-5.2 Pro",
-    "reasoning": true,
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.2-2025-12-11": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.75,
-    "output_cost_per_mil_tokens": 14,
-    "input_cache_read_cost_per_mil_tokens": 0.175,
-    "displayName": "GPT-5.2 (2025-12-11)",
-    "reasoning": true,
-    "parent": "gpt-5.2",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.2-pro-2025-12-11": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 21,
-    "output_cost_per_mil_tokens": 168,
-    "displayName": "GPT-5.2 Pro (2025-12-11)",
-    "reasoning": true,
-    "parent": "gpt-5.2-pro",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.1": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5.1",
-    "reasoning": true,
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.1-chat-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5.1 chat",
-    "reasoning": true,
-    "deprecation_date": "2026-07-23",
-    "parent": "gpt-5.1",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.1-codex": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5.1 Codex",
-    "reasoning": true,
-    "deprecation_date": "2026-07-23",
-    "parent": "gpt-5.1",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.1-codex-max": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "reasoning": true,
-    "deprecation_date": "2026-07-23",
-    "parent": "gpt-5.1",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.1-codex-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 2,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "displayName": "GPT-5.1 Codex Mini",
-    "reasoning": true,
-    "deprecation_date": "2026-07-23",
-    "parent": "gpt-5.1",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.1-2025-11-13": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5.1 (2025-11-13)",
-    "reasoning": true,
-    "parent": "gpt-5.1",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5",
-    "reasoning": true,
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-chat-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5 chat",
-    "reasoning": true,
-    "deprecation_date": "2026-07-23",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-codex": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5 Codex",
-    "reasoning": true,
-    "deprecation_date": "2026-07-23",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 2,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "displayName": "GPT-5 mini",
-    "reasoning": true,
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-nano": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.05,
-    "output_cost_per_mil_tokens": 0.4,
-    "input_cache_read_cost_per_mil_tokens": 0.005,
-    "displayName": "GPT-5 nano",
-    "reasoning": true,
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 15,
-    "output_cost_per_mil_tokens": 120,
-    "displayName": "GPT-5 Pro",
-    "reasoning": true,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 272000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-search-api": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5 Search API",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-search-api-2025-10-14": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5 Search API (2025-10-14)",
-    "parent": "gpt-5-search-api",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-pro-2025-10-06": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 15,
-    "output_cost_per_mil_tokens": 120,
-    "displayName": "GPT-5 Pro (2025-10-06)",
-    "reasoning": true,
-    "parent": "gpt-5-pro",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 272000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-2025-08-07": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5 (2025-08-07)",
-    "reasoning": true,
-    "deprecation_date": "2026-12-11",
-    "parent": "gpt-5",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-mini-2025-08-07": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 2,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "displayName": "GPT-5 mini (2025-08-07)",
-    "reasoning": true,
-    "deprecation_date": "2026-12-11",
-    "parent": "gpt-5-mini",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-nano-2025-08-07": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.05,
-    "output_cost_per_mil_tokens": 0.4,
-    "input_cache_read_cost_per_mil_tokens": 0.005,
-    "displayName": "GPT-5 nano (2025-08-07)",
-    "reasoning": true,
-    "parent": "gpt-5-nano",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4.1": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 8,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "displayName": "GPT-4.1",
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4.1-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.4,
-    "output_cost_per_mil_tokens": 1.6,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "displayName": "GPT-4.1 mini",
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4.1-nano": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "displayName": "GPT-4.1 nano",
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4.1-2025-04-14": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 8,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "displayName": "GPT-4.1 (2025-04-14)",
-    "parent": "gpt-4.1",
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4.1-mini-2025-04-14": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.4,
-    "output_cost_per_mil_tokens": 1.6,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "displayName": "GPT-4.1 mini (2025-04-14)",
-    "parent": "gpt-4.1-mini",
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4.1-nano-2025-04-14": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "displayName": "GPT-4.1 nano (2025-04-14)",
-    "parent": "gpt-4.1-nano",
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 30,
-    "output_cost_per_mil_tokens": 60,
-    "displayName": "GPT-4",
-    "max_input_tokens": 8192,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4-turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 10,
-    "output_cost_per_mil_tokens": 30,
-    "displayName": "GPT-4 Turbo",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "displayName": "GPT-4o",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-audio-preview": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "GPT-4o Audio Preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "input_cache_read_cost_per_mil_tokens": 0.075,
-    "displayName": "GPT-4o mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-audio-preview": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "GPT-4o mini Audio Preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-realtime-preview": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "displayName": "GPT-4o mini Realtime Preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-search-preview": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "input_cache_read_cost_per_mil_tokens": 0.075,
-    "displayName": "GPT-4o mini Search Preview",
-    "experimental": true,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-transcribe": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 5,
-    "displayName": "GPT-4o mini Transcribe",
-    "max_input_tokens": 16000,
-    "max_output_tokens": 2000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-tts": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "GPT-4o mini TTS",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-realtime-preview": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 20,
-    "input_cache_read_cost_per_mil_tokens": 2.5,
-    "displayName": "GPT-4o Realtime Preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-search-preview": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "displayName": "GPT-4o Search Preview",
-    "experimental": true,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-transcribe": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "max_input_tokens": 16000,
-    "max_output_tokens": 2000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-transcribe-diarize": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "max_input_tokens": 16000,
-    "max_output_tokens": 2000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-transcribe-2025-12-15": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 5,
-    "displayName": "GPT-4o mini Transcribe (2025-12-15)",
-    "parent": "gpt-4o-mini-transcribe",
-    "max_input_tokens": 16000,
-    "max_output_tokens": 2000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-tts-2025-12-15": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "GPT-4o mini TTS (2025-12-15)",
-    "parent": "gpt-4o-mini-tts",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-audio-preview-2025-06-03": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "GPT-4o Audio Preview (2025-06-03)",
-    "parent": "gpt-4o-audio-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-realtime-preview-2025-06-03": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 20,
-    "input_cache_read_cost_per_mil_tokens": 2.5,
-    "displayName": "GPT-4o Realtime Preview (2025-06-03)",
-    "parent": "gpt-4o-realtime-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-transcribe-2025-03-20": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 5,
-    "displayName": "GPT-4o mini Transcribe (2025-03-20)",
-    "parent": "gpt-4o-mini-transcribe",
-    "max_input_tokens": 16000,
-    "max_output_tokens": 2000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-tts-2025-03-20": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "GPT-4o mini TTS (2025-03-20)",
-    "parent": "gpt-4o-mini-tts",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-search-preview-2025-03-11": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "input_cache_read_cost_per_mil_tokens": 0.075,
-    "displayName": "GPT-4o mini Search Preview (2025-03-11)",
-    "experimental": true,
-    "parent": "gpt-4o-mini-search-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-search-preview-2025-03-11": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "displayName": "GPT-4o Search Preview (2025-03-11)",
-    "experimental": true,
-    "parent": "gpt-4o-search-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-audio-preview-2024-12-17": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "GPT-4o Audio Preview (2024-12-17)",
-    "parent": "gpt-4o-audio-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-audio-preview-2024-12-17": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "GPT-4o mini Audio Preview (2024-12-17)",
-    "parent": "gpt-4o-mini-audio-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-realtime-preview-2024-12-17": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "displayName": "GPT-4o mini Realtime Preview (2024-12-17)",
-    "parent": "gpt-4o-mini-realtime-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-realtime-preview-2024-12-17": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 20,
-    "input_cache_read_cost_per_mil_tokens": 2.5,
-    "displayName": "GPT-4o Realtime Preview (2024-12-17)",
-    "parent": "gpt-4o-realtime-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-2024-11-20": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "displayName": "GPT-4o (2024-11-20)",
-    "parent": "gpt-4o",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-2024-08-06": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "displayName": "GPT-4o (2024-08-06)",
-    "parent": "gpt-4o",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-2024-07-18": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "input_cache_read_cost_per_mil_tokens": 0.075,
-    "displayName": "GPT-4o mini (2024-07-18)",
-    "parent": "gpt-4o-mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-2024-05-13": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 15,
-    "displayName": "GPT-4o (2024-05-13)",
-    "deprecation_date": "2026-10-23",
-    "parent": "gpt-4o",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4-turbo-2024-04-09": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 10,
-    "output_cost_per_mil_tokens": 30,
-    "displayName": "GPT-4 Turbo (2024-04-09)",
-    "parent": "gpt-4-turbo",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4-0613": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 30,
-    "output_cost_per_mil_tokens": 60,
-    "deprecation_date": "2025-06-06",
-    "parent": "gpt-4",
-    "max_input_tokens": 8192,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-3.5-turbo-16k": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 4,
-    "displayName": "GPT 3.5T 16k",
-    "deprecated": true,
-    "max_input_tokens": 16385,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-3.5-turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 1.5,
-    "displayName": "GPT 3.5T",
-    "deprecated": true,
-    "max_input_tokens": 16385,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-3.5-turbo-instruct": {
-    "format": "openai",
-    "flavor": "completion",
-    "input_cost_per_mil_tokens": 1.5,
-    "output_cost_per_mil_tokens": 2,
-    "displayName": "GPT 3.5T Instruct",
-    "deprecated": true,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-3.5-turbo-1106": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 2,
-    "displayName": "GPT 3.5T 1106",
-    "deprecated": true,
-    "deprecation_date": "2026-09-28",
-    "max_input_tokens": 16385,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-3.5-turbo-instruct-0914": {
-    "format": "openai",
-    "flavor": "completion",
-    "input_cost_per_mil_tokens": 1.5,
-    "output_cost_per_mil_tokens": 2,
-    "displayName": "GPT 3.5T Instruct 0914",
-    "deprecated": true,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 4097,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-3.5-turbo-0125": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 1.5,
-    "displayName": "GPT 3.5T 0125",
-    "deprecated": true,
-    "max_input_tokens": 16385,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o4-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.1,
-    "output_cost_per_mil_tokens": 4.4,
-    "input_cache_read_cost_per_mil_tokens": 0.275,
-    "displayName": "o4-mini",
-    "reasoning": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
     "available_providers": [
       "openai",
       "azure"
@@ -1389,233 +360,6 @@
       "azure"
     ]
   },
-  "o4-mini-2025-04-16": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.1,
-    "output_cost_per_mil_tokens": 4.4,
-    "input_cache_read_cost_per_mil_tokens": 0.275,
-    "displayName": "o4-mini (2025-04-16)",
-    "reasoning": true,
-    "deprecation_date": "2026-10-23",
-    "parent": "o4-mini",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o3": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 8,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "displayName": "o3",
-    "reasoning": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o3-deep-research": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 10,
-    "output_cost_per_mil_tokens": 40,
-    "input_cache_read_cost_per_mil_tokens": 2.5,
-    "displayName": "o3 Deep Research",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o3-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.1,
-    "output_cost_per_mil_tokens": 4.4,
-    "input_cache_read_cost_per_mil_tokens": 0.55,
-    "displayName": "o3 mini",
-    "reasoning": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o3-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 20,
-    "output_cost_per_mil_tokens": 80,
-    "displayName": "o3 Pro",
-    "reasoning": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o3-deep-research-2025-06-26": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 10,
-    "output_cost_per_mil_tokens": 40,
-    "input_cache_read_cost_per_mil_tokens": 2.5,
-    "displayName": "o3 Deep Research (2025-06-26)",
-    "deprecation_date": "2026-07-23",
-    "parent": "o3-deep-research",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o3-pro-2025-06-10": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 20,
-    "output_cost_per_mil_tokens": 80,
-    "displayName": "o3 Pro (2025-06-10)",
-    "reasoning": true,
-    "parent": "o3-pro",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o3-2025-04-16": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 8,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "displayName": "o3 (2025-04-16)",
-    "reasoning": true,
-    "deprecation_date": "2026-12-11",
-    "parent": "o3",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o3-mini-2025-01-31": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.1,
-    "output_cost_per_mil_tokens": 4.4,
-    "input_cache_read_cost_per_mil_tokens": 0.55,
-    "displayName": "o3 mini (2025-01-31)",
-    "reasoning": true,
-    "parent": "o3-mini",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o1": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 15,
-    "output_cost_per_mil_tokens": 60,
-    "input_cache_read_cost_per_mil_tokens": 7.5,
-    "displayName": "o1",
-    "reasoning": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o1-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 150,
-    "output_cost_per_mil_tokens": 600,
-    "displayName": "o1 Pro",
-    "reasoning": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o1-pro-2025-03-19": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 150,
-    "output_cost_per_mil_tokens": 600,
-    "displayName": "o1 Pro (2025-03-19)",
-    "reasoning": true,
-    "parent": "o1-pro",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o1-2024-12-17": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 15,
-    "output_cost_per_mil_tokens": 60,
-    "input_cache_read_cost_per_mil_tokens": 7.5,
-    "displayName": "o1 (2024-12-17)",
-    "reasoning": true,
-    "deprecation_date": "2026-10-23",
-    "parent": "o1",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-audio-2025-08-28": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "GPT Audio (2025-08-28)",
-    "parent": "gpt-audio",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
   "gpt-audio-1.5": {
     "format": "openai",
     "flavor": "chat",
@@ -1623,75 +367,6 @@
     "output_cost_per_mil_tokens": 10,
     "max_input_tokens": 128000,
     "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-audio": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "GPT Audio",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-audio-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "displayName": "GPT Audio mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-audio-mini-2025-12-15": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "displayName": "GPT Audio mini (2025-12-15)",
-    "parent": "gpt-audio-mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-audio-mini-2025-10-06": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "displayName": "GPT Audio mini (2025-10-06)",
-    "parent": "gpt-audio-mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-realtime-2025-08-28": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 4,
-    "output_cost_per_mil_tokens": 16,
-    "input_cache_read_cost_per_mil_tokens": 0.4,
-    "displayName": "GPT Realtime (2025-08-28)",
-    "parent": "gpt-realtime",
-    "max_input_tokens": 32000,
-    "max_output_tokens": 4096,
     "available_providers": [
       "openai",
       "azure"
@@ -1706,103 +381,6 @@
     "displayName": "GPT Realtime 2",
     "max_input_tokens": 32000,
     "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-realtime-1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 4,
-    "output_cost_per_mil_tokens": 16,
-    "input_cache_read_cost_per_mil_tokens": 0.4,
-    "max_input_tokens": 32000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-realtime": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 4,
-    "output_cost_per_mil_tokens": 16,
-    "input_cache_read_cost_per_mil_tokens": 0.4,
-    "displayName": "GPT Realtime",
-    "max_input_tokens": 32000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-realtime-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "displayName": "GPT Realtime mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-realtime-mini-2025-12-15": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "input_cache_read_cost_per_mil_tokens": 0.06,
-    "displayName": "GPT Realtime mini (2025-12-15)",
-    "parent": "gpt-realtime-mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-realtime-mini-2025-10-06": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "input_cache_read_cost_per_mil_tokens": 0.06,
-    "displayName": "GPT Realtime mini (2025-10-06)",
-    "parent": "gpt-realtime-mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-image-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "displayName": "GPT Image 2",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-image-2-2026-04-21": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "displayName": "GPT Image 2 (2026-04-21)",
-    "parent": "gpt-image-2",
     "available_providers": [
       "openai",
       "azure"
@@ -2150,21 +728,203 @@
       "azure"
     ]
   },
-  "gpt-image-1": {
+  "1024-x-1024/dall-e-2": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 5,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
     "available_providers": [
       "openai",
       "azure"
     ]
   },
-  "gpt-image-1-mini": {
+  "256-x-256/dall-e-2": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 2,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "512-x-512/dall-e-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "dall-e-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "openai/sora-2-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "sora-2-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "tts-1-hd": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "omni-moderation-2024-09-26": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "text-moderation-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "ft:gpt-4.1-mini-2025-04-14": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.8,
+    "output_cost_per_mil_tokens": 3.2,
     "input_cache_read_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.6-sol": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 30,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "displayName": "GPT-5.6 Sol",
+    "reasoning": true,
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o3": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 8,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "o3",
+    "reasoning": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o3-2025-04-16": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 8,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "o3 (2025-04-16)",
+    "reasoning": true,
+    "deprecation_date": "2026-12-11",
+    "parent": "o3",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-audio-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "displayName": "GPT Audio mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-audio-mini-2025-12-15": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "displayName": "GPT Audio mini (2025-12-15)",
+    "parent": "gpt-audio-mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-audio-mini-2025-10-06": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "displayName": "GPT Audio mini (2025-10-06)",
+    "parent": "gpt-audio-mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-realtime-1.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 4,
+    "output_cost_per_mil_tokens": 16,
+    "input_cache_read_cost_per_mil_tokens": 0.4,
+    "max_input_tokens": 32000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-image-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 5,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
     "available_providers": [
       "openai",
       "azure"
@@ -2202,23 +962,7 @@
       "azure"
     ]
   },
-  "low/1024-x-1024/gpt-image-1-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
   "low/1024-x-1536/gpt-image-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "low/1024-x-1536/gpt-image-1-mini": {
     "format": "openai",
     "flavor": "chat",
     "available_providers": [
@@ -2234,23 +978,7 @@
       "azure"
     ]
   },
-  "low/1536-x-1024/gpt-image-1-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
   "medium/1024-x-1024/gpt-image-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "medium/1024-x-1024/gpt-image-1-mini": {
     "format": "openai",
     "flavor": "chat",
     "available_providers": [
@@ -2266,137 +994,7 @@
       "azure"
     ]
   },
-  "medium/1024-x-1536/gpt-image-1-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
   "medium/1536-x-1024/gpt-image-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "medium/1536-x-1024/gpt-image-1-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "chatgpt-image-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 5,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "dall-e-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "hd/1024-x-1024/dall-e-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "hd/1024-x-1792/dall-e-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "hd/1792-x-1024/dall-e-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "standard/1024-x-1024/dall-e-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "standard/1024-x-1792/dall-e-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "standard/1792-x-1024/dall-e-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "1024-x-1024/dall-e-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "256-x-256/dall-e-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "512-x-512/dall-e-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "dall-e-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "openai/sora-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "openai/sora-2-pro": {
     "format": "openai",
     "flavor": "chat",
     "available_providers": [
@@ -2412,39 +1010,7 @@
       "azure"
     ]
   },
-  "sora-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "sora-2-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
   "sora-2-pro-high-res": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "tts-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "tts-1-hd": {
     "format": "openai",
     "flavor": "chat",
     "available_providers": [
@@ -2460,112 +1026,10 @@
       "azure"
     ]
   },
-  "tts-1-hd-1106": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "whisper-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "omni-moderation-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "omni-moderation-2024-09-26": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "text-moderation-007": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "text-moderation-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
   "text-moderation-stable": {
     "format": "openai",
     "flavor": "chat",
     "max_input_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "babbage-002": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.4,
-    "output_cost_per_mil_tokens": 0.4,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "davinci-002": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "ft:gpt-4.1-2025-04-14": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 12,
-    "input_cache_read_cost_per_mil_tokens": 0.75,
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "ft:gpt-4.1-mini-2025-04-14": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.8,
-    "output_cost_per_mil_tokens": 3.2,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
     "available_providers": [
       "openai",
       "azure"
@@ -2584,6 +1048,164 @@
       "azure"
     ]
   },
+  "gpt-5.6-terra": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.25,
+    "input_cache_write_cost_per_mil_tokens": 3.125,
+    "displayName": "GPT-5.6 Terra",
+    "reasoning": true,
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o3-deep-research": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 10,
+    "output_cost_per_mil_tokens": 40,
+    "input_cache_read_cost_per_mil_tokens": 2.5,
+    "displayName": "o3 Deep Research",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o3-deep-research-2025-06-26": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 10,
+    "output_cost_per_mil_tokens": 40,
+    "input_cache_read_cost_per_mil_tokens": 2.5,
+    "displayName": "o3 Deep Research (2025-06-26)",
+    "deprecation_date": "2026-07-23",
+    "parent": "o3-deep-research",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-realtime-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "displayName": "GPT Realtime mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-realtime-mini-2025-12-15": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "input_cache_read_cost_per_mil_tokens": 0.06,
+    "displayName": "GPT Realtime mini (2025-12-15)",
+    "parent": "gpt-realtime-mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-realtime-mini-2025-10-06": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "input_cache_read_cost_per_mil_tokens": 0.06,
+    "displayName": "GPT Realtime mini (2025-10-06)",
+    "parent": "gpt-realtime-mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-image-1-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "low/1024-x-1024/gpt-image-1-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "low/1024-x-1536/gpt-image-1-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "low/1536-x-1024/gpt-image-1-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "medium/1024-x-1024/gpt-image-1-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "medium/1024-x-1536/gpt-image-1-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "medium/1536-x-1024/gpt-image-1-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "tts-1-hd-1106": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
   "ft:o4-mini-2025-04-16": {
     "format": "openai",
     "flavor": "chat",
@@ -2591,6 +1213,75 @@
     "output_cost_per_mil_tokens": 16,
     "input_cache_read_cost_per_mil_tokens": 1,
     "reasoning": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 30,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "GPT-5.5",
+    "reasoning": true,
+    "fallback_models": [
+      "openai.gpt-5.5"
+    ],
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.5-2026-04-23": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 30,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "GPT-5.5 (2026-04-23)",
+    "reasoning": true,
+    "parent": "gpt-5.5",
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o3-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.1,
+    "output_cost_per_mil_tokens": 4.4,
+    "input_cache_read_cost_per_mil_tokens": 0.55,
+    "displayName": "o3 mini",
+    "reasoning": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o3-mini-2025-01-31": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.1,
+    "output_cost_per_mil_tokens": 4.4,
+    "input_cache_read_cost_per_mil_tokens": 0.55,
+    "displayName": "o3 mini (2025-01-31)",
+    "reasoning": true,
+    "parent": "o3-mini",
     "max_input_tokens": 200000,
     "max_output_tokens": 100000,
     "available_providers": [
@@ -2625,6 +1316,70 @@
       "azure"
     ]
   },
+  "gpt-5.5-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 30,
+    "output_cost_per_mil_tokens": 180,
+    "input_cache_read_cost_per_mil_tokens": 3,
+    "displayName": "GPT-5.5 Pro",
+    "reasoning": true,
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.5-pro-2026-04-23": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 30,
+    "output_cost_per_mil_tokens": 180,
+    "input_cache_read_cost_per_mil_tokens": 3,
+    "displayName": "GPT-5.5 Pro (2026-04-23)",
+    "reasoning": true,
+    "parent": "gpt-5.5-pro",
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o3-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 20,
+    "output_cost_per_mil_tokens": 80,
+    "displayName": "o3 Pro",
+    "reasoning": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o3-pro-2025-06-10": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 20,
+    "output_cost_per_mil_tokens": 80,
+    "displayName": "o3 Pro (2025-06-10)",
+    "reasoning": true,
+    "parent": "o3-pro",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
   "ft:gpt-4o-mini-2024-07-18": {
     "format": "openai",
     "flavor": "chat",
@@ -2633,6 +1388,76 @@
     "input_cache_read_cost_per_mil_tokens": 0.15,
     "max_input_tokens": 128000,
     "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.4": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.25,
+    "displayName": "GPT-5.4",
+    "reasoning": true,
+    "fallback_models": [
+      "openai.gpt-5.4"
+    ],
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.4-2026-03-05": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.25,
+    "displayName": "GPT-5.4 (2026-03-05)",
+    "reasoning": true,
+    "parent": "gpt-5.4",
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o1": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 15,
+    "output_cost_per_mil_tokens": 60,
+    "input_cache_read_cost_per_mil_tokens": 7.5,
+    "displayName": "o1",
+    "reasoning": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o1-2024-12-17": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 15,
+    "output_cost_per_mil_tokens": 60,
+    "input_cache_read_cost_per_mil_tokens": 7.5,
+    "displayName": "o1 (2024-12-17)",
+    "reasoning": true,
+    "deprecation_date": "2026-10-23",
+    "parent": "o1",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
     "available_providers": [
       "openai",
       "azure"
@@ -2650,6 +1475,70 @@
       "azure"
     ]
   },
+  "gpt-5.4-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.75,
+    "output_cost_per_mil_tokens": 4.5,
+    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "displayName": "GPT-5.4 mini",
+    "reasoning": true,
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.4-mini-2026-03-17": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.75,
+    "output_cost_per_mil_tokens": 4.5,
+    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "displayName": "GPT-5.4 mini (2026-03-17)",
+    "reasoning": true,
+    "parent": "gpt-5.4-mini",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o1-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 150,
+    "output_cost_per_mil_tokens": 600,
+    "displayName": "o1 Pro",
+    "reasoning": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o1-pro-2025-03-19": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 150,
+    "output_cost_per_mil_tokens": 600,
+    "displayName": "o1 Pro (2025-03-19)",
+    "reasoning": true,
+    "parent": "o1-pro",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
   "ft:gpt-3.5-turbo": {
     "format": "openai",
     "flavor": "chat",
@@ -2657,6 +1546,39 @@
     "output_cost_per_mil_tokens": 6,
     "max_input_tokens": 16385,
     "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.4-nano": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 1.25,
+    "input_cache_read_cost_per_mil_tokens": 0.02,
+    "displayName": "GPT-5.4 nano",
+    "reasoning": true,
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.4-nano-2026-03-17": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 1.25,
+    "input_cache_read_cost_per_mil_tokens": 0.02,
+    "displayName": "GPT-5.4 nano (2026-03-17)",
+    "reasoning": true,
+    "parent": "gpt-5.4-nano",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
     "available_providers": [
       "openai",
       "azure"
@@ -2674,6 +1596,39 @@
       "azure"
     ]
   },
+  "gpt-5.4-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 30,
+    "output_cost_per_mil_tokens": 180,
+    "input_cache_read_cost_per_mil_tokens": 3,
+    "displayName": "GPT-5.4 Pro",
+    "reasoning": true,
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.4-pro-2026-03-05": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 30,
+    "output_cost_per_mil_tokens": 180,
+    "input_cache_read_cost_per_mil_tokens": 3,
+    "displayName": "GPT-5.4 Pro (2026-03-05)",
+    "reasoning": true,
+    "parent": "gpt-5.4-pro",
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
   "ft:gpt-3.5-turbo-0613": {
     "format": "openai",
     "flavor": "chat",
@@ -2681,6 +1636,23 @@
     "output_cost_per_mil_tokens": 6,
     "max_input_tokens": 4096,
     "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.3-chat-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.75,
+    "output_cost_per_mil_tokens": 14,
+    "input_cache_read_cost_per_mil_tokens": 0.175,
+    "displayName": "GPT-5.3 chat",
+    "reasoning": true,
+    "deprecation_date": "2026-08-10",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
     "available_providers": [
       "openai",
       "azure"
@@ -2698,6 +1670,22 @@
       "azure"
     ]
   },
+  "gpt-5.3-codex": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.75,
+    "output_cost_per_mil_tokens": 14,
+    "input_cache_read_cost_per_mil_tokens": 0.175,
+    "displayName": "GPT-5.3 Codex",
+    "reasoning": true,
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
   "ft:babbage-002": {
     "format": "openai",
     "flavor": "chat",
@@ -2705,6 +1693,39 @@
     "output_cost_per_mil_tokens": 1.6,
     "max_input_tokens": 16384,
     "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.2": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.75,
+    "output_cost_per_mil_tokens": 14,
+    "input_cache_read_cost_per_mil_tokens": 0.175,
+    "displayName": "GPT-5.2",
+    "reasoning": true,
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.2-2025-12-11": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.75,
+    "output_cost_per_mil_tokens": 14,
+    "input_cache_read_cost_per_mil_tokens": 0.175,
+    "displayName": "GPT-5.2 (2025-12-11)",
+    "reasoning": true,
+    "parent": "gpt-5.2",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
     "available_providers": [
       "openai",
       "azure"
@@ -2722,25 +1743,1004 @@
       "azure"
     ]
   },
-  "openai/container": {
+  "gpt-5.2-chat-latest": {
     "format": "openai",
     "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.75,
+    "output_cost_per_mil_tokens": 14,
+    "input_cache_read_cost_per_mil_tokens": 0.175,
+    "displayName": "GPT-5.2 chat",
+    "reasoning": true,
+    "deprecation_date": "2026-08-10",
+    "parent": "gpt-5.2",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
     "available_providers": [
       "openai",
       "azure"
     ]
   },
-  "chat-latest": {
+  "gpt-5.2-codex": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.75,
+    "output_cost_per_mil_tokens": 14,
+    "input_cache_read_cost_per_mil_tokens": 0.175,
+    "displayName": "GPT-5.2 Codex",
+    "reasoning": true,
+    "deprecation_date": "2026-07-23",
+    "parent": "gpt-5.2",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.2-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 21,
+    "output_cost_per_mil_tokens": 168,
+    "displayName": "GPT-5.2 Pro",
+    "reasoning": true,
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.2-pro-2025-12-11": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 21,
+    "output_cost_per_mil_tokens": 168,
+    "displayName": "GPT-5.2 Pro (2025-12-11)",
+    "reasoning": true,
+    "parent": "gpt-5.2-pro",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.1": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "GPT-5.1",
+    "reasoning": true,
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.1-2025-11-13": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "GPT-5.1 (2025-11-13)",
+    "reasoning": true,
+    "parent": "gpt-5.1",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.1-chat-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "GPT-5.1 chat",
+    "reasoning": true,
+    "deprecation_date": "2026-07-23",
+    "parent": "gpt-5.1",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.1-codex": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "GPT-5.1 Codex",
+    "reasoning": true,
+    "deprecation_date": "2026-07-23",
+    "parent": "gpt-5.1",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.1-codex-max": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "reasoning": true,
+    "deprecation_date": "2026-07-23",
+    "parent": "gpt-5.1",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.1-codex-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 2,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "displayName": "GPT-5.1 Codex Mini",
+    "reasoning": true,
+    "deprecation_date": "2026-07-23",
+    "parent": "gpt-5.1",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "GPT-5",
+    "reasoning": true,
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-2025-08-07": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "GPT-5 (2025-08-07)",
+    "reasoning": true,
+    "deprecation_date": "2026-12-11",
+    "parent": "gpt-5",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-chat-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "GPT-5 chat",
+    "reasoning": true,
+    "deprecation_date": "2026-07-23",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-codex": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "GPT-5 Codex",
+    "reasoning": true,
+    "deprecation_date": "2026-07-23",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 2,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "displayName": "GPT-5 mini",
+    "reasoning": true,
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-mini-2025-08-07": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 2,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "displayName": "GPT-5 mini (2025-08-07)",
+    "reasoning": true,
+    "deprecation_date": "2026-12-11",
+    "parent": "gpt-5-mini",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-nano": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.05,
+    "output_cost_per_mil_tokens": 0.4,
+    "input_cache_read_cost_per_mil_tokens": 0.005,
+    "displayName": "GPT-5 nano",
+    "reasoning": true,
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-nano-2025-08-07": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.05,
+    "output_cost_per_mil_tokens": 0.4,
+    "input_cache_read_cost_per_mil_tokens": 0.005,
+    "displayName": "GPT-5 nano (2025-08-07)",
+    "reasoning": true,
+    "parent": "gpt-5-nano",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 15,
+    "output_cost_per_mil_tokens": 120,
+    "displayName": "GPT-5 Pro",
+    "reasoning": true,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 272000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-pro-2025-10-06": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 15,
+    "output_cost_per_mil_tokens": 120,
+    "displayName": "GPT-5 Pro (2025-10-06)",
+    "reasoning": true,
+    "parent": "gpt-5-pro",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 272000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-search-api": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "GPT-5 Search API",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-search-api-2025-10-14": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "GPT-5 Search API (2025-10-14)",
+    "parent": "gpt-5-search-api",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4.1": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 8,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "GPT-4.1",
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4.1-2025-04-14": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 8,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "GPT-4.1 (2025-04-14)",
+    "parent": "gpt-4.1",
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4.1-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.4,
+    "output_cost_per_mil_tokens": 1.6,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "displayName": "GPT-4.1 mini",
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4.1-mini-2025-04-14": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.4,
+    "output_cost_per_mil_tokens": 1.6,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "displayName": "GPT-4.1 mini (2025-04-14)",
+    "parent": "gpt-4.1-mini",
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4.1-nano": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "displayName": "GPT-4.1 nano",
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4.1-nano-2025-04-14": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "displayName": "GPT-4.1 nano (2025-04-14)",
+    "parent": "gpt-4.1-nano",
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 30,
+    "output_cost_per_mil_tokens": 60,
+    "displayName": "GPT-4",
+    "max_input_tokens": 8192,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4-turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 10,
+    "output_cost_per_mil_tokens": 30,
+    "displayName": "GPT-4 Turbo",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4-turbo-2024-04-09": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 10,
+    "output_cost_per_mil_tokens": 30,
+    "displayName": "GPT-4 Turbo (2024-04-09)",
+    "parent": "gpt-4-turbo",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "displayName": "GPT-4o",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-2024-11-20": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "displayName": "GPT-4o (2024-11-20)",
+    "parent": "gpt-4o",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-2024-08-06": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "displayName": "GPT-4o (2024-08-06)",
+    "parent": "gpt-4o",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-2024-05-13": {
     "format": "openai",
     "flavor": "chat",
     "multimodal": true,
     "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 30,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "displayName": "GPT Chat Latest",
-    "reasoning": true,
+    "output_cost_per_mil_tokens": 15,
+    "displayName": "GPT-4o (2024-05-13)",
+    "deprecation_date": "2026-10-23",
+    "parent": "gpt-4o",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-audio-preview": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "GPT-4o Audio Preview",
     "max_input_tokens": 128000,
     "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-audio-preview-2025-06-03": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "GPT-4o Audio Preview (2025-06-03)",
+    "parent": "gpt-4o-audio-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-audio-preview-2024-12-17": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "GPT-4o Audio Preview (2024-12-17)",
+    "parent": "gpt-4o-audio-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "displayName": "GPT-4o mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-2024-07-18": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "displayName": "GPT-4o mini (2024-07-18)",
+    "parent": "gpt-4o-mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-audio-preview": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "GPT-4o mini Audio Preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-audio-preview-2024-12-17": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "GPT-4o mini Audio Preview (2024-12-17)",
+    "parent": "gpt-4o-mini-audio-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-realtime-preview": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "displayName": "GPT-4o mini Realtime Preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-realtime-preview-2024-12-17": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "displayName": "GPT-4o mini Realtime Preview (2024-12-17)",
+    "parent": "gpt-4o-mini-realtime-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-search-preview": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "displayName": "GPT-4o mini Search Preview",
+    "experimental": true,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-search-preview-2025-03-11": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "displayName": "GPT-4o mini Search Preview (2025-03-11)",
+    "experimental": true,
+    "parent": "gpt-4o-mini-search-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-transcribe": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 5,
+    "displayName": "GPT-4o mini Transcribe",
+    "max_input_tokens": 16000,
+    "max_output_tokens": 2000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-transcribe-2025-12-15": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 5,
+    "displayName": "GPT-4o mini Transcribe (2025-12-15)",
+    "parent": "gpt-4o-mini-transcribe",
+    "max_input_tokens": 16000,
+    "max_output_tokens": 2000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-transcribe-2025-03-20": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 5,
+    "displayName": "GPT-4o mini Transcribe (2025-03-20)",
+    "parent": "gpt-4o-mini-transcribe",
+    "max_input_tokens": 16000,
+    "max_output_tokens": 2000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-tts": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "GPT-4o mini TTS",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-tts-2025-12-15": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "GPT-4o mini TTS (2025-12-15)",
+    "parent": "gpt-4o-mini-tts",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-tts-2025-03-20": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "GPT-4o mini TTS (2025-03-20)",
+    "parent": "gpt-4o-mini-tts",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-realtime-preview": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 20,
+    "input_cache_read_cost_per_mil_tokens": 2.5,
+    "displayName": "GPT-4o Realtime Preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-realtime-preview-2025-06-03": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 20,
+    "input_cache_read_cost_per_mil_tokens": 2.5,
+    "displayName": "GPT-4o Realtime Preview (2025-06-03)",
+    "parent": "gpt-4o-realtime-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-realtime-preview-2024-12-17": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 20,
+    "input_cache_read_cost_per_mil_tokens": 2.5,
+    "displayName": "GPT-4o Realtime Preview (2024-12-17)",
+    "parent": "gpt-4o-realtime-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-search-preview": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "displayName": "GPT-4o Search Preview",
+    "experimental": true,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-search-preview-2025-03-11": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "displayName": "GPT-4o Search Preview (2025-03-11)",
+    "experimental": true,
+    "parent": "gpt-4o-search-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-transcribe": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "max_input_tokens": 16000,
+    "max_output_tokens": 2000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-transcribe-diarize": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "max_input_tokens": 16000,
+    "max_output_tokens": 2000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4-0613": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 30,
+    "output_cost_per_mil_tokens": 60,
+    "deprecation_date": "2025-06-06",
+    "parent": "gpt-4",
+    "max_input_tokens": 8192,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-3.5-turbo-16k": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 4,
+    "displayName": "GPT 3.5T 16k",
+    "deprecated": true,
+    "max_input_tokens": 16385,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-3.5-turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 1.5,
+    "displayName": "GPT 3.5T",
+    "deprecated": true,
+    "max_input_tokens": 16385,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-3.5-turbo-instruct": {
+    "format": "openai",
+    "flavor": "completion",
+    "input_cost_per_mil_tokens": 1.5,
+    "output_cost_per_mil_tokens": 2,
+    "displayName": "GPT 3.5T Instruct",
+    "deprecated": true,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-3.5-turbo-1106": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 2,
+    "displayName": "GPT 3.5T 1106",
+    "deprecated": true,
+    "deprecation_date": "2026-09-28",
+    "max_input_tokens": 16385,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-3.5-turbo-instruct-0914": {
+    "format": "openai",
+    "flavor": "completion",
+    "input_cost_per_mil_tokens": 1.5,
+    "output_cost_per_mil_tokens": 2,
+    "displayName": "GPT 3.5T Instruct 0914",
+    "deprecated": true,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 4097,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-3.5-turbo-0125": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 1.5,
+    "displayName": "GPT 3.5T 0125",
+    "deprecated": true,
+    "max_input_tokens": 16385,
+    "max_output_tokens": 4096,
     "available_providers": [
       "openai",
       "azure"
@@ -2759,6 +2759,778 @@
       "fireworks"
     ]
   },
+  "accounts/fireworks/models/qwen3p7-plus": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.4,
+    "output_cost_per_mil_tokens": 1.6,
+    "input_cache_read_cost_per_mil_tokens": 0.08,
+    "displayName": "Qwen3.7 Plus",
+    "max_input_tokens": 262144,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/qwq-32b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "displayName": "Qwen QwQ 32B",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/glm-5p2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.4,
+    "output_cost_per_mil_tokens": 4.4,
+    "input_cache_read_cost_per_mil_tokens": 0.14,
+    "displayName": "GLM 5.2",
+    "reasoning": true,
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/kimi-k2p7-code": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.95,
+    "output_cost_per_mil_tokens": 4,
+    "input_cache_read_cost_per_mil_tokens": 0.19,
+    "displayName": "Kimi K2.7 Code",
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/minimax-m3": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 1.2,
+    "input_cache_read_cost_per_mil_tokens": 0.06,
+    "displayName": "MiniMax M3",
+    "max_input_tokens": 512000,
+    "max_output_tokens": 512000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3-70b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama4-maverick-instruct-basic": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.22,
+    "output_cost_per_mil_tokens": 0.88,
+    "displayName": "Llama 4 Maverick Instruct (Basic)",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-70b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mixtral-8x22b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 65536,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-7b-instruct-4k": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gemma-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/yi-34b-200k-capybara": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 200000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/phi-3-mini-128k-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/chronos-hermes-13b-v2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-qwen-1p5-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 65536,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/codegemma-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/cogito-671b-v2-p1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/cogito-v1-preview-llama-70b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/dbrx-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/devstral-small-2505": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/dobby-mini-unhinged-plus-llama-3-1-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/dobby-unhinged-llama-3-3-70b-new": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/dolphin-2-9-2-qwen2-72b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/ernie-4p5-300b-a47b-pt": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/fare-20b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/firefunction-v2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/firellava-13b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/firesearch-ocr-v6": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks-ai-56b-to-176b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/fireworks-asr-v2": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/flux-1-dev-fp8": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.0005,
+    "output_cost_per_mil_tokens": 0.0005,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/flux-kontext-max": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.08,
+    "output_cost_per_mil_tokens": 0.08,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gpt-oss-120b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "input_cache_read_cost_per_mil_tokens": 0.015,
+    "displayName": "GPT-OSS (120B)",
+    "reasoning": true,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks_ai/thenlper/gte-base": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.008,
+    "max_input_tokens": 512,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks_ai/thenlper/gte-large": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.016,
+    "max_input_tokens": 512,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/hermes-2-pro-mistral-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/internvl3-78b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/japanese-stable-diffusion-xl": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.00013,
+    "output_cost_per_mil_tokens": 0.00013,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/kat-coder": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/kat-dev-72b-exp": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-guard-3-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llamaguard-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llava-yi-34b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/ministral-3-14b-instruct-2512": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-large-3-fp8": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-nemo-base-2407": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-small-24b-instruct-2501": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "displayName": "Mistral Small 3 Instruct",
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mythomax-l2-13b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nemotron-nano-v2-12b-vl": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks_ai/nomic-ai/nomic-embed-text-v1.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.008,
+    "max_input_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nous-capybara-7b-v1p9": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nous-hermes-llama2-70b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nvidia-nemotron-nano-12b-v2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/openchat-3p5-0106-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/openhermes-2-mistral-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/openorca-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/phind-code-llama-34b-v2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/playground-v2-5-1024px-aesthetic": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.00013,
+    "output_cost_per_mil_tokens": 0.00013,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/pythia-12b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 2048,
+    "max_output_tokens": 2048,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/rolm-ocr": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/snorkel-mistral-7b-pairrm-dpo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/SSD-1B": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.00013,
+    "output_cost_per_mil_tokens": 0.00013,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/stable-diffusion-xl-1024-v1-0": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.00013,
+    "output_cost_per_mil_tokens": 0.00013,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/stablecode-3b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/starcoder-16b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/toppy-m-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks_ai/WhereIsAI/UAE-Large-V1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.016,
+    "max_input_tokens": 512,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/whisper-v3": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/yi-large": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 3,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/zephyr-7b-beta": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
   "accounts/fireworks/models/deepseek-v4-pro": {
     "format": "openai",
     "flavor": "chat",
@@ -2768,6 +3540,395 @@
     "displayName": "DeepSeek V4 Pro",
     "max_input_tokens": 1048576,
     "max_output_tokens": 384000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/qwen3p6-plus": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 3,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "displayName": "Qwen3.6 Plus",
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/glm-5p1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.4,
+    "output_cost_per_mil_tokens": 4.4,
+    "input_cache_read_cost_per_mil_tokens": 0.26,
+    "displayName": "GLM 5.1",
+    "reasoning": true,
+    "max_input_tokens": 202800,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/kimi-k2p6": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.95,
+    "output_cost_per_mil_tokens": 4,
+    "input_cache_read_cost_per_mil_tokens": 0.16,
+    "displayName": "Kimi K2.6",
+    "reasoning": true,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/minimax-m2p7": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 1.2,
+    "input_cache_read_cost_per_mil_tokens": 0.06,
+    "displayName": "MiniMax M2.7",
+    "max_input_tokens": 196608,
+    "max_output_tokens": 196608,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3-70b-instruct-hf": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama4-scout-instruct-basic": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "Llama 4 Scout Instruct (Basic)",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-70b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mixtral-8x22b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "displayName": "Mixtral MoE 8x22B Instruct",
+    "max_input_tokens": 65536,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-7b-instruct-v3": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gemma-7b-it": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/yi-34b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/phi-3-vision-128k-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "displayName": "Phi 3.5 Vision Instruct",
+    "max_input_tokens": 32064,
+    "max_output_tokens": 32064,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/codegemma-2b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/cogito-v1-preview-qwen-32b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/dolphin-2p6-mixtral-8x7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/ernie-4p5-21b-a3b-pt": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/firefunction-v1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks-ai-moe-up-to-56b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/fireworks-asr-large": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/flux-1-schnell-fp8": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.00035,
+    "output_cost_per_mil_tokens": 0.00035,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/flux-kontext-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.04,
+    "output_cost_per_mil_tokens": 0.04,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gpt-oss-safeguard-120b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/internvl3-38b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/kat-dev-32b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-guard-3-1b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/ministral-3-8b-instruct-2512": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-nemo-instruct-2407": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks_ai/nomic-ai/nomic-embed-text-v1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.008,
+    "max_input_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nous-hermes-2-yi-34b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nvidia-nemotron-nano-9b-v2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/openhermes-2p5-mistral-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/phind-code-llama-34b-python-v1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/playground-v2-1024px-aesthetic": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.00013,
+    "output_cost_per_mil_tokens": 0.00013,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/starcoder-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/whisper-v3-turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
     "available_providers": [
       "fireworks"
     ]
@@ -2784,6 +3945,244 @@
       "fireworks"
     ]
   },
+  "accounts/fireworks/models/qwen3-coder-480b-a35b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.45,
+    "output_cost_per_mil_tokens": 1.8,
+    "displayName": "Qwen3 Coder 480B A35B Instruct",
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/glm-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 3.2,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "GLM 5",
+    "max_input_tokens": 202752,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/kimi-k2p5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 3,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "displayName": "Kimi K2.5",
+    "reasoning": true,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/minimax-m2p5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 1.2,
+    "input_cache_read_cost_per_mil_tokens": 0.03,
+    "displayName": "MiniMax M2.5",
+    "max_input_tokens": 196608,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-70b-python": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mixtral-8x22b-instruct-hf": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 65536,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-7b-instruct-v0p2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gemma-3-27b-it": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/yi-34b-chat": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/phi-2-3b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 2048,
+    "max_output_tokens": 2048,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/cogito-v1-preview-qwen-14b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks-ai-above-16b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/flux-1-dev": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gpt-oss-20b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.07,
+    "output_cost_per_mil_tokens": 0.3,
+    "input_cache_read_cost_per_mil_tokens": 0.035,
+    "displayName": "GPT-OSS (20B)",
+    "reasoning": true,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/internvl3-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-guard-2-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/ministral-3-3b-instruct-2512": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nous-hermes-llama2-13b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/phind-code-llama-34b-v1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/starcoder2-15b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
   "accounts/fireworks/models/deepseek-v3p1": {
     "format": "openai",
     "flavor": "chat",
@@ -2792,6 +4191,183 @@
     "reasoning": true,
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/qwen3-coder-480b-instruct-bf16": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/glm-4p7": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.2,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "reasoning": true,
+    "max_input_tokens": 202800,
+    "max_output_tokens": 202800,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/kimi-k2-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.5,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/minimax-m2p1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 1.2,
+    "input_cache_read_cost_per_mil_tokens": 0.03,
+    "max_input_tokens": 204800,
+    "max_output_tokens": 204800,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3-8b-instruct-hf": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-34b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mixtral-8x7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-7b-v0p2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gemma2-9b-it": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/yi-6b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/cogito-v1-preview-llama-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks-ai-4.1b-to-16b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/flux-1-dev-controlnet-union": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.001,
+    "output_cost_per_mil_tokens": 0.001,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gpt-oss-safeguard-20b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nous-hermes-2-mixtral-8x7b-dpo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/starcoder2-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
     "available_providers": [
       "fireworks"
     ]
@@ -2808,6 +4384,164 @@
       "fireworks"
     ]
   },
+  "accounts/fireworks/models/qwen3-235b-a22b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.22,
+    "output_cost_per_mil_tokens": 0.88,
+    "displayName": "Qwen3 235B A22B",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/glm-4p6": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.55,
+    "output_cost_per_mil_tokens": 2.19,
+    "reasoning": true,
+    "max_input_tokens": 202800,
+    "max_output_tokens": 202800,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/kimi-k2-thinking": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.5,
+    "displayName": "Kimi K2 Thinking",
+    "reasoning": true,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/minimax-m2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3p3-70b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "displayName": "Llama 3.3 70B Instruct",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-34b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mixtral-8x7b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "displayName": "Mixtral MoE 8x7B Instruct",
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gemma-2b-it": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/cogito-v1-preview-llama-3b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks-ai-up-to-4b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/flux-1-schnell": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nous-hermes-llama2-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/starcoder2-3b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
   "accounts/fireworks/models/deepseek-v3": {
     "format": "openai",
     "flavor": "chat",
@@ -2816,6 +4550,93 @@
     "displayName": "DeepSeek V3",
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/qwen3-vl-235b-a22b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.22,
+    "output_cost_per_mil_tokens": 0.88,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/glm-4p5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.55,
+    "output_cost_per_mil_tokens": 2.19,
+    "reasoning": true,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 96000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/kimi-k2-instruct-0905": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.5,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/minimax-m1-80k": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3p2-90b-vision-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "displayName": "Llama 3.2 90B Vision Instruct",
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-34b-python": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mixtral-8x7b-instruct-hf": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks-ai-default": {
+    "format": "openai",
+    "flavor": "chat",
     "available_providers": [
       "fireworks"
     ]
@@ -2832,6 +4653,53 @@
       "fireworks"
     ]
   },
+  "accounts/fireworks/models/qwen3-vl-235b-a22b-thinking": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.22,
+    "output_cost_per_mil_tokens": 0.88,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/glm-4p5-air": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.22,
+    "output_cost_per_mil_tokens": 0.88,
+    "reasoning": true,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 96000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3p2-11b-vision-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "displayName": "Llama 3.2 11B Vision Instruct",
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-13b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
   "accounts/fireworks/models/deepseek-v2p5": {
     "format": "openai",
     "flavor": "chat",
@@ -2839,6 +4707,52 @@
     "output_cost_per_mil_tokens": 1.2,
     "max_input_tokens": 32768,
     "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/qwen3-235b-a22b-instruct-2507": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.22,
+    "output_cost_per_mil_tokens": 0.88,
+    "displayName": "Qwen3 235B A22B Instruct 2507",
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/glm-4p5v": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "reasoning": true,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3p2-3b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-13b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
     "available_providers": [
       "fireworks"
     ]
@@ -2854,11 +4768,78 @@
       "fireworks"
     ]
   },
+  "accounts/fireworks/models/qwen3-235b-a22b-thinking-2507": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.22,
+    "output_cost_per_mil_tokens": 0.88,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3p2-3b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "displayName": "Llama 3.2 3B Instruct",
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-13b-python": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
   "accounts/fireworks/models/deepseek-coder-33b-instruct": {
     "format": "openai",
     "flavor": "chat",
     "input_cost_per_mil_tokens": 0.9,
     "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/qwen3-next-80b-a3b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3p2-1b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
     "max_input_tokens": 16384,
     "max_output_tokens": 16384,
     "available_providers": [
@@ -2876,150 +4857,18 @@
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/deepseek-coder-7b-instruct-v1p5": {
+  "accounts/fireworks/models/qwen3-next-80b-a3b-thinking": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
     "max_input_tokens": 4096,
     "max_output_tokens": 4096,
     "available_providers": [
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/deepseek-coder-7b-base": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-coder-v2-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 65536,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-coder-v2-lite-base": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-coder-v2-lite-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-prover-v2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-r1-distill-llama-70b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-r1-distill-qwen-32b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-r1-distill-qwen-14b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-r1-distill-llama-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-r1-distill-qwen-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-r1-0528-distill-qwen3-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-r1-distill-qwen-1p5b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-coder-1b-base": {
+  "accounts/fireworks/models/llama-v3p2-1b-instruct": {
     "format": "openai",
     "flavor": "chat",
     "input_cost_per_mil_tokens": 0.1,
@@ -3030,161 +4879,22 @@
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/deepseek-r1": {
+  "accounts/fireworks/models/code-llama-7b-instruct": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 8,
-    "displayName": "DeepSeek R1 (Fast)",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 20480,
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
     "available_providers": [
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/deepseek-r1-basic": {
+  "accounts/fireworks/models/deepseek-coder-7b-instruct-v1p5": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.55,
-    "output_cost_per_mil_tokens": 2.19,
-    "displayName": "DeepSeek R1 Basic",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 20480,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-r1-0528": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 8,
-    "max_input_tokens": 160000,
-    "max_output_tokens": 160000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/qwen3p7-plus": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.4,
-    "output_cost_per_mil_tokens": 1.6,
-    "input_cache_read_cost_per_mil_tokens": 0.08,
-    "displayName": "Qwen3.7 Plus",
-    "max_input_tokens": 262144,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/qwen3p6-plus": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 3,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "displayName": "Qwen3.6 Plus",
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/qwen3-coder-480b-a35b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.45,
-    "output_cost_per_mil_tokens": 1.8,
-    "displayName": "Qwen3 Coder 480B A35B Instruct",
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/qwen3-coder-480b-instruct-bf16": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/qwen3-235b-a22b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.22,
-    "output_cost_per_mil_tokens": 0.88,
-    "displayName": "Qwen3 235B A22B",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/qwen3-vl-235b-a22b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.22,
-    "output_cost_per_mil_tokens": 0.88,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/qwen3-vl-235b-a22b-thinking": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.22,
-    "output_cost_per_mil_tokens": 0.88,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/qwen3-235b-a22b-instruct-2507": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.22,
-    "output_cost_per_mil_tokens": 0.88,
-    "displayName": "Qwen3 235B A22B Instruct 2507",
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/qwen3-235b-a22b-thinking-2507": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.22,
-    "output_cost_per_mil_tokens": 0.88,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/qwen3-next-80b-a3b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/qwen3-next-80b-a3b-thinking": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
     "max_input_tokens": 4096,
     "max_output_tokens": 4096,
     "available_providers": [
@@ -3203,6 +4913,40 @@
       "fireworks"
     ]
   },
+  "accounts/fireworks/models/llama-v3p1-405b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 3,
+    "displayName": "Llama 3.1 405B Instruct",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-7b-python": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-coder-7b-base": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
   "accounts/fireworks/models/qwen3-vl-32b-instruct": {
     "format": "openai",
     "flavor": "chat",
@@ -3210,6 +4954,29 @@
     "output_cost_per_mil_tokens": 0.9,
     "max_input_tokens": 4096,
     "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3p1-405b-instruct-long": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "displayName": "Llama 3.1 405B Instruct Long",
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-coder-v2-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 65536,
+    "max_output_tokens": 65536,
     "available_providers": [
       "fireworks"
     ]
@@ -3226,6 +4993,28 @@
       "fireworks"
     ]
   },
+  "accounts/fireworks/models/llama-v3p1-70b-instruct-1b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-coder-v2-lite-base": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
   "accounts/fireworks/models/qwen3-coder-30b-a3b-instruct": {
     "format": "openai",
     "flavor": "chat",
@@ -3233,6 +5022,29 @@
     "output_cost_per_mil_tokens": 0.6,
     "max_input_tokens": 262144,
     "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3p1-70b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "displayName": "Llama 3.1 70B Instruct",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-coder-v2-lite-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
     "available_providers": [
       "fireworks"
     ]
@@ -3248,6 +5060,28 @@
       "fireworks"
     ]
   },
+  "accounts/fireworks/models/llama-v3p1-nemotron-70b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-prover-v2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
   "accounts/fireworks/models/qwen3-vl-30b-a3b-thinking": {
     "format": "openai",
     "flavor": "chat",
@@ -3255,6 +5089,29 @@
     "output_cost_per_mil_tokens": 0.6,
     "max_input_tokens": 262144,
     "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3p1-8b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "displayName": "Llama 3.1 8B Instruct",
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-r1-distill-llama-70b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
     "available_providers": [
       "fireworks"
     ]
@@ -3270,6 +5127,28 @@
       "fireworks"
     ]
   },
+  "accounts/fireworks/models/llama-v2-70b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-r1-distill-qwen-32b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
   "accounts/fireworks/models/qwen3-30b-a3b-thinking-2507": {
     "format": "openai",
     "flavor": "chat",
@@ -3281,6 +5160,28 @@
       "fireworks"
     ]
   },
+  "accounts/fireworks/models/llama-v2-70b-chat": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 2048,
+    "max_output_tokens": 2048,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-r1-distill-qwen-14b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
   "accounts/fireworks/models/qwen3-14b": {
     "format": "openai",
     "flavor": "chat",
@@ -3288,6 +5189,28 @@
     "output_cost_per_mil_tokens": 0.2,
     "max_input_tokens": 40960,
     "max_output_tokens": 40960,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v2-13b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-r1-distill-llama-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
     "available_providers": [
       "fireworks"
     ]
@@ -3304,11 +5227,55 @@
       "fireworks"
     ]
   },
+  "accounts/fireworks/models/llama-v2-13b-chat": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-r1-distill-qwen-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
   "accounts/fireworks/models/qwen3-reranker-8b": {
     "format": "openai",
     "flavor": "chat",
     "max_input_tokens": 40960,
     "max_output_tokens": 40960,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v2-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-r1-0528-distill-qwen3-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
     "available_providers": [
       "fireworks"
     ]
@@ -3324,6 +5291,28 @@
       "fireworks"
     ]
   },
+  "accounts/fireworks/models/llama-v2-7b-chat": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-r1-distill-qwen-1p5b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
   "accounts/fireworks/models/qwen3-4b": {
     "format": "openai",
     "flavor": "chat",
@@ -3331,6 +5320,17 @@
     "output_cost_per_mil_tokens": 0.2,
     "max_input_tokens": 40960,
     "max_output_tokens": 40960,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-coder-1b-base": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
     "available_providers": [
       "fireworks"
     ]
@@ -3344,6 +5344,18 @@
       "fireworks"
     ]
   },
+  "accounts/fireworks/models/deepseek-r1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 8,
+    "displayName": "DeepSeek R1 (Fast)",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 20480,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
   "accounts/fireworks/models/qwen3-4b-instruct-2507": {
     "format": "openai",
     "flavor": "chat",
@@ -3351,6 +5363,18 @@
     "output_cost_per_mil_tokens": 0.2,
     "max_input_tokens": 262144,
     "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-r1-basic": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.55,
+    "output_cost_per_mil_tokens": 2.19,
+    "displayName": "DeepSeek R1 Basic",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 20480,
     "available_providers": [
       "fireworks"
     ]
@@ -3373,6 +5397,17 @@
     "output_cost_per_mil_tokens": 0.1,
     "max_input_tokens": 131072,
     "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-r1-0528": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 8,
+    "max_input_tokens": 160000,
+    "max_output_tokens": 160000,
     "available_providers": [
       "fireworks"
     ]
@@ -3831,2041 +5866,6 @@
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/qwq-32b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "displayName": "Qwen QwQ 32B",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/glm-5p2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.4,
-    "output_cost_per_mil_tokens": 4.4,
-    "input_cache_read_cost_per_mil_tokens": 0.14,
-    "displayName": "GLM 5.2",
-    "reasoning": true,
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/glm-5p1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.4,
-    "output_cost_per_mil_tokens": 4.4,
-    "input_cache_read_cost_per_mil_tokens": 0.26,
-    "displayName": "GLM 5.1",
-    "reasoning": true,
-    "max_input_tokens": 202800,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/glm-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 3.2,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "GLM 5",
-    "max_input_tokens": 202752,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/glm-4p7": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.2,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "reasoning": true,
-    "max_input_tokens": 202800,
-    "max_output_tokens": 202800,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/glm-4p6": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.55,
-    "output_cost_per_mil_tokens": 2.19,
-    "reasoning": true,
-    "max_input_tokens": 202800,
-    "max_output_tokens": 202800,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/glm-4p5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.55,
-    "output_cost_per_mil_tokens": 2.19,
-    "reasoning": true,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 96000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/glm-4p5-air": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.22,
-    "output_cost_per_mil_tokens": 0.88,
-    "reasoning": true,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 96000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/glm-4p5v": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "reasoning": true,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/kimi-k2p7-code": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.95,
-    "output_cost_per_mil_tokens": 4,
-    "input_cache_read_cost_per_mil_tokens": 0.19,
-    "displayName": "Kimi K2.7 Code",
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/kimi-k2p6": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.95,
-    "output_cost_per_mil_tokens": 4,
-    "input_cache_read_cost_per_mil_tokens": 0.16,
-    "displayName": "Kimi K2.6",
-    "reasoning": true,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/kimi-k2p5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 3,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "displayName": "Kimi K2.5",
-    "reasoning": true,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/kimi-k2-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.5,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/kimi-k2-thinking": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.5,
-    "displayName": "Kimi K2 Thinking",
-    "reasoning": true,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/kimi-k2-instruct-0905": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.5,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/minimax-m3": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 1.2,
-    "input_cache_read_cost_per_mil_tokens": 0.06,
-    "displayName": "MiniMax M3",
-    "max_input_tokens": 512000,
-    "max_output_tokens": 512000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/minimax-m2p7": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 1.2,
-    "input_cache_read_cost_per_mil_tokens": 0.06,
-    "displayName": "MiniMax M2.7",
-    "max_input_tokens": 196608,
-    "max_output_tokens": 196608,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/minimax-m2p5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 1.2,
-    "input_cache_read_cost_per_mil_tokens": 0.03,
-    "displayName": "MiniMax M2.5",
-    "max_input_tokens": 196608,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/minimax-m2p1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 1.2,
-    "input_cache_read_cost_per_mil_tokens": 0.03,
-    "max_input_tokens": 204800,
-    "max_output_tokens": 204800,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/minimax-m2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/minimax-m1-80k": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3-70b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3-70b-instruct-hf": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3-8b-instruct-hf": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3p3-70b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "displayName": "Llama 3.3 70B Instruct",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3p2-90b-vision-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "displayName": "Llama 3.2 90B Vision Instruct",
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3p2-11b-vision-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "displayName": "Llama 3.2 11B Vision Instruct",
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3p2-3b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3p2-3b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "displayName": "Llama 3.2 3B Instruct",
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3p2-1b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3p2-1b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3p1-405b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 3,
-    "displayName": "Llama 3.1 405B Instruct",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3p1-405b-instruct-long": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "displayName": "Llama 3.1 405B Instruct Long",
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3p1-70b-instruct-1b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3p1-70b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "displayName": "Llama 3.1 70B Instruct",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3p1-nemotron-70b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3p1-8b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "displayName": "Llama 3.1 8B Instruct",
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v2-70b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v2-70b-chat": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 2048,
-    "max_output_tokens": 2048,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v2-13b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v2-13b-chat": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v2-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v2-7b-chat": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama4-maverick-instruct-basic": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.22,
-    "output_cost_per_mil_tokens": 0.88,
-    "displayName": "Llama 4 Maverick Instruct (Basic)",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama4-scout-instruct-basic": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "Llama 4 Scout Instruct (Basic)",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-70b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-70b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-70b-python": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-34b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-34b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-34b-python": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-13b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-13b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-13b-python": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-7b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-7b-python": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mixtral-8x22b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 65536,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mixtral-8x22b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "displayName": "Mixtral MoE 8x22B Instruct",
-    "max_input_tokens": 65536,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mixtral-8x22b-instruct-hf": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 65536,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mixtral-8x7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mixtral-8x7b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "displayName": "Mixtral MoE 8x7B Instruct",
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mixtral-8x7b-instruct-hf": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mistral-7b-instruct-4k": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mistral-7b-instruct-v3": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mistral-7b-instruct-v0p2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mistral-7b-v0p2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mistral-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/gemma-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/gemma-7b-it": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/gemma-3-27b-it": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/gemma2-9b-it": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/gemma-2b-it": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/yi-34b-200k-capybara": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 200000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/yi-34b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/yi-34b-chat": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/yi-6b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/phi-3-mini-128k-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/phi-3-vision-128k-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "displayName": "Phi 3.5 Vision Instruct",
-    "max_input_tokens": 32064,
-    "max_output_tokens": 32064,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/phi-2-3b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 2048,
-    "max_output_tokens": 2048,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/chronos-hermes-13b-v2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-qwen-1p5-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 65536,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/codegemma-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/codegemma-2b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/cogito-671b-v2-p1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/cogito-v1-preview-llama-70b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/cogito-v1-preview-qwen-32b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/cogito-v1-preview-qwen-14b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/cogito-v1-preview-llama-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/cogito-v1-preview-llama-3b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/dbrx-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/devstral-small-2505": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/dobby-mini-unhinged-plus-llama-3-1-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/dobby-unhinged-llama-3-3-70b-new": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/dolphin-2-9-2-qwen2-72b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/dolphin-2p6-mixtral-8x7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/ernie-4p5-300b-a47b-pt": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/ernie-4p5-21b-a3b-pt": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/fare-20b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/firefunction-v2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/firefunction-v1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/firellava-13b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/firesearch-ocr-v6": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/fireworks-asr-v2": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/fireworks-asr-large": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/flux-1-dev-fp8": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.0005,
-    "output_cost_per_mil_tokens": 0.0005,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/flux-1-schnell-fp8": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.00035,
-    "output_cost_per_mil_tokens": 0.00035,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/flux-1-dev": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/flux-1-dev-controlnet-union": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.001,
-    "output_cost_per_mil_tokens": 0.001,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/flux-1-schnell": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/flux-kontext-max": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.08,
-    "output_cost_per_mil_tokens": 0.08,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/flux-kontext-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.04,
-    "output_cost_per_mil_tokens": 0.04,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/gpt-oss-120b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "input_cache_read_cost_per_mil_tokens": 0.015,
-    "displayName": "GPT-OSS (120B)",
-    "reasoning": true,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/gpt-oss-safeguard-120b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/gpt-oss-20b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.07,
-    "output_cost_per_mil_tokens": 0.3,
-    "input_cache_read_cost_per_mil_tokens": 0.035,
-    "displayName": "GPT-OSS (20B)",
-    "reasoning": true,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/gpt-oss-safeguard-20b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/hermes-2-pro-mistral-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/internvl3-78b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/internvl3-38b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/internvl3-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/japanese-stable-diffusion-xl": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.00013,
-    "output_cost_per_mil_tokens": 0.00013,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/kat-coder": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/kat-dev-72b-exp": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/kat-dev-32b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-guard-3-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-guard-3-1b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-guard-2-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llamaguard-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llava-yi-34b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/ministral-3-14b-instruct-2512": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/ministral-3-8b-instruct-2512": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/ministral-3-3b-instruct-2512": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mistral-large-3-fp8": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mistral-nemo-base-2407": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mistral-nemo-instruct-2407": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mistral-small-24b-instruct-2501": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "displayName": "Mistral Small 3 Instruct",
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mythomax-l2-13b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nemotron-nano-v2-12b-vl": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nous-capybara-7b-v1p9": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nous-hermes-llama2-70b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nous-hermes-2-yi-34b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nous-hermes-llama2-13b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nous-hermes-2-mixtral-8x7b-dpo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nous-hermes-llama2-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nvidia-nemotron-nano-12b-v2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nvidia-nemotron-nano-9b-v2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/openchat-3p5-0106-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/openhermes-2-mistral-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/openhermes-2p5-mistral-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/openorca-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/phind-code-llama-34b-v2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/phind-code-llama-34b-python-v1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/phind-code-llama-34b-v1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/playground-v2-5-1024px-aesthetic": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.00013,
-    "output_cost_per_mil_tokens": 0.00013,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/playground-v2-1024px-aesthetic": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.00013,
-    "output_cost_per_mil_tokens": 0.00013,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/pythia-12b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 2048,
-    "max_output_tokens": 2048,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/rolm-ocr": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/snorkel-mistral-7b-pairrm-dpo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/SSD-1B": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.00013,
-    "output_cost_per_mil_tokens": 0.00013,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/stable-diffusion-xl-1024-v1-0": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.00013,
-    "output_cost_per_mil_tokens": 0.00013,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/stablecode-3b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/starcoder-16b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/starcoder-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/starcoder2-15b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/starcoder2-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/starcoder2-3b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/toppy-m-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/whisper-v3": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/whisper-v3-turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/yi-large": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 3,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/zephyr-7b-beta": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks_ai/nomic-ai/nomic-embed-text-v1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.008,
-    "max_input_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks_ai/nomic-ai/nomic-embed-text-v1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.008,
-    "max_input_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks_ai/thenlper/gte-base": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.008,
-    "max_input_tokens": 512,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks_ai/thenlper/gte-large": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.016,
-    "max_input_tokens": 512,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks_ai/WhereIsAI/UAE-Large-V1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.016,
-    "max_input_tokens": 512,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks-ai-56b-to-176b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks-ai-moe-up-to-56b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks-ai-above-16b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks-ai-4.1b-to-16b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks-ai-up-to-4b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks-ai-default": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "fireworks"
-    ]
-  },
   "gpt-oss-120b": {
     "format": "openai",
     "flavor": "chat",
@@ -5922,6 +5922,51 @@
       "baseten"
     ]
   },
+  "meta-llama/llama-4-scout-17b-16e-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.11,
+    "output_cost_per_mil_tokens": 0.34,
+    "displayName": "Llama 4 Scout (17Bx16E)",
+    "experimental": true,
+    "deprecation_date": "2026-07-17",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "groq"
+    ]
+  },
+  "qwen/qwen3.6-27b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 3,
+    "displayName": "Qwen 3.6 27B",
+    "experimental": true,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "groq"
+    ]
+  },
+  "groq/compound": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "groq"
+    ]
+  },
+  "groq/compound-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "groq"
+    ]
+  },
   "openai/gpt-oss-20b": {
     "format": "openai",
     "flavor": "chat",
@@ -5937,33 +5982,6 @@
       "together"
     ]
   },
-  "openai/gpt-oss-safeguard-20b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.075,
-    "output_cost_per_mil_tokens": 0.3,
-    "displayName": "GPT-OSS Safeguard (20B)",
-    "experimental": true,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "groq"
-    ]
-  },
-  "meta-llama/llama-4-scout-17b-16e-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.11,
-    "output_cost_per_mil_tokens": 0.34,
-    "displayName": "Llama 4 Scout (17Bx16E)",
-    "experimental": true,
-    "deprecation_date": "2026-07-17",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "groq"
-    ]
-  },
   "llama-3.3-70b-versatile": {
     "format": "openai",
     "flavor": "chat",
@@ -5972,31 +5990,6 @@
     "displayName": "Llama 3.3 70B Versatile 128k",
     "deprecation_date": "2026-08-16",
     "max_input_tokens": 128000,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "groq"
-    ]
-  },
-  "llama-3.1-8b-instant": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.05,
-    "output_cost_per_mil_tokens": 0.08,
-    "displayName": "Llama 3.1 8B Instant 128k",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "groq"
-    ]
-  },
-  "qwen/qwen3.6-27b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 3,
-    "displayName": "Qwen 3.6 27B",
-    "experimental": true,
-    "max_input_tokens": 131072,
     "max_output_tokens": 32768,
     "available_providers": [
       "groq"
@@ -6017,20 +6010,27 @@
       "groq"
     ]
   },
-  "groq/compound": {
+  "openai/gpt-oss-safeguard-20b": {
     "format": "openai",
     "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.075,
+    "output_cost_per_mil_tokens": 0.3,
+    "displayName": "GPT-OSS Safeguard (20B)",
+    "experimental": true,
     "max_input_tokens": 131072,
-    "max_output_tokens": 8192,
+    "max_output_tokens": 65536,
     "available_providers": [
       "groq"
     ]
   },
-  "groq/compound-mini": {
+  "llama-3.1-8b-instant": {
     "format": "openai",
     "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.05,
+    "output_cost_per_mil_tokens": 0.08,
+    "displayName": "Llama 3.1 8B Instant 128k",
     "max_input_tokens": 131072,
-    "max_output_tokens": 8192,
+    "max_output_tokens": 131072,
     "available_providers": [
       "groq"
     ]
@@ -6942,6 +6942,73 @@
       "anthropic"
     ]
   },
+  "claude-sonnet-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "input_cache_write_cost_per_mil_tokens": 2.5,
+    "input_cache_write_5m_cost_per_mil_tokens": 2.5,
+    "input_cache_write_1h_cost_per_mil_tokens": 4,
+    "displayName": "Claude Sonnet 5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "fallback_models": [
+      "anthropic.claude-sonnet-5",
+      "global.anthropic.claude-sonnet-5",
+      "publishers/anthropic/models/claude-sonnet-5",
+      "us.anthropic.claude-sonnet-5"
+    ],
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "anthropic"
+    ]
+  },
+  "claude-haiku-4-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 5,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "input_cache_write_cost_per_mil_tokens": 1.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 1.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 2,
+    "displayName": "Claude Haiku 4.5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "fallback_models": [
+      "publishers/anthropic/models/claude-haiku-4-5"
+    ],
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "anthropic"
+    ]
+  },
+  "claude-haiku-4-5-20251001": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 5,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "input_cache_write_cost_per_mil_tokens": 1.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 1.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 2,
+    "displayName": "Claude Haiku 4.5 (2025-10-01)",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "claude-haiku-4-5",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "anthropic"
+    ]
+  },
   "claude-opus-4-7": {
     "format": "anthropic",
     "flavor": "chat",
@@ -6967,6 +7034,31 @@
       "anthropic"
     ]
   },
+  "claude-sonnet-4-6": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "displayName": "Claude Sonnet 4.6",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "fallback_models": [
+      "anthropic.claude-sonnet-4-6",
+      "global.anthropic.claude-sonnet-4-6",
+      "publishers/anthropic/models/claude-sonnet-4-6",
+      "us.anthropic.claude-sonnet-4-6"
+    ],
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "anthropic"
+    ]
+  },
   "claude-opus-4-6": {
     "format": "anthropic",
     "flavor": "chat",
@@ -6985,6 +7077,48 @@
     ],
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
+    "available_providers": [
+      "anthropic"
+    ]
+  },
+  "claude-sonnet-4-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "displayName": "Claude Sonnet 4.5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "fallback_models": [
+      "publishers/anthropic/models/claude-sonnet-4-5"
+    ],
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "anthropic"
+    ]
+  },
+  "claude-sonnet-4-5-20250929": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "displayName": "Claude Sonnet 4.5 (2025-09-29)",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "claude-sonnet-4-5",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
     "available_providers": [
       "anthropic"
     ]
@@ -7067,140 +7201,6 @@
       "anthropic"
     ]
   },
-  "claude-sonnet-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "input_cache_write_cost_per_mil_tokens": 2.5,
-    "input_cache_write_5m_cost_per_mil_tokens": 2.5,
-    "input_cache_write_1h_cost_per_mil_tokens": 4,
-    "displayName": "Claude Sonnet 5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "fallback_models": [
-      "anthropic.claude-sonnet-5",
-      "global.anthropic.claude-sonnet-5",
-      "publishers/anthropic/models/claude-sonnet-5",
-      "us.anthropic.claude-sonnet-5"
-    ],
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "anthropic"
-    ]
-  },
-  "claude-sonnet-4-6": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "displayName": "Claude Sonnet 4.6",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "fallback_models": [
-      "anthropic.claude-sonnet-4-6",
-      "global.anthropic.claude-sonnet-4-6",
-      "publishers/anthropic/models/claude-sonnet-4-6",
-      "us.anthropic.claude-sonnet-4-6"
-    ],
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "anthropic"
-    ]
-  },
-  "claude-sonnet-4-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "displayName": "Claude Sonnet 4.5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "fallback_models": [
-      "publishers/anthropic/models/claude-sonnet-4-5"
-    ],
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "anthropic"
-    ]
-  },
-  "claude-sonnet-4-5-20250929": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "displayName": "Claude Sonnet 4.5 (2025-09-29)",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "claude-sonnet-4-5",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "anthropic"
-    ]
-  },
-  "claude-haiku-4-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 5,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "input_cache_write_cost_per_mil_tokens": 1.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 1.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 2,
-    "displayName": "Claude Haiku 4.5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "fallback_models": [
-      "publishers/anthropic/models/claude-haiku-4-5"
-    ],
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "anthropic"
-    ]
-  },
-  "claude-haiku-4-5-20251001": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 5,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "input_cache_write_cost_per_mil_tokens": 1.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 1.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 2,
-    "displayName": "Claude Haiku 4.5 (2025-10-01)",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "claude-haiku-4-5",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "anthropic"
-    ]
-  },
   "publishers/google/models/gemini-3.5-flash": {
     "format": "google",
     "flavor": "chat",
@@ -7216,6 +7216,120 @@
     ],
     "max_input_tokens": 1048576,
     "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-pro": {
+    "format": "google",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 1.5,
+    "displayName": "Gemini Pro",
+    "deprecated": true,
+    "max_input_tokens": 32760,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-fable-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 10,
+    "output_cost_per_mil_tokens": 50,
+    "input_cache_read_cost_per_mil_tokens": 1,
+    "input_cache_write_cost_per_mil_tokens": 12.5,
+    "displayName": "Claude Fable 5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-opus-4-8": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "displayName": "Claude Opus 4.8",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-sonnet-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "displayName": "Claude Sonnet 5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-haiku-4-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 5,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "input_cache_write_cost_per_mil_tokens": 1.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 1.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 2,
+    "displayName": "Claude Haiku 4.5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/mistralai/models/mistral-large-2411": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 6,
+    "displayName": "Mistral Large (24.11)",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/mistralai/models/codestral-2501": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 0.9,
+    "displayName": "Codestral (25.01)",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-embedding-2": {
+    "format": "google",
+    "flavor": "embedding",
+    "multimodal": true,
+    "displayName": "Gemini embedding 2",
     "available_providers": [
       "vertex"
     ]
@@ -7236,6 +7350,52 @@
       "vertex"
     ]
   },
+  "publishers/anthropic/models/claude-opus-4-7": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 10,
+    "displayName": "Claude Opus 4.7",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-sonnet-4-6": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "displayName": "Claude Sonnet 4.6",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-embedding-001": {
+    "format": "google",
+    "flavor": "embedding",
+    "displayName": "Gemini embedding 001",
+    "available_providers": [
+      "vertex"
+    ]
+  },
   "publishers/google/models/gemini-3.1-flash-image-preview": {
     "format": "google",
     "flavor": "chat",
@@ -7248,6 +7408,42 @@
     ],
     "max_input_tokens": 131072,
     "max_output_tokens": 32768,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-opus-4-6": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 10,
+    "displayName": "Claude Opus 4.6",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-sonnet-4-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "displayName": "Claude Sonnet 4.5",
+    "reasoning": true,
+    "reasoning_budget": true,
     "available_providers": [
       "vertex"
     ]
@@ -7447,6 +7643,22 @@
       "vertex"
     ]
   },
+  "publishers/google/models/gemini-2.5-flash-lite-preview-09-2025": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": true,
+    "parent": "publishers/google/models/gemini-2.5-flash-lite",
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
   "gemini-2.5-flash-preview-09-2025": {
     "format": "google",
     "flavor": "chat",
@@ -7464,22 +7676,6 @@
     "supported_regions": [
       "global"
     ],
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-flash-lite-preview-09-2025": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": true,
-    "parent": "publishers/google/models/gemini-2.5-flash-lite",
     "max_input_tokens": 1048576,
     "max_output_tokens": 65535,
     "available_providers": [
@@ -7674,6 +7870,17 @@
       "vertex"
     ]
   },
+  "publishers/google/models/gemini-2.5-pro-exp-03-25": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 2.5 Pro Experimental",
+    "experimental": true,
+    "parent": "publishers/google/models/gemini-2.5-pro",
+    "available_providers": [
+      "vertex"
+    ]
+  },
   "gemini-2.5-pro-preview-03-25": {
     "format": "google",
     "flavor": "chat",
@@ -7692,17 +7899,6 @@
     ],
     "max_input_tokens": 1048576,
     "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-2.5-pro-exp-03-25": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 2.5 Pro Experimental",
-    "experimental": true,
-    "parent": "publishers/google/models/gemini-2.5-pro",
     "available_providers": [
       "vertex"
     ]
@@ -7908,6 +8104,15 @@
       "vertex"
     ]
   },
+  "publishers/google/models/gemini-1.5-flash-002": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "parent": "publishers/google/models/gemini-1.5-flash",
+    "available_providers": [
+      "vertex"
+    ]
+  },
   "gemini-1.5-pro-002": {
     "format": "google",
     "flavor": "chat",
@@ -7921,15 +8126,6 @@
     ],
     "max_input_tokens": 2097152,
     "max_output_tokens": 8192,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-1.5-flash-002": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "parent": "publishers/google/models/gemini-1.5-flash",
     "available_providers": [
       "vertex"
     ]
@@ -7962,6 +8158,15 @@
       "vertex"
     ]
   },
+  "publishers/google/models/gemini-1.5-flash-001": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "parent": "publishers/google/models/gemini-1.5-flash",
+    "available_providers": [
+      "vertex"
+    ]
+  },
   "gemini-1.5-pro-001": {
     "format": "google",
     "flavor": "chat",
@@ -7975,15 +8180,6 @@
     ],
     "max_input_tokens": 1000000,
     "max_output_tokens": 8192,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-1.5-flash-001": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "parent": "publishers/google/models/gemini-1.5-flash",
     "available_providers": [
       "vertex"
     ]
@@ -8014,20 +8210,20 @@
       "vertex"
     ]
   },
-  "publishers/google/models/gemini-1.5-flash": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 1.5 Flash",
-    "available_providers": [
-      "vertex"
-    ]
-  },
   "publishers/google/models/gemini-1.5-pro": {
     "format": "google",
     "flavor": "chat",
     "multimodal": true,
     "displayName": "Gemini 1.5 Pro",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-1.5-flash": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 1.5 Flash",
     "available_providers": [
       "vertex"
     ]
@@ -8052,202 +8248,6 @@
     "format": "google",
     "flavor": "chat",
     "displayName": "Gemini 1.0 Pro",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "gemini-pro": {
-    "format": "google",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 1.5,
-    "displayName": "Gemini Pro",
-    "deprecated": true,
-    "max_input_tokens": 32760,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-fable-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 10,
-    "output_cost_per_mil_tokens": 50,
-    "input_cache_read_cost_per_mil_tokens": 1,
-    "input_cache_write_cost_per_mil_tokens": 12.5,
-    "displayName": "Claude Fable 5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-opus-4-8": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "displayName": "Claude Opus 4.8",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-opus-4-7": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 10,
-    "displayName": "Claude Opus 4.7",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-opus-4-6": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 10,
-    "displayName": "Claude Opus 4.6",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-sonnet-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "displayName": "Claude Sonnet 5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-sonnet-4-6": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "displayName": "Claude Sonnet 4.6",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-sonnet-4-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "displayName": "Claude Sonnet 4.5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-haiku-4-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 5,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "input_cache_write_cost_per_mil_tokens": 1.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 1.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 2,
-    "displayName": "Claude Haiku 4.5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/mistralai/models/mistral-large-2411": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 6,
-    "displayName": "Mistral Large (24.11)",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/mistralai/models/codestral-2501": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 0.9,
-    "displayName": "Codestral (25.01)",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-embedding-2": {
-    "format": "google",
-    "flavor": "embedding",
-    "multimodal": true,
-    "displayName": "Gemini embedding 2",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-embedding-001": {
-    "format": "google",
-    "flavor": "embedding",
-    "displayName": "Gemini embedding 001",
     "available_providers": [
       "vertex"
     ]
@@ -9919,30 +9919,6 @@
       "baseten"
     ]
   },
-  "deepseek-ai/DeepSeek-V3": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 1.25,
-    "displayName": "DeepSeek V3",
-    "max_input_tokens": 65536,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "deepseek-ai/DeepSeek-R1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 7,
-    "displayName": "DeepSeek R1",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 20480,
-    "available_providers": [
-      "together"
-    ]
-  },
   "Qwen/Qwen3.7-Max": {
     "format": "openai",
     "flavor": "chat",
@@ -9956,6 +9932,162 @@
       "together"
     ]
   },
+  "moonshotai/Kimi-K2.7-Code": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.95,
+    "output_cost_per_mil_tokens": 4,
+    "input_cache_read_cost_per_mil_tokens": 0.16,
+    "displayName": "Kimi K2.7 Code",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "together",
+      "baseten"
+    ]
+  },
+  "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.27,
+    "output_cost_per_mil_tokens": 0.85,
+    "displayName": "Llama 4 Maverick Instruct (17Bx128E)",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3.5,
+    "output_cost_per_mil_tokens": 3.5,
+    "displayName": "Llama 3.1 405B Instruct Turbo",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "MiniMaxAI/MiniMax-M3": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 1.2,
+    "input_cache_read_cost_per_mil_tokens": 0.06,
+    "displayName": "MiniMax M3",
+    "max_input_tokens": 524288,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "mistralai/Mistral-7B-Instruct-v0.1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "displayName": "Mistral (7B) Instruct",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "google/gemma-4-31B-it": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.39,
+    "output_cost_per_mil_tokens": 0.97,
+    "displayName": "Gemma 4 31B IT",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "pearl-ai/gemma-4-31b-it": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.28,
+    "output_cost_per_mil_tokens": 0.86,
+    "displayName": "Gemma 4 31B IT (Pearl)",
+    "max_input_tokens": 32000,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "LiquidAI/LFM2-24B-A2B": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.03,
+    "output_cost_per_mil_tokens": 0.12,
+    "displayName": "LFM2 24B A2B",
+    "max_input_tokens": 32768,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "deepcogito/cogito-v2-1-671b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 1.25,
+    "displayName": "Cogito v2.1 671B",
+    "max_input_tokens": 163840,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "mistralai/Mistral-Small-24B-Instruct-2501": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.8,
+    "output_cost_per_mil_tokens": 0.8,
+    "displayName": "Mistral Small (24B) Instruct 25.01",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "mistralai/Mixtral-8x7B-Instruct-v0.1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "Mixtral 8x7B Instruct v0.1",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "nvidia/nemotron-3-ultra-550b-a55b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 3.6,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "NVIDIA Nemotron 3 Ultra 550B",
+    "reasoning": true,
+    "max_input_tokens": 512300,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "essentialai/rnj-1-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.15,
+    "displayName": "RNJ-1 Instruct",
+    "max_input_tokens": 32768,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "deepseek-ai/DeepSeek-V3": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 1.25,
+    "displayName": "DeepSeek V3",
+    "max_input_tokens": 65536,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "together"
+    ]
+  },
   "Qwen/Qwen3.7-Plus": {
     "format": "openai",
     "flavor": "chat",
@@ -9963,6 +10095,82 @@
     "output_cost_per_mil_tokens": 1.28,
     "displayName": "Qwen 3.7 Plus",
     "max_input_tokens": 1000000,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "moonshotai/Kimi-K2-Instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 3,
+    "displayName": "Kimi K2 Instruct",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.18,
+    "output_cost_per_mil_tokens": 0.59,
+    "displayName": "Llama 4 Scout Instruct (17Bx16E)",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.88,
+    "output_cost_per_mil_tokens": 0.88,
+    "displayName": "Llama 3.1 70B Instruct Turbo",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "MiniMaxAI/MiniMax-M2.7": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 1.2,
+    "input_cache_read_cost_per_mil_tokens": 0.06,
+    "displayName": "MiniMax M2.7",
+    "max_input_tokens": 202752,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "google/gemma-3n-E4B-it": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.06,
+    "output_cost_per_mil_tokens": 0.12,
+    "displayName": "Gemma 3n E4B IT",
+    "max_input_tokens": 32768,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "LiquidAI/LFM2.5-8B-A1B": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.03,
+    "output_cost_per_mil_tokens": 0.12,
+    "displayName": "LFM2.5 8B A1B",
+    "max_input_tokens": 32768,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "deepseek-ai/DeepSeek-R1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 7,
+    "displayName": "DeepSeek R1",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 20480,
     "available_providers": [
       "together"
     ]
@@ -9980,6 +10188,26 @@
       "together"
     ]
   },
+  "meta-llama/Llama-3.3-70B-Instruct-Turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.04,
+    "output_cost_per_mil_tokens": 1.04,
+    "displayName": "Llama 3.3 70B Instruct Turbo",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.18,
+    "output_cost_per_mil_tokens": 0.18,
+    "displayName": "Llama 3.1 8B Instruct Turbo",
+    "available_providers": [
+      "together"
+    ]
+  },
   "Qwen/Qwen3.5-397B-A17B": {
     "format": "openai",
     "flavor": "chat",
@@ -9992,6 +10220,14 @@
       "together"
     ]
   },
+  "meta-llama/Llama-3.3-70B-Instruct-Turbo-Free": {
+    "format": "openai",
+    "flavor": "chat",
+    "displayName": "Llama 3.3 70B Instruct Turbo Free",
+    "available_providers": [
+      "together"
+    ]
+  },
   "Qwen/Qwen3.5-9B": {
     "format": "openai",
     "flavor": "chat",
@@ -9999,6 +10235,16 @@
     "output_cost_per_mil_tokens": 0.25,
     "displayName": "Qwen3.5 9B",
     "max_input_tokens": 262144,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "meta-llama/Llama-3.2-3B-Instruct-Turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.06,
+    "output_cost_per_mil_tokens": 0.06,
+    "displayName": "Llama 3.2 3B Instruct Turbo",
     "available_providers": [
       "together"
     ]
@@ -10041,252 +10287,6 @@
     "input_cost_per_mil_tokens": 0.3,
     "output_cost_per_mil_tokens": 0.3,
     "displayName": "Qwen 2.5 7B Instruct Turbo",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "moonshotai/Kimi-K2.7-Code": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.95,
-    "output_cost_per_mil_tokens": 4,
-    "input_cache_read_cost_per_mil_tokens": 0.16,
-    "displayName": "Kimi K2.7 Code",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "together",
-      "baseten"
-    ]
-  },
-  "moonshotai/Kimi-K2-Instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 3,
-    "displayName": "Kimi K2 Instruct",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.27,
-    "output_cost_per_mil_tokens": 0.85,
-    "displayName": "Llama 4 Maverick Instruct (17Bx128E)",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.18,
-    "output_cost_per_mil_tokens": 0.59,
-    "displayName": "Llama 4 Scout Instruct (17Bx16E)",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta-llama/Llama-3.3-70B-Instruct-Turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.04,
-    "output_cost_per_mil_tokens": 1.04,
-    "displayName": "Llama 3.3 70B Instruct Turbo",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta-llama/Llama-3.3-70B-Instruct-Turbo-Free": {
-    "format": "openai",
-    "flavor": "chat",
-    "displayName": "Llama 3.3 70B Instruct Turbo Free",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta-llama/Llama-3.2-3B-Instruct-Turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.06,
-    "output_cost_per_mil_tokens": 0.06,
-    "displayName": "Llama 3.2 3B Instruct Turbo",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3.5,
-    "output_cost_per_mil_tokens": 3.5,
-    "displayName": "Llama 3.1 405B Instruct Turbo",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.88,
-    "output_cost_per_mil_tokens": 0.88,
-    "displayName": "Llama 3.1 70B Instruct Turbo",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.18,
-    "output_cost_per_mil_tokens": 0.18,
-    "displayName": "Llama 3.1 8B Instruct Turbo",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "MiniMaxAI/MiniMax-M3": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 1.2,
-    "input_cache_read_cost_per_mil_tokens": 0.06,
-    "displayName": "MiniMax M3",
-    "max_input_tokens": 524288,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "MiniMaxAI/MiniMax-M2.7": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 1.2,
-    "input_cache_read_cost_per_mil_tokens": 0.06,
-    "displayName": "MiniMax M2.7",
-    "max_input_tokens": 202752,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "mistralai/Mistral-7B-Instruct-v0.1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "displayName": "Mistral (7B) Instruct",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "google/gemma-4-31B-it": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.39,
-    "output_cost_per_mil_tokens": 0.97,
-    "displayName": "Gemma 4 31B IT",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "pearl-ai/gemma-4-31b-it": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.28,
-    "output_cost_per_mil_tokens": 0.86,
-    "displayName": "Gemma 4 31B IT (Pearl)",
-    "max_input_tokens": 32000,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "google/gemma-3n-E4B-it": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.06,
-    "output_cost_per_mil_tokens": 0.12,
-    "displayName": "Gemma 3n E4B IT",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "LiquidAI/LFM2-24B-A2B": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.03,
-    "output_cost_per_mil_tokens": 0.12,
-    "displayName": "LFM2 24B A2B",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "LiquidAI/LFM2.5-8B-A1B": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.03,
-    "output_cost_per_mil_tokens": 0.12,
-    "displayName": "LFM2.5 8B A1B",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "deepcogito/cogito-v2-1-671b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 1.25,
-    "displayName": "Cogito v2.1 671B",
-    "max_input_tokens": 163840,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "essentialai/rnj-1-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.15,
-    "displayName": "RNJ-1 Instruct",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "mistralai/Mistral-Small-24B-Instruct-2501": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.8,
-    "output_cost_per_mil_tokens": 0.8,
-    "displayName": "Mistral Small (24B) Instruct 25.01",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "mistralai/Mixtral-8x7B-Instruct-v0.1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "Mixtral 8x7B Instruct v0.1",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "nvidia/nemotron-3-ultra-550b-a55b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 3.6,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "NVIDIA Nemotron 3 Ultra 550B",
-    "reasoning": true,
-    "max_input_tokens": 512300,
     "available_providers": [
       "together"
     ]
@@ -10360,42 +10360,6 @@
       "together"
     ]
   },
-  "zai-org/GLM-5.1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.3,
-    "output_cost_per_mil_tokens": 4.3,
-    "input_cache_read_cost_per_mil_tokens": 0.26,
-    "displayName": "GLM 5.1",
-    "reasoning": true,
-    "max_input_tokens": 202752,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "baseten",
-      "together"
-    ]
-  },
-  "zai-org/GLM-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.95,
-    "output_cost_per_mil_tokens": 3.15,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "available_providers": [
-      "baseten",
-      "together"
-    ]
-  },
-  "zai-org/GLM-4.7": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.2,
-    "input_cache_read_cost_per_mil_tokens": 0.12,
-    "available_providers": [
-      "baseten"
-    ]
-  },
   "moonshotai/Kimi-K2.6": {
     "format": "openai",
     "flavor": "chat",
@@ -10403,17 +10367,6 @@
     "output_cost_per_mil_tokens": 4,
     "input_cache_read_cost_per_mil_tokens": 0.16,
     "displayName": "Kimi K2.6",
-    "available_providers": [
-      "baseten",
-      "together"
-    ]
-  },
-  "moonshotai/Kimi-K2.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 3,
-    "input_cache_read_cost_per_mil_tokens": 0.12,
     "available_providers": [
       "baseten",
       "together"
@@ -10442,6 +10395,53 @@
       "baseten"
     ]
   },
+  "zai-org/GLM-5.1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.3,
+    "output_cost_per_mil_tokens": 4.3,
+    "input_cache_read_cost_per_mil_tokens": 0.26,
+    "displayName": "GLM 5.1",
+    "reasoning": true,
+    "max_input_tokens": 202752,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "baseten",
+      "together"
+    ]
+  },
+  "moonshotai/Kimi-K2.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 3,
+    "input_cache_read_cost_per_mil_tokens": 0.12,
+    "available_providers": [
+      "baseten",
+      "together"
+    ]
+  },
+  "zai-org/GLM-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.95,
+    "output_cost_per_mil_tokens": 3.15,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "available_providers": [
+      "baseten",
+      "together"
+    ]
+  },
+  "zai-org/GLM-4.7": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.2,
+    "input_cache_read_cost_per_mil_tokens": 0.12,
+    "available_providers": [
+      "baseten"
+    ]
+  },
   "mistral-large-latest": {
     "format": "openai",
     "flavor": "chat",
@@ -10450,19 +10450,6 @@
     "displayName": "Mistral Large",
     "max_input_tokens": 262144,
     "max_output_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-large-2512": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 1.5,
-    "displayName": "Mistral Large (2512)",
-    "parent": "mistral-large-latest",
-    "max_input_tokens": 262144,
     "available_providers": [
       "mistral"
     ]
@@ -10481,89 +10468,6 @@
       "mistral"
     ]
   },
-  "mistral-medium-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.5,
-    "output_cost_per_mil_tokens": 7.5,
-    "displayName": "Mistral Medium 3",
-    "parent": "mistral-medium-3.5",
-    "max_input_tokens": 256000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-medium": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.7,
-    "output_cost_per_mil_tokens": 8.1,
-    "displayName": "Mistral Medium",
-    "deprecated": true,
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8191,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-medium-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.5,
-    "output_cost_per_mil_tokens": 7.5,
-    "displayName": "Mistral Medium 3.5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 256000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-medium-2604": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.5,
-    "output_cost_per_mil_tokens": 7.5,
-    "displayName": "Mistral Medium 3.5 (2604)",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "mistral-medium-latest",
-    "max_input_tokens": 256000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-medium-2508": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.4,
-    "output_cost_per_mil_tokens": 2,
-    "displayName": "Mistral Medium (2508)",
-    "deprecation_date": "2026-05-22",
-    "parent": "mistral-medium-latest",
-    "max_input_tokens": 128000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-medium-2505": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.4,
-    "output_cost_per_mil_tokens": 2,
-    "deprecation_date": "2026-05-22",
-    "parent": "mistral-medium-latest",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 8191,
-    "available_providers": [
-      "mistral"
-    ]
-  },
   "magistral-medium-latest": {
     "format": "openai",
     "flavor": "chat",
@@ -10576,19 +10480,6 @@
       "mistral"
     ]
   },
-  "magistral-medium-2509": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 5,
-    "displayName": "Magistral Medium (2509)",
-    "deprecation_date": "2026-07-31",
-    "parent": "magistral-medium-latest",
-    "max_input_tokens": 128000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
   "codestral-2508": {
     "format": "openai",
     "flavor": "chat",
@@ -10597,19 +10488,6 @@
     "displayName": "Codestral 2508",
     "parent": "codestral-latest",
     "max_input_tokens": 256000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "codestral-2501": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 0.9,
-    "parent": "codestral-latest",
-    "fallback_models": [
-      "publishers/mistralai/models/codestral-2501"
-    ],
     "available_providers": [
       "mistral"
     ]
@@ -10684,34 +10562,6 @@
       "mistral"
     ]
   },
-  "mistral-small-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "Mistral Small",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-small-2603": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "Mistral Small (2603)",
-    "parent": "mistral-small-latest",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
   "magistral-small-latest": {
     "format": "openai",
     "flavor": "chat",
@@ -10720,19 +10570,6 @@
     "displayName": "Magistral Small Latest",
     "max_input_tokens": 128000,
     "max_output_tokens": 40000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "magistral-small-2509": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 1.5,
-    "displayName": "Magistral Small (2509)",
-    "deprecation_date": "2026-07-31",
-    "parent": "magistral-small-latest",
-    "max_input_tokens": 128000,
     "available_providers": [
       "mistral"
     ]
@@ -10762,17 +10599,6 @@
       "mistral"
     ]
   },
-  "voxtral-small-2507": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "max_input_tokens": 32000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
   "ministral-14b-latest": {
     "format": "openai",
     "flavor": "chat",
@@ -10781,68 +10607,6 @@
     "output_cost_per_mil_tokens": 0.2,
     "displayName": "Ministral 14B",
     "max_input_tokens": 256000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "ministral-14b-2512": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "displayName": "Ministral 14B 2512",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "ministral-8b-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.15,
-    "displayName": "Ministral 8B",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "ministral-8b-2512": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.15,
-    "displayName": "Ministral 8B (2512)",
-    "parent": "ministral-8b-latest",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "ministral-3b-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "displayName": "Ministral 3B",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "ministral-3b-2512": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "displayName": "Ministral 3B (2512)",
-    "parent": "ministral-3b-latest",
-    "max_input_tokens": 262144,
     "available_providers": [
       "mistral"
     ]
@@ -10873,18 +10637,6 @@
       "mistral"
     ]
   },
-  "open-mistral-nemo-2407": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.15,
-    "deprecation_date": "2026-07-31",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
   "open-mixtral-8x22b": {
     "format": "openai",
     "flavor": "chat",
@@ -10903,6 +10655,254 @@
     "flavor": "chat",
     "displayName": "Leanstral 1.5",
     "max_input_tokens": 256000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-large-2512": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 1.5,
+    "displayName": "Mistral Large (2512)",
+    "parent": "mistral-large-latest",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-medium-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.5,
+    "output_cost_per_mil_tokens": 7.5,
+    "displayName": "Mistral Medium 3",
+    "parent": "mistral-medium-3.5",
+    "max_input_tokens": 256000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "magistral-medium-2509": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 5,
+    "displayName": "Magistral Medium (2509)",
+    "deprecation_date": "2026-07-31",
+    "parent": "magistral-medium-latest",
+    "max_input_tokens": 128000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "codestral-2501": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 0.9,
+    "parent": "codestral-latest",
+    "fallback_models": [
+      "publishers/mistralai/models/codestral-2501"
+    ],
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-small-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "Mistral Small",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "magistral-small-2509": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 1.5,
+    "displayName": "Magistral Small (2509)",
+    "deprecation_date": "2026-07-31",
+    "parent": "magistral-small-latest",
+    "max_input_tokens": 128000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "voxtral-small-2507": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "max_input_tokens": 32000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "ministral-14b-2512": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "displayName": "Ministral 14B 2512",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "open-mistral-nemo-2407": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.15,
+    "deprecation_date": "2026-07-31",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-medium": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.7,
+    "output_cost_per_mil_tokens": 8.1,
+    "displayName": "Mistral Medium",
+    "deprecated": true,
+    "max_input_tokens": 32000,
+    "max_output_tokens": 8191,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-small-2603": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "Mistral Small (2603)",
+    "parent": "mistral-small-latest",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "ministral-8b-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.15,
+    "displayName": "Ministral 8B",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-medium-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.5,
+    "output_cost_per_mil_tokens": 7.5,
+    "displayName": "Mistral Medium 3.5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 256000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "ministral-8b-2512": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.15,
+    "displayName": "Ministral 8B (2512)",
+    "parent": "ministral-8b-latest",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-medium-2604": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.5,
+    "output_cost_per_mil_tokens": 7.5,
+    "displayName": "Mistral Medium 3.5 (2604)",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "mistral-medium-latest",
+    "max_input_tokens": 256000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "ministral-3b-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "displayName": "Ministral 3B",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-medium-2508": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.4,
+    "output_cost_per_mil_tokens": 2,
+    "displayName": "Mistral Medium (2508)",
+    "deprecation_date": "2026-05-22",
+    "parent": "mistral-medium-latest",
+    "max_input_tokens": 128000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "ministral-3b-2512": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "displayName": "Ministral 3B (2512)",
+    "parent": "ministral-3b-latest",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-medium-2505": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.4,
+    "output_cost_per_mil_tokens": 2,
+    "deprecation_date": "2026-05-22",
+    "parent": "mistral-medium-latest",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 8191,
     "available_providers": [
       "mistral"
     ]
@@ -10927,6 +10927,19 @@
       "vertex"
     ]
   },
+  "gemini-embedding-2": {
+    "format": "google",
+    "flavor": "embedding",
+    "multimodal": true,
+    "displayName": "Gemini embedding 2",
+    "fallback_models": [
+      "publishers/google/models/gemini-embedding-2"
+    ],
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
   "gemini-3.1-flash-image": {
     "format": "google",
     "flavor": "chat",
@@ -10942,6 +10955,18 @@
     ],
     "max_input_tokens": 131072,
     "max_output_tokens": 32768,
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-embedding-001": {
+    "format": "google",
+    "flavor": "embedding",
+    "displayName": "Gemini embedding 001",
+    "fallback_models": [
+      "publishers/google/models/gemini-embedding-001"
+    ],
     "available_providers": [
       "google",
       "vertex"
@@ -11402,31 +11427,6 @@
     ],
     "max_input_tokens": 1048576,
     "max_output_tokens": 8192,
-    "available_providers": [
-      "google",
-      "vertex"
-    ]
-  },
-  "gemini-embedding-2": {
-    "format": "google",
-    "flavor": "embedding",
-    "multimodal": true,
-    "displayName": "Gemini embedding 2",
-    "fallback_models": [
-      "publishers/google/models/gemini-embedding-2"
-    ],
-    "available_providers": [
-      "google",
-      "vertex"
-    ]
-  },
-  "gemini-embedding-001": {
-    "format": "google",
-    "flavor": "embedding",
-    "displayName": "Gemini embedding 001",
-    "fallback_models": [
-      "publishers/google/models/gemini-embedding-001"
-    ],
     "available_providers": [
       "google",
       "vertex"
@@ -11969,284 +11969,12 @@
       "databricks"
     ]
   },
-  "databricks-claude-sonnet-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Sonnet 5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-opus-4-8": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Opus 4.8",
-    "reasoning": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-opus-4-7": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Opus 4.7",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-opus-4-6": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Opus 4.6",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-sonnet-4-6": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Sonnet 4.6",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-haiku-4-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Haiku 4.5",
-    "max_input_tokens": 200000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-opus-4-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Opus 4.5",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 32000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-sonnet-4-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Sonnet 4.5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-opus-4-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Opus 4.1",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 32000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-sonnet-4": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Sonnet 4",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-3-7-sonnet": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2.99999,
-    "output_cost_per_mil_tokens": 15.00002,
-    "displayName": "Claude Sonnet 3.7",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "deprecation_date": "2026-02-19",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
   "databricks-gpt-oss-120b": {
     "format": "openai",
     "flavor": "chat",
     "displayName": "GPT-OSS 120B",
     "reasoning": true,
     "max_input_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-oss-20b": {
-    "format": "openai",
-    "flavor": "chat",
-    "displayName": "GPT-OSS 20B",
-    "reasoning": true,
-    "max_input_tokens": 131072,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-6-luna": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.6 Luna",
-    "reasoning": true,
-    "max_input_tokens": 400000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-6-sol": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.6 Sol",
-    "reasoning": true,
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-6-terra": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.6 Terra",
-    "reasoning": true,
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.5",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-4": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.4",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-4-nano": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.4 nano",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.2",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.1",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5 mini",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-nano": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5 nano",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
     "available_providers": [
       "databricks"
     ]
@@ -12262,47 +11990,6 @@
       "databricks"
     ]
   },
-  "databricks-gemini-3-1-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 3.1 Pro",
-    "max_input_tokens": 1000000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gemini-3-flash": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 3 Flash",
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gemini-2-5-flash": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 2.5 Flash",
-    "max_input_tokens": 1000000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gemini-2-5-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 2.5 Pro",
-    "max_input_tokens": 1000000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
   "databricks-meta-llama-3-3-70b-instruct": {
     "format": "openai",
     "flavor": "chat",
@@ -12310,30 +11997,6 @@
     "output_cost_per_mil_tokens": 1.50003,
     "displayName": "Llama 3.3 70B Instruct",
     "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-meta-llama-3-1-405b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 5.00003,
-    "output_cost_per_mil_tokens": 15.00002,
-    "displayName": "Llama 3.1 405B Instruct",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-meta-llama-3-1-8b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15001,
-    "output_cost_per_mil_tokens": 0.45003,
-    "displayName": "Llama 3.1 8B Instruct",
-    "max_input_tokens": 200000,
     "max_output_tokens": 128000,
     "available_providers": [
       "databricks"
@@ -12361,6 +12024,51 @@
       "databricks"
     ]
   },
+  "databricks-claude-sonnet-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Sonnet 5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-oss-20b": {
+    "format": "openai",
+    "flavor": "chat",
+    "displayName": "GPT-OSS 20B",
+    "reasoning": true,
+    "max_input_tokens": 131072,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gemini-3-1-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 3.1 Pro",
+    "max_input_tokens": 1000000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-meta-llama-3-1-405b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 5.00003,
+    "output_cost_per_mil_tokens": 15.00002,
+    "displayName": "Llama 3.1 405B Instruct",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
   "databricks-qwen3-next-80b-a3b-instruct": {
     "format": "openai",
     "flavor": "chat",
@@ -12368,6 +12076,298 @@
     "experimental": true,
     "max_input_tokens": 262144,
     "max_output_tokens": 16384,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-opus-4-8": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Opus 4.8",
+    "reasoning": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-6-luna": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.6 Luna",
+    "reasoning": true,
+    "max_input_tokens": 400000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gemini-3-flash": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 3 Flash",
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-meta-llama-3-1-8b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15001,
+    "output_cost_per_mil_tokens": 0.45003,
+    "displayName": "Llama 3.1 8B Instruct",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-opus-4-7": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Opus 4.7",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-6-sol": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.6 Sol",
+    "reasoning": true,
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gemini-2-5-flash": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 2.5 Flash",
+    "max_input_tokens": 1000000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-opus-4-6": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Opus 4.6",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-6-terra": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.6 Terra",
+    "reasoning": true,
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gemini-2-5-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 2.5 Pro",
+    "max_input_tokens": 1000000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-sonnet-4-6": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Sonnet 4.6",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.5",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-haiku-4-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Haiku 4.5",
+    "max_input_tokens": 200000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-4": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.4",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-opus-4-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Opus 4.5",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 32000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-4-nano": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.4 nano",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-sonnet-4-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Sonnet 4.5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.2",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-opus-4-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Opus 4.1",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 32000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.1",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-sonnet-4": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Sonnet 4",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-3-7-sonnet": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.99999,
+    "output_cost_per_mil_tokens": 15.00002,
+    "displayName": "Claude Sonnet 3.7",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "deprecation_date": "2026-02-19",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5 mini",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-nano": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5 nano",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
     "available_providers": [
       "databricks"
     ]

--- a/packages/proxy/schema/model_list.json
+++ b/packages/proxy/schema/model_list.json
@@ -6044,13 +6044,36 @@
       "groq"
     ]
   },
-  "text-davinci-003": {
-    "format": "openai",
-    "flavor": "completion",
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 2,
-    "displayName": "Text Davinci 003",
+  "publishers/google/models/gemini-2.0-flash-lite-preview-02-05": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.075,
+    "output_cost_per_mil_tokens": 0.3,
+    "displayName": "Gemini 2.0 Flash-Lite",
     "deprecated": true
+  },
+  "publishers/google/models/gemini-1.0-pro-002": {
+    "format": "google",
+    "flavor": "chat",
+    "parent": "publishers/google/models/gemini-1.0-pro"
+  },
+  "publishers/google/models/gemini-1.0-pro-001": {
+    "format": "google",
+    "flavor": "chat",
+    "parent": "publishers/google/models/gemini-1.0-pro"
+  },
+  "publishers/google/models/gemini-1.0-pro-vision-001": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "parent": "publishers/google/models/gemini-1.0-pro-vision"
+  },
+  "publishers/google/models/gemini-1.0-pro-vision": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 1.0 Pro Vision"
   },
   "publishers/anthropic/models/claude-opus-4-5@20251101": {
     "format": "anthropic",
@@ -6111,6 +6134,267 @@
     "reasoning": true,
     "reasoning_budget": true,
     "parent": "publishers/anthropic/models/claude-opus-4"
+  },
+  "publishers/anthropic/models/claude-sonnet-4-5@20250929": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": true,
+    "parent": "publishers/anthropic/models/claude-sonnet-4-5"
+  },
+  "publishers/anthropic/models/claude-sonnet-4": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "displayName": "Claude Sonnet 4",
+    "reasoning": true,
+    "reasoning_budget": true
+  },
+  "publishers/anthropic/models/claude-sonnet-4@20250514": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": true,
+    "parent": "publishers/anthropic/models/claude-sonnet-4"
+  },
+  "publishers/anthropic/models/claude-haiku-4-5@20251001": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 5,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "input_cache_write_cost_per_mil_tokens": 1.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 1.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 2,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "publishers/anthropic/models/claude-haiku-4-5",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000
+  },
+  "publishers/anthropic/models/claude-3-7-sonnet": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "displayName": "Claude Sonnet 3.7",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "deprecation_date": "2026-02-19"
+  },
+  "publishers/anthropic/models/claude-3-7-sonnet@20250219": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": true,
+    "deprecation_date": "2026-02-19",
+    "parent": "publishers/anthropic/models/claude-3-7-sonnet"
+  },
+  "publishers/anthropic/models/claude-3-5-sonnet-v2": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "displayName": "Claude Sonnet 3.5 v2"
+  },
+  "publishers/anthropic/models/claude-3-5-sonnet-v2@20241022": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "parent": "publishers/anthropic/models/claude-3-5-sonnet-v2"
+  },
+  "publishers/anthropic/models/claude-3-5-haiku": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.8,
+    "output_cost_per_mil_tokens": 4,
+    "input_cache_read_cost_per_mil_tokens": 0.08,
+    "input_cache_write_cost_per_mil_tokens": 1,
+    "input_cache_write_5m_cost_per_mil_tokens": 1,
+    "input_cache_write_1h_cost_per_mil_tokens": 1.6,
+    "displayName": "Claude Haiku 3.5",
+    "deprecation_date": "2026-02-19",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8192
+  },
+  "publishers/anthropic/models/claude-3-5-sonnet": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "displayName": "Claude Sonnet 3.5"
+  },
+  "publishers/anthropic/models/claude-3-5-haiku@20241022": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.8,
+    "output_cost_per_mil_tokens": 4,
+    "input_cache_read_cost_per_mil_tokens": 0.08,
+    "input_cache_write_cost_per_mil_tokens": 1,
+    "input_cache_write_5m_cost_per_mil_tokens": 1,
+    "input_cache_write_1h_cost_per_mil_tokens": 1.6,
+    "deprecation_date": "2026-02-19",
+    "parent": "publishers/anthropic/models/claude-3-5-haiku",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8192
+  },
+  "publishers/anthropic/models/claude-3-5-sonnet@20240620": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "parent": "publishers/anthropic/models/claude-3-5-sonnet"
+  },
+  "publishers/anthropic/models/claude-3-haiku": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 1.25,
+    "input_cache_read_cost_per_mil_tokens": 0.03,
+    "input_cache_write_cost_per_mil_tokens": 0.3,
+    "input_cache_write_5m_cost_per_mil_tokens": 0.3,
+    "input_cache_write_1h_cost_per_mil_tokens": 0.5,
+    "displayName": "Claude Haiku 3"
+  },
+  "publishers/anthropic/models/claude-3-opus": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 15,
+    "output_cost_per_mil_tokens": 75,
+    "input_cache_read_cost_per_mil_tokens": 1.5,
+    "input_cache_write_cost_per_mil_tokens": 18.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 18.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 30,
+    "displayName": "Claude Opus 3"
+  },
+  "publishers/anthropic/models/claude-3-haiku@20240307": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 1.25,
+    "input_cache_read_cost_per_mil_tokens": 0.03,
+    "input_cache_write_cost_per_mil_tokens": 0.3,
+    "input_cache_write_5m_cost_per_mil_tokens": 0.3,
+    "input_cache_write_1h_cost_per_mil_tokens": 0.5,
+    "parent": "publishers/anthropic/models/claude-3-haiku"
+  },
+  "publishers/anthropic/models/claude-3-opus@20240229": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 15,
+    "output_cost_per_mil_tokens": 75,
+    "input_cache_read_cost_per_mil_tokens": 1.5,
+    "input_cache_write_cost_per_mil_tokens": 18.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 18.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 30,
+    "parent": "publishers/anthropic/models/claude-3-opus"
+  },
+  "publishers/meta/models/llama-3.3-70b-instruct-maas": {
+    "format": "openai",
+    "flavor": "chat",
+    "displayName": "Llama 3.3 70B Instruct",
+    "experimental": true
+  },
+  "publishers/meta/models/llama-3.2-90b-vision-instruct-maas": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Llama 3.2 90B Vision Instruct",
+    "experimental": true
+  },
+  "publishers/meta/models/llama-3.1-401b-instruct-maas": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 16,
+    "displayName": "Llama 3.1 401B Instruct"
+  },
+  "publishers/meta/models/llama-3.1-70b-instruct-maas": {
+    "format": "openai",
+    "flavor": "chat",
+    "displayName": "Llama 3.1 70B Instruct",
+    "experimental": true
+  },
+  "publishers/meta/models/llama-3.1-8b-instruct-maas": {
+    "format": "openai",
+    "flavor": "chat",
+    "displayName": "Llama 3.1 8B Instruct",
+    "experimental": true
+  },
+  "publishers/mistralai/models/mistral-nemo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.15,
+    "displayName": "Mistral Nemo"
+  },
+  "publishers/qwen/models/qwen3-235b-a22b-instruct-2507-maas": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.22,
+    "output_cost_per_mil_tokens": 0.88,
+    "displayName": "Qwen3 235B A22B Instruct 2507",
+    "locations": [
+      "global",
+      "us-south1"
+    ],
+    "max_input_tokens": 262144,
+    "max_output_tokens": 16384
+  },
+  "text-davinci-003": {
+    "format": "openai",
+    "flavor": "completion",
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 2,
+    "displayName": "Text Davinci 003",
+    "deprecated": true
   },
   "claude-instant-1.2": {
     "format": "anthropic",
@@ -6339,19 +6623,6 @@
     "input_cost_per_mil_tokens": 0.18,
     "output_cost_per_mil_tokens": 0.18,
     "displayName": "DeepSeek R1 Distill Qwen 1.5B"
-  },
-  "publishers/qwen/models/qwen3-235b-a22b-instruct-2507-maas": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.22,
-    "output_cost_per_mil_tokens": 0.88,
-    "displayName": "Qwen3 235B A22B Instruct 2507",
-    "locations": [
-      "global",
-      "us-south1"
-    ],
-    "max_input_tokens": 262144,
-    "max_output_tokens": 16384
   },
   "Qwen/Qwen2.5-Coder-32B-Instruct": {
     "format": "openai",
@@ -6609,277 +6880,6 @@
     "deprecation_date": "2026-05-15",
     "max_input_tokens": 2000000,
     "max_output_tokens": 2000000
-  },
-  "publishers/google/models/gemini-1.0-pro-vision": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 1.0 Pro Vision"
-  },
-  "publishers/google/models/gemini-1.0-pro-vision-001": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "parent": "publishers/google/models/gemini-1.0-pro-vision"
-  },
-  "publishers/google/models/gemini-1.0-pro-002": {
-    "format": "google",
-    "flavor": "chat",
-    "parent": "publishers/google/models/gemini-1.0-pro"
-  },
-  "publishers/google/models/gemini-1.0-pro-001": {
-    "format": "google",
-    "flavor": "chat",
-    "parent": "publishers/google/models/gemini-1.0-pro"
-  },
-  "publishers/anthropic/models/claude-sonnet-4-5@20250929": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": true,
-    "parent": "publishers/anthropic/models/claude-sonnet-4-5"
-  },
-  "publishers/anthropic/models/claude-sonnet-4": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "displayName": "Claude Sonnet 4",
-    "reasoning": true,
-    "reasoning_budget": true
-  },
-  "publishers/anthropic/models/claude-sonnet-4@20250514": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": true,
-    "parent": "publishers/anthropic/models/claude-sonnet-4"
-  },
-  "publishers/anthropic/models/claude-3-7-sonnet": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "displayName": "Claude Sonnet 3.7",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "deprecation_date": "2026-02-19"
-  },
-  "publishers/anthropic/models/claude-3-7-sonnet@20250219": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": true,
-    "deprecation_date": "2026-02-19",
-    "parent": "publishers/anthropic/models/claude-3-7-sonnet"
-  },
-  "publishers/anthropic/models/claude-haiku-4-5@20251001": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 5,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "input_cache_write_cost_per_mil_tokens": 1.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 1.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 2,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "publishers/anthropic/models/claude-haiku-4-5",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000
-  },
-  "publishers/anthropic/models/claude-3-5-haiku": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.8,
-    "output_cost_per_mil_tokens": 4,
-    "input_cache_read_cost_per_mil_tokens": 0.08,
-    "input_cache_write_cost_per_mil_tokens": 1,
-    "input_cache_write_5m_cost_per_mil_tokens": 1,
-    "input_cache_write_1h_cost_per_mil_tokens": 1.6,
-    "displayName": "Claude Haiku 3.5",
-    "deprecation_date": "2026-02-19",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 8192
-  },
-  "publishers/anthropic/models/claude-3-5-haiku@20241022": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.8,
-    "output_cost_per_mil_tokens": 4,
-    "input_cache_read_cost_per_mil_tokens": 0.08,
-    "input_cache_write_cost_per_mil_tokens": 1,
-    "input_cache_write_5m_cost_per_mil_tokens": 1,
-    "input_cache_write_1h_cost_per_mil_tokens": 1.6,
-    "deprecation_date": "2026-02-19",
-    "parent": "publishers/anthropic/models/claude-3-5-haiku",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 8192
-  },
-  "publishers/anthropic/models/claude-3-5-sonnet-v2": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "displayName": "Claude Sonnet 3.5 v2"
-  },
-  "publishers/anthropic/models/claude-3-5-sonnet-v2@20241022": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "parent": "publishers/anthropic/models/claude-3-5-sonnet-v2"
-  },
-  "publishers/anthropic/models/claude-3-5-sonnet": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "displayName": "Claude Sonnet 3.5"
-  },
-  "publishers/anthropic/models/claude-3-5-sonnet@20240620": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "parent": "publishers/anthropic/models/claude-3-5-sonnet"
-  },
-  "publishers/anthropic/models/claude-3-opus": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 15,
-    "output_cost_per_mil_tokens": 75,
-    "input_cache_read_cost_per_mil_tokens": 1.5,
-    "input_cache_write_cost_per_mil_tokens": 18.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 18.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 30,
-    "displayName": "Claude Opus 3"
-  },
-  "publishers/anthropic/models/claude-3-opus@20240229": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 15,
-    "output_cost_per_mil_tokens": 75,
-    "input_cache_read_cost_per_mil_tokens": 1.5,
-    "input_cache_write_cost_per_mil_tokens": 18.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 18.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 30,
-    "parent": "publishers/anthropic/models/claude-3-opus"
-  },
-  "publishers/anthropic/models/claude-3-haiku": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 1.25,
-    "input_cache_read_cost_per_mil_tokens": 0.03,
-    "input_cache_write_cost_per_mil_tokens": 0.3,
-    "input_cache_write_5m_cost_per_mil_tokens": 0.3,
-    "input_cache_write_1h_cost_per_mil_tokens": 0.5,
-    "displayName": "Claude Haiku 3"
-  },
-  "publishers/anthropic/models/claude-3-haiku@20240307": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 1.25,
-    "input_cache_read_cost_per_mil_tokens": 0.03,
-    "input_cache_write_cost_per_mil_tokens": 0.3,
-    "input_cache_write_5m_cost_per_mil_tokens": 0.3,
-    "input_cache_write_1h_cost_per_mil_tokens": 0.5,
-    "parent": "publishers/anthropic/models/claude-3-haiku"
-  },
-  "publishers/meta/models/llama-3.1-401b-instruct-maas": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 16,
-    "displayName": "Llama 3.1 401B Instruct"
-  },
-  "publishers/mistralai/models/mistral-nemo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.15,
-    "displayName": "Mistral Nemo"
-  },
-  "publishers/meta/models/llama-3.3-70b-instruct-maas": {
-    "format": "openai",
-    "flavor": "chat",
-    "displayName": "Llama 3.3 70B Instruct",
-    "experimental": true
-  },
-  "publishers/meta/models/llama-3.2-90b-vision-instruct-maas": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Llama 3.2 90B Vision Instruct",
-    "experimental": true
-  },
-  "publishers/meta/models/llama-3.1-70b-instruct-maas": {
-    "format": "openai",
-    "flavor": "chat",
-    "displayName": "Llama 3.1 70B Instruct",
-    "experimental": true
-  },
-  "publishers/meta/models/llama-3.1-8b-instruct-maas": {
-    "format": "openai",
-    "flavor": "chat",
-    "displayName": "Llama 3.1 8B Instruct",
-    "experimental": true
-  },
-  "publishers/google/models/gemini-2.0-flash-lite-preview-02-05": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.075,
-    "output_cost_per_mil_tokens": 0.3,
-    "displayName": "Gemini 2.0 Flash-Lite",
-    "deprecated": true
   },
   "text-block": {
     "format": "js",

--- a/packages/proxy/schema/model_list.json
+++ b/packages/proxy/schema/model_list.json
@@ -17,300 +17,6 @@
       "azure"
     ]
   },
-  "o4-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.1,
-    "output_cost_per_mil_tokens": 4.4,
-    "input_cache_read_cost_per_mil_tokens": 0.275,
-    "displayName": "o4-mini",
-    "reasoning": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o4-mini-2025-04-16": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.1,
-    "output_cost_per_mil_tokens": 4.4,
-    "input_cache_read_cost_per_mil_tokens": 0.275,
-    "displayName": "o4-mini (2025-04-16)",
-    "reasoning": true,
-    "deprecation_date": "2026-10-23",
-    "parent": "o4-mini",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-audio-2025-08-28": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "GPT Audio (2025-08-28)",
-    "parent": "gpt-audio",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-audio": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "GPT Audio",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-realtime-2025-08-28": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 4,
-    "output_cost_per_mil_tokens": 16,
-    "input_cache_read_cost_per_mil_tokens": 0.4,
-    "displayName": "GPT Realtime (2025-08-28)",
-    "parent": "gpt-realtime",
-    "max_input_tokens": 32000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-realtime": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 4,
-    "output_cost_per_mil_tokens": 16,
-    "input_cache_read_cost_per_mil_tokens": 0.4,
-    "displayName": "GPT Realtime",
-    "max_input_tokens": 32000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-image-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "displayName": "GPT Image 2",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-image-2-2026-04-21": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "displayName": "GPT Image 2 (2026-04-21)",
-    "parent": "gpt-image-2",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "chatgpt-image-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 5,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "dall-e-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "hd/1024-x-1024/dall-e-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "hd/1024-x-1792/dall-e-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "hd/1792-x-1024/dall-e-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "standard/1024-x-1024/dall-e-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "standard/1024-x-1792/dall-e-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "standard/1792-x-1024/dall-e-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "openai/sora-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "sora-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "tts-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "whisper-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "omni-moderation-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "text-moderation-007": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "babbage-002": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.4,
-    "output_cost_per_mil_tokens": 0.4,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "davinci-002": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "ft:gpt-4.1-2025-04-14": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 12,
-    "input_cache_read_cost_per_mil_tokens": 0.75,
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "openai/container": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "chat-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 30,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "displayName": "GPT Chat Latest",
-    "reasoning": true,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
   "gpt-5.6-luna": {
     "format": "openai",
     "flavor": "chat",
@@ -323,6 +29,1329 @@
     "reasoning": true,
     "max_input_tokens": 1050000,
     "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.6-sol": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 30,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "displayName": "GPT-5.6 Sol",
+    "reasoning": true,
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.6-terra": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.25,
+    "input_cache_write_cost_per_mil_tokens": 3.125,
+    "displayName": "GPT-5.6 Terra",
+    "reasoning": true,
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 30,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "GPT-5.5",
+    "reasoning": true,
+    "fallback_models": [
+      "openai.gpt-5.5"
+    ],
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.5-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 30,
+    "output_cost_per_mil_tokens": 180,
+    "input_cache_read_cost_per_mil_tokens": 3,
+    "displayName": "GPT-5.5 Pro",
+    "reasoning": true,
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.5-2026-04-23": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 30,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "GPT-5.5 (2026-04-23)",
+    "reasoning": true,
+    "parent": "gpt-5.5",
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.5-pro-2026-04-23": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 30,
+    "output_cost_per_mil_tokens": 180,
+    "input_cache_read_cost_per_mil_tokens": 3,
+    "displayName": "GPT-5.5 Pro (2026-04-23)",
+    "reasoning": true,
+    "parent": "gpt-5.5-pro",
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.4": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.25,
+    "displayName": "GPT-5.4",
+    "reasoning": true,
+    "fallback_models": [
+      "openai.gpt-5.4"
+    ],
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.4-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.75,
+    "output_cost_per_mil_tokens": 4.5,
+    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "displayName": "GPT-5.4 mini",
+    "reasoning": true,
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.4-nano": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 1.25,
+    "input_cache_read_cost_per_mil_tokens": 0.02,
+    "displayName": "GPT-5.4 nano",
+    "reasoning": true,
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.4-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 30,
+    "output_cost_per_mil_tokens": 180,
+    "input_cache_read_cost_per_mil_tokens": 3,
+    "displayName": "GPT-5.4 Pro",
+    "reasoning": true,
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.4-mini-2026-03-17": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.75,
+    "output_cost_per_mil_tokens": 4.5,
+    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "displayName": "GPT-5.4 mini (2026-03-17)",
+    "reasoning": true,
+    "parent": "gpt-5.4-mini",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.4-nano-2026-03-17": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 1.25,
+    "input_cache_read_cost_per_mil_tokens": 0.02,
+    "displayName": "GPT-5.4 nano (2026-03-17)",
+    "reasoning": true,
+    "parent": "gpt-5.4-nano",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.4-2026-03-05": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.25,
+    "displayName": "GPT-5.4 (2026-03-05)",
+    "reasoning": true,
+    "parent": "gpt-5.4",
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.4-pro-2026-03-05": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 30,
+    "output_cost_per_mil_tokens": 180,
+    "input_cache_read_cost_per_mil_tokens": 3,
+    "displayName": "GPT-5.4 Pro (2026-03-05)",
+    "reasoning": true,
+    "parent": "gpt-5.4-pro",
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.3-chat-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.75,
+    "output_cost_per_mil_tokens": 14,
+    "input_cache_read_cost_per_mil_tokens": 0.175,
+    "displayName": "GPT-5.3 chat",
+    "reasoning": true,
+    "deprecation_date": "2026-08-10",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.3-codex": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.75,
+    "output_cost_per_mil_tokens": 14,
+    "input_cache_read_cost_per_mil_tokens": 0.175,
+    "displayName": "GPT-5.3 Codex",
+    "reasoning": true,
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.2": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.75,
+    "output_cost_per_mil_tokens": 14,
+    "input_cache_read_cost_per_mil_tokens": 0.175,
+    "displayName": "GPT-5.2",
+    "reasoning": true,
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.2-chat-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.75,
+    "output_cost_per_mil_tokens": 14,
+    "input_cache_read_cost_per_mil_tokens": 0.175,
+    "displayName": "GPT-5.2 chat",
+    "reasoning": true,
+    "deprecation_date": "2026-08-10",
+    "parent": "gpt-5.2",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.2-codex": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.75,
+    "output_cost_per_mil_tokens": 14,
+    "input_cache_read_cost_per_mil_tokens": 0.175,
+    "displayName": "GPT-5.2 Codex",
+    "reasoning": true,
+    "deprecation_date": "2026-07-23",
+    "parent": "gpt-5.2",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.2-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 21,
+    "output_cost_per_mil_tokens": 168,
+    "displayName": "GPT-5.2 Pro",
+    "reasoning": true,
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.2-2025-12-11": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.75,
+    "output_cost_per_mil_tokens": 14,
+    "input_cache_read_cost_per_mil_tokens": 0.175,
+    "displayName": "GPT-5.2 (2025-12-11)",
+    "reasoning": true,
+    "parent": "gpt-5.2",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.2-pro-2025-12-11": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 21,
+    "output_cost_per_mil_tokens": 168,
+    "displayName": "GPT-5.2 Pro (2025-12-11)",
+    "reasoning": true,
+    "parent": "gpt-5.2-pro",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.1": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "GPT-5.1",
+    "reasoning": true,
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.1-chat-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "GPT-5.1 chat",
+    "reasoning": true,
+    "deprecation_date": "2026-07-23",
+    "parent": "gpt-5.1",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.1-codex": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "GPT-5.1 Codex",
+    "reasoning": true,
+    "deprecation_date": "2026-07-23",
+    "parent": "gpt-5.1",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.1-codex-max": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "reasoning": true,
+    "deprecation_date": "2026-07-23",
+    "parent": "gpt-5.1",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.1-codex-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 2,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "displayName": "GPT-5.1 Codex Mini",
+    "reasoning": true,
+    "deprecation_date": "2026-07-23",
+    "parent": "gpt-5.1",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5.1-2025-11-13": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "GPT-5.1 (2025-11-13)",
+    "reasoning": true,
+    "parent": "gpt-5.1",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "GPT-5",
+    "reasoning": true,
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-chat-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "GPT-5 chat",
+    "reasoning": true,
+    "deprecation_date": "2026-07-23",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-codex": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "GPT-5 Codex",
+    "reasoning": true,
+    "deprecation_date": "2026-07-23",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 2,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "displayName": "GPT-5 mini",
+    "reasoning": true,
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-nano": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.05,
+    "output_cost_per_mil_tokens": 0.4,
+    "input_cache_read_cost_per_mil_tokens": 0.005,
+    "displayName": "GPT-5 nano",
+    "reasoning": true,
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 15,
+    "output_cost_per_mil_tokens": 120,
+    "displayName": "GPT-5 Pro",
+    "reasoning": true,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 272000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-search-api": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "GPT-5 Search API",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-search-api-2025-10-14": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "GPT-5 Search API (2025-10-14)",
+    "parent": "gpt-5-search-api",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-pro-2025-10-06": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 15,
+    "output_cost_per_mil_tokens": 120,
+    "displayName": "GPT-5 Pro (2025-10-06)",
+    "reasoning": true,
+    "parent": "gpt-5-pro",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 272000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-2025-08-07": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 0.125,
+    "displayName": "GPT-5 (2025-08-07)",
+    "reasoning": true,
+    "deprecation_date": "2026-12-11",
+    "parent": "gpt-5",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-mini-2025-08-07": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.25,
+    "output_cost_per_mil_tokens": 2,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "displayName": "GPT-5 mini (2025-08-07)",
+    "reasoning": true,
+    "deprecation_date": "2026-12-11",
+    "parent": "gpt-5-mini",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-5-nano-2025-08-07": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.05,
+    "output_cost_per_mil_tokens": 0.4,
+    "input_cache_read_cost_per_mil_tokens": 0.005,
+    "displayName": "GPT-5 nano (2025-08-07)",
+    "reasoning": true,
+    "parent": "gpt-5-nano",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4.1": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 8,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "GPT-4.1",
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4.1-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.4,
+    "output_cost_per_mil_tokens": 1.6,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "displayName": "GPT-4.1 mini",
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4.1-nano": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "displayName": "GPT-4.1 nano",
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4.1-2025-04-14": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 8,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "GPT-4.1 (2025-04-14)",
+    "parent": "gpt-4.1",
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4.1-mini-2025-04-14": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.4,
+    "output_cost_per_mil_tokens": 1.6,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "displayName": "GPT-4.1 mini (2025-04-14)",
+    "parent": "gpt-4.1-mini",
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4.1-nano-2025-04-14": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "input_cache_read_cost_per_mil_tokens": 0.025,
+    "displayName": "GPT-4.1 nano (2025-04-14)",
+    "parent": "gpt-4.1-nano",
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 30,
+    "output_cost_per_mil_tokens": 60,
+    "displayName": "GPT-4",
+    "max_input_tokens": 8192,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4-turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 10,
+    "output_cost_per_mil_tokens": 30,
+    "displayName": "GPT-4 Turbo",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "displayName": "GPT-4o",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-audio-preview": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "GPT-4o Audio Preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "displayName": "GPT-4o mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-audio-preview": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "GPT-4o mini Audio Preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-realtime-preview": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "displayName": "GPT-4o mini Realtime Preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-search-preview": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "displayName": "GPT-4o mini Search Preview",
+    "experimental": true,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-transcribe": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 5,
+    "displayName": "GPT-4o mini Transcribe",
+    "max_input_tokens": 16000,
+    "max_output_tokens": 2000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-tts": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "GPT-4o mini TTS",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-realtime-preview": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 20,
+    "input_cache_read_cost_per_mil_tokens": 2.5,
+    "displayName": "GPT-4o Realtime Preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-search-preview": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "displayName": "GPT-4o Search Preview",
+    "experimental": true,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-transcribe": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "max_input_tokens": 16000,
+    "max_output_tokens": 2000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-transcribe-diarize": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "max_input_tokens": 16000,
+    "max_output_tokens": 2000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-transcribe-2025-12-15": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 5,
+    "displayName": "GPT-4o mini Transcribe (2025-12-15)",
+    "parent": "gpt-4o-mini-transcribe",
+    "max_input_tokens": 16000,
+    "max_output_tokens": 2000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-tts-2025-12-15": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "GPT-4o mini TTS (2025-12-15)",
+    "parent": "gpt-4o-mini-tts",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-audio-preview-2025-06-03": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "GPT-4o Audio Preview (2025-06-03)",
+    "parent": "gpt-4o-audio-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-realtime-preview-2025-06-03": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 20,
+    "input_cache_read_cost_per_mil_tokens": 2.5,
+    "displayName": "GPT-4o Realtime Preview (2025-06-03)",
+    "parent": "gpt-4o-realtime-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-transcribe-2025-03-20": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 5,
+    "displayName": "GPT-4o mini Transcribe (2025-03-20)",
+    "parent": "gpt-4o-mini-transcribe",
+    "max_input_tokens": 16000,
+    "max_output_tokens": 2000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-tts-2025-03-20": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "GPT-4o mini TTS (2025-03-20)",
+    "parent": "gpt-4o-mini-tts",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-search-preview-2025-03-11": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "displayName": "GPT-4o mini Search Preview (2025-03-11)",
+    "experimental": true,
+    "parent": "gpt-4o-mini-search-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-search-preview-2025-03-11": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "displayName": "GPT-4o Search Preview (2025-03-11)",
+    "experimental": true,
+    "parent": "gpt-4o-search-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-audio-preview-2024-12-17": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "GPT-4o Audio Preview (2024-12-17)",
+    "parent": "gpt-4o-audio-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-audio-preview-2024-12-17": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "GPT-4o mini Audio Preview (2024-12-17)",
+    "parent": "gpt-4o-mini-audio-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-realtime-preview-2024-12-17": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "displayName": "GPT-4o mini Realtime Preview (2024-12-17)",
+    "parent": "gpt-4o-mini-realtime-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-realtime-preview-2024-12-17": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 20,
+    "input_cache_read_cost_per_mil_tokens": 2.5,
+    "displayName": "GPT-4o Realtime Preview (2024-12-17)",
+    "parent": "gpt-4o-realtime-preview",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-2024-11-20": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "displayName": "GPT-4o (2024-11-20)",
+    "parent": "gpt-4o",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-2024-08-06": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "displayName": "GPT-4o (2024-08-06)",
+    "parent": "gpt-4o",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-mini-2024-07-18": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "displayName": "GPT-4o mini (2024-07-18)",
+    "parent": "gpt-4o-mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4o-2024-05-13": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 15,
+    "displayName": "GPT-4o (2024-05-13)",
+    "deprecation_date": "2026-10-23",
+    "parent": "gpt-4o",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4-turbo-2024-04-09": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 10,
+    "output_cost_per_mil_tokens": 30,
+    "displayName": "GPT-4 Turbo (2024-04-09)",
+    "parent": "gpt-4-turbo",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-4-0613": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 30,
+    "output_cost_per_mil_tokens": 60,
+    "deprecation_date": "2025-06-06",
+    "parent": "gpt-4",
+    "max_input_tokens": 8192,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-3.5-turbo-16k": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 4,
+    "displayName": "GPT 3.5T 16k",
+    "deprecated": true,
+    "max_input_tokens": 16385,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-3.5-turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 1.5,
+    "displayName": "GPT 3.5T",
+    "deprecated": true,
+    "max_input_tokens": 16385,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-3.5-turbo-instruct": {
+    "format": "openai",
+    "flavor": "completion",
+    "input_cost_per_mil_tokens": 1.5,
+    "output_cost_per_mil_tokens": 2,
+    "displayName": "GPT 3.5T Instruct",
+    "deprecated": true,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-3.5-turbo-1106": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 2,
+    "displayName": "GPT 3.5T 1106",
+    "deprecated": true,
+    "deprecation_date": "2026-09-28",
+    "max_input_tokens": 16385,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-3.5-turbo-instruct-0914": {
+    "format": "openai",
+    "flavor": "completion",
+    "input_cost_per_mil_tokens": 1.5,
+    "output_cost_per_mil_tokens": 2,
+    "displayName": "GPT 3.5T Instruct 0914",
+    "deprecated": true,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 4097,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-3.5-turbo-0125": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 1.5,
+    "displayName": "GPT 3.5T 0125",
+    "deprecated": true,
+    "max_input_tokens": 16385,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o4-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.1,
+    "output_cost_per_mil_tokens": 4.4,
+    "input_cache_read_cost_per_mil_tokens": 0.275,
+    "displayName": "o4-mini",
+    "reasoning": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
     "available_providers": [
       "openai",
       "azure"
@@ -360,6 +1389,233 @@
       "azure"
     ]
   },
+  "o4-mini-2025-04-16": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.1,
+    "output_cost_per_mil_tokens": 4.4,
+    "input_cache_read_cost_per_mil_tokens": 0.275,
+    "displayName": "o4-mini (2025-04-16)",
+    "reasoning": true,
+    "deprecation_date": "2026-10-23",
+    "parent": "o4-mini",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o3": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 8,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "o3",
+    "reasoning": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o3-deep-research": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 10,
+    "output_cost_per_mil_tokens": 40,
+    "input_cache_read_cost_per_mil_tokens": 2.5,
+    "displayName": "o3 Deep Research",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o3-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.1,
+    "output_cost_per_mil_tokens": 4.4,
+    "input_cache_read_cost_per_mil_tokens": 0.55,
+    "displayName": "o3 mini",
+    "reasoning": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o3-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 20,
+    "output_cost_per_mil_tokens": 80,
+    "displayName": "o3 Pro",
+    "reasoning": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o3-deep-research-2025-06-26": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 10,
+    "output_cost_per_mil_tokens": 40,
+    "input_cache_read_cost_per_mil_tokens": 2.5,
+    "displayName": "o3 Deep Research (2025-06-26)",
+    "deprecation_date": "2026-07-23",
+    "parent": "o3-deep-research",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o3-pro-2025-06-10": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 20,
+    "output_cost_per_mil_tokens": 80,
+    "displayName": "o3 Pro (2025-06-10)",
+    "reasoning": true,
+    "parent": "o3-pro",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o3-2025-04-16": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 8,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "o3 (2025-04-16)",
+    "reasoning": true,
+    "deprecation_date": "2026-12-11",
+    "parent": "o3",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o3-mini-2025-01-31": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.1,
+    "output_cost_per_mil_tokens": 4.4,
+    "input_cache_read_cost_per_mil_tokens": 0.55,
+    "displayName": "o3 mini (2025-01-31)",
+    "reasoning": true,
+    "parent": "o3-mini",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o1": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 15,
+    "output_cost_per_mil_tokens": 60,
+    "input_cache_read_cost_per_mil_tokens": 7.5,
+    "displayName": "o1",
+    "reasoning": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o1-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 150,
+    "output_cost_per_mil_tokens": 600,
+    "displayName": "o1 Pro",
+    "reasoning": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o1-pro-2025-03-19": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 150,
+    "output_cost_per_mil_tokens": 600,
+    "displayName": "o1 Pro (2025-03-19)",
+    "reasoning": true,
+    "parent": "o1-pro",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "o1-2024-12-17": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 15,
+    "output_cost_per_mil_tokens": 60,
+    "input_cache_read_cost_per_mil_tokens": 7.5,
+    "displayName": "o1 (2024-12-17)",
+    "reasoning": true,
+    "deprecation_date": "2026-10-23",
+    "parent": "o1",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-audio-2025-08-28": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "GPT Audio (2025-08-28)",
+    "parent": "gpt-audio",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
   "gpt-audio-1.5": {
     "format": "openai",
     "flavor": "chat",
@@ -367,6 +1623,75 @@
     "output_cost_per_mil_tokens": 10,
     "max_input_tokens": 128000,
     "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-audio": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.5,
+    "output_cost_per_mil_tokens": 10,
+    "displayName": "GPT Audio",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-audio-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "displayName": "GPT Audio mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-audio-mini-2025-12-15": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "displayName": "GPT Audio mini (2025-12-15)",
+    "parent": "gpt-audio-mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-audio-mini-2025-10-06": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "displayName": "GPT Audio mini (2025-10-06)",
+    "parent": "gpt-audio-mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-realtime-2025-08-28": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 4,
+    "output_cost_per_mil_tokens": 16,
+    "input_cache_read_cost_per_mil_tokens": 0.4,
+    "displayName": "GPT Realtime (2025-08-28)",
+    "parent": "gpt-realtime",
+    "max_input_tokens": 32000,
+    "max_output_tokens": 4096,
     "available_providers": [
       "openai",
       "azure"
@@ -381,6 +1706,103 @@
     "displayName": "GPT Realtime 2",
     "max_input_tokens": 32000,
     "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-realtime-1.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 4,
+    "output_cost_per_mil_tokens": 16,
+    "input_cache_read_cost_per_mil_tokens": 0.4,
+    "max_input_tokens": 32000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-realtime": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 4,
+    "output_cost_per_mil_tokens": 16,
+    "input_cache_read_cost_per_mil_tokens": 0.4,
+    "displayName": "GPT Realtime",
+    "max_input_tokens": 32000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-realtime-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "displayName": "GPT Realtime mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-realtime-mini-2025-12-15": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "input_cache_read_cost_per_mil_tokens": 0.06,
+    "displayName": "GPT Realtime mini (2025-12-15)",
+    "parent": "gpt-realtime-mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-realtime-mini-2025-10-06": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.4,
+    "input_cache_read_cost_per_mil_tokens": 0.06,
+    "displayName": "GPT Realtime mini (2025-10-06)",
+    "parent": "gpt-realtime-mini",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-image-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "displayName": "GPT Image 2",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-image-2-2026-04-21": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 10,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "displayName": "GPT Image 2 (2026-04-21)",
+    "parent": "gpt-image-2",
     "available_providers": [
       "openai",
       "azure"
@@ -728,203 +2150,21 @@
       "azure"
     ]
   },
-  "1024-x-1024/dall-e-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "256-x-256/dall-e-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "512-x-512/dall-e-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "dall-e-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "openai/sora-2-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "sora-2-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "tts-1-hd": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "omni-moderation-2024-09-26": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "text-moderation-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "ft:gpt-4.1-mini-2025-04-14": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.8,
-    "output_cost_per_mil_tokens": 3.2,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.6-sol": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 30,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "displayName": "GPT-5.6 Sol",
-    "reasoning": true,
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o3": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 8,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "displayName": "o3",
-    "reasoning": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o3-2025-04-16": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 8,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "displayName": "o3 (2025-04-16)",
-    "reasoning": true,
-    "deprecation_date": "2026-12-11",
-    "parent": "o3",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-audio-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "displayName": "GPT Audio mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-audio-mini-2025-12-15": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "displayName": "GPT Audio mini (2025-12-15)",
-    "parent": "gpt-audio-mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-audio-mini-2025-10-06": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "displayName": "GPT Audio mini (2025-10-06)",
-    "parent": "gpt-audio-mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-realtime-1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 4,
-    "output_cost_per_mil_tokens": 16,
-    "input_cache_read_cost_per_mil_tokens": 0.4,
-    "max_input_tokens": 32000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
   "gpt-image-1": {
     "format": "openai",
     "flavor": "chat",
     "input_cost_per_mil_tokens": 5,
     "input_cache_read_cost_per_mil_tokens": 1.25,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "gpt-image-1-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
     "available_providers": [
       "openai",
       "azure"
@@ -962,7 +2202,23 @@
       "azure"
     ]
   },
+  "low/1024-x-1024/gpt-image-1-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
   "low/1024-x-1536/gpt-image-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "low/1024-x-1536/gpt-image-1-mini": {
     "format": "openai",
     "flavor": "chat",
     "available_providers": [
@@ -978,7 +2234,23 @@
       "azure"
     ]
   },
+  "low/1536-x-1024/gpt-image-1-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
   "medium/1024-x-1024/gpt-image-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "medium/1024-x-1024/gpt-image-1-mini": {
     "format": "openai",
     "flavor": "chat",
     "available_providers": [
@@ -994,7 +2266,137 @@
       "azure"
     ]
   },
+  "medium/1024-x-1536/gpt-image-1-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
   "medium/1536-x-1024/gpt-image-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "medium/1536-x-1024/gpt-image-1-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "chatgpt-image-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 5,
+    "input_cache_read_cost_per_mil_tokens": 1.25,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "dall-e-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "hd/1024-x-1024/dall-e-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "hd/1024-x-1792/dall-e-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "hd/1792-x-1024/dall-e-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "standard/1024-x-1024/dall-e-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "standard/1024-x-1792/dall-e-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "standard/1792-x-1024/dall-e-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "1024-x-1024/dall-e-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "256-x-256/dall-e-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "512-x-512/dall-e-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "dall-e-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "openai/sora-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "openai/sora-2-pro": {
     "format": "openai",
     "flavor": "chat",
     "available_providers": [
@@ -1010,7 +2412,39 @@
       "azure"
     ]
   },
+  "sora-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "sora-2-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
   "sora-2-pro-high-res": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "tts-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "tts-1-hd": {
     "format": "openai",
     "flavor": "chat",
     "available_providers": [
@@ -1026,10 +2460,112 @@
       "azure"
     ]
   },
+  "tts-1-hd-1106": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "whisper-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "omni-moderation-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "omni-moderation-2024-09-26": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "text-moderation-007": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "text-moderation-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
   "text-moderation-stable": {
     "format": "openai",
     "flavor": "chat",
     "max_input_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "babbage-002": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.4,
+    "output_cost_per_mil_tokens": 0.4,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "davinci-002": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "ft:gpt-4.1-2025-04-14": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 12,
+    "input_cache_read_cost_per_mil_tokens": 0.75,
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "ft:gpt-4.1-mini-2025-04-14": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.8,
+    "output_cost_per_mil_tokens": 3.2,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
     "available_providers": [
       "openai",
       "azure"
@@ -1048,164 +2584,6 @@
       "azure"
     ]
   },
-  "gpt-5.6-terra": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.25,
-    "input_cache_write_cost_per_mil_tokens": 3.125,
-    "displayName": "GPT-5.6 Terra",
-    "reasoning": true,
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o3-deep-research": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 10,
-    "output_cost_per_mil_tokens": 40,
-    "input_cache_read_cost_per_mil_tokens": 2.5,
-    "displayName": "o3 Deep Research",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o3-deep-research-2025-06-26": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 10,
-    "output_cost_per_mil_tokens": 40,
-    "input_cache_read_cost_per_mil_tokens": 2.5,
-    "displayName": "o3 Deep Research (2025-06-26)",
-    "deprecation_date": "2026-07-23",
-    "parent": "o3-deep-research",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-realtime-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "displayName": "GPT Realtime mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-realtime-mini-2025-12-15": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "input_cache_read_cost_per_mil_tokens": 0.06,
-    "displayName": "GPT Realtime mini (2025-12-15)",
-    "parent": "gpt-realtime-mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-realtime-mini-2025-10-06": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "input_cache_read_cost_per_mil_tokens": 0.06,
-    "displayName": "GPT Realtime mini (2025-10-06)",
-    "parent": "gpt-realtime-mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-image-1-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "low/1024-x-1024/gpt-image-1-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "low/1024-x-1536/gpt-image-1-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "low/1536-x-1024/gpt-image-1-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "medium/1024-x-1024/gpt-image-1-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "medium/1024-x-1536/gpt-image-1-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "medium/1536-x-1024/gpt-image-1-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "tts-1-hd-1106": {
-    "format": "openai",
-    "flavor": "chat",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
   "ft:o4-mini-2025-04-16": {
     "format": "openai",
     "flavor": "chat",
@@ -1213,75 +2591,6 @@
     "output_cost_per_mil_tokens": 16,
     "input_cache_read_cost_per_mil_tokens": 1,
     "reasoning": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 30,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "displayName": "GPT-5.5",
-    "reasoning": true,
-    "fallback_models": [
-      "openai.gpt-5.5"
-    ],
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.5-2026-04-23": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 30,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "displayName": "GPT-5.5 (2026-04-23)",
-    "reasoning": true,
-    "parent": "gpt-5.5",
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o3-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.1,
-    "output_cost_per_mil_tokens": 4.4,
-    "input_cache_read_cost_per_mil_tokens": 0.55,
-    "displayName": "o3 mini",
-    "reasoning": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o3-mini-2025-01-31": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.1,
-    "output_cost_per_mil_tokens": 4.4,
-    "input_cache_read_cost_per_mil_tokens": 0.55,
-    "displayName": "o3 mini (2025-01-31)",
-    "reasoning": true,
-    "parent": "o3-mini",
     "max_input_tokens": 200000,
     "max_output_tokens": 100000,
     "available_providers": [
@@ -1316,70 +2625,6 @@
       "azure"
     ]
   },
-  "gpt-5.5-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 30,
-    "output_cost_per_mil_tokens": 180,
-    "input_cache_read_cost_per_mil_tokens": 3,
-    "displayName": "GPT-5.5 Pro",
-    "reasoning": true,
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.5-pro-2026-04-23": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 30,
-    "output_cost_per_mil_tokens": 180,
-    "input_cache_read_cost_per_mil_tokens": 3,
-    "displayName": "GPT-5.5 Pro (2026-04-23)",
-    "reasoning": true,
-    "parent": "gpt-5.5-pro",
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o3-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 20,
-    "output_cost_per_mil_tokens": 80,
-    "displayName": "o3 Pro",
-    "reasoning": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o3-pro-2025-06-10": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 20,
-    "output_cost_per_mil_tokens": 80,
-    "displayName": "o3 Pro (2025-06-10)",
-    "reasoning": true,
-    "parent": "o3-pro",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
   "ft:gpt-4o-mini-2024-07-18": {
     "format": "openai",
     "flavor": "chat",
@@ -1388,76 +2633,6 @@
     "input_cache_read_cost_per_mil_tokens": 0.15,
     "max_input_tokens": 128000,
     "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.4": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.25,
-    "displayName": "GPT-5.4",
-    "reasoning": true,
-    "fallback_models": [
-      "openai.gpt-5.4"
-    ],
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.4-2026-03-05": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.25,
-    "displayName": "GPT-5.4 (2026-03-05)",
-    "reasoning": true,
-    "parent": "gpt-5.4",
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o1": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 15,
-    "output_cost_per_mil_tokens": 60,
-    "input_cache_read_cost_per_mil_tokens": 7.5,
-    "displayName": "o1",
-    "reasoning": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o1-2024-12-17": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 15,
-    "output_cost_per_mil_tokens": 60,
-    "input_cache_read_cost_per_mil_tokens": 7.5,
-    "displayName": "o1 (2024-12-17)",
-    "reasoning": true,
-    "deprecation_date": "2026-10-23",
-    "parent": "o1",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
     "available_providers": [
       "openai",
       "azure"
@@ -1475,70 +2650,6 @@
       "azure"
     ]
   },
-  "gpt-5.4-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.75,
-    "output_cost_per_mil_tokens": 4.5,
-    "input_cache_read_cost_per_mil_tokens": 0.075,
-    "displayName": "GPT-5.4 mini",
-    "reasoning": true,
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.4-mini-2026-03-17": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.75,
-    "output_cost_per_mil_tokens": 4.5,
-    "input_cache_read_cost_per_mil_tokens": 0.075,
-    "displayName": "GPT-5.4 mini (2026-03-17)",
-    "reasoning": true,
-    "parent": "gpt-5.4-mini",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o1-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 150,
-    "output_cost_per_mil_tokens": 600,
-    "displayName": "o1 Pro",
-    "reasoning": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "o1-pro-2025-03-19": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 150,
-    "output_cost_per_mil_tokens": 600,
-    "displayName": "o1 Pro (2025-03-19)",
-    "reasoning": true,
-    "parent": "o1-pro",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 100000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
   "ft:gpt-3.5-turbo": {
     "format": "openai",
     "flavor": "chat",
@@ -1546,39 +2657,6 @@
     "output_cost_per_mil_tokens": 6,
     "max_input_tokens": 16385,
     "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.4-nano": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 1.25,
-    "input_cache_read_cost_per_mil_tokens": 0.02,
-    "displayName": "GPT-5.4 nano",
-    "reasoning": true,
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.4-nano-2026-03-17": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 1.25,
-    "input_cache_read_cost_per_mil_tokens": 0.02,
-    "displayName": "GPT-5.4 nano (2026-03-17)",
-    "reasoning": true,
-    "parent": "gpt-5.4-nano",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
     "available_providers": [
       "openai",
       "azure"
@@ -1596,39 +2674,6 @@
       "azure"
     ]
   },
-  "gpt-5.4-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 30,
-    "output_cost_per_mil_tokens": 180,
-    "input_cache_read_cost_per_mil_tokens": 3,
-    "displayName": "GPT-5.4 Pro",
-    "reasoning": true,
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.4-pro-2026-03-05": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 30,
-    "output_cost_per_mil_tokens": 180,
-    "input_cache_read_cost_per_mil_tokens": 3,
-    "displayName": "GPT-5.4 Pro (2026-03-05)",
-    "reasoning": true,
-    "parent": "gpt-5.4-pro",
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
   "ft:gpt-3.5-turbo-0613": {
     "format": "openai",
     "flavor": "chat",
@@ -1636,23 +2681,6 @@
     "output_cost_per_mil_tokens": 6,
     "max_input_tokens": 4096,
     "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.3-chat-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.75,
-    "output_cost_per_mil_tokens": 14,
-    "input_cache_read_cost_per_mil_tokens": 0.175,
-    "displayName": "GPT-5.3 chat",
-    "reasoning": true,
-    "deprecation_date": "2026-08-10",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
     "available_providers": [
       "openai",
       "azure"
@@ -1670,22 +2698,6 @@
       "azure"
     ]
   },
-  "gpt-5.3-codex": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.75,
-    "output_cost_per_mil_tokens": 14,
-    "input_cache_read_cost_per_mil_tokens": 0.175,
-    "displayName": "GPT-5.3 Codex",
-    "reasoning": true,
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
   "ft:babbage-002": {
     "format": "openai",
     "flavor": "chat",
@@ -1693,39 +2705,6 @@
     "output_cost_per_mil_tokens": 1.6,
     "max_input_tokens": 16384,
     "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.2": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.75,
-    "output_cost_per_mil_tokens": 14,
-    "input_cache_read_cost_per_mil_tokens": 0.175,
-    "displayName": "GPT-5.2",
-    "reasoning": true,
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.2-2025-12-11": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.75,
-    "output_cost_per_mil_tokens": 14,
-    "input_cache_read_cost_per_mil_tokens": 0.175,
-    "displayName": "GPT-5.2 (2025-12-11)",
-    "reasoning": true,
-    "parent": "gpt-5.2",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
     "available_providers": [
       "openai",
       "azure"
@@ -1743,1004 +2722,25 @@
       "azure"
     ]
   },
-  "gpt-5.2-chat-latest": {
+  "openai/container": {
     "format": "openai",
     "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.75,
-    "output_cost_per_mil_tokens": 14,
-    "input_cache_read_cost_per_mil_tokens": 0.175,
-    "displayName": "GPT-5.2 chat",
-    "reasoning": true,
-    "deprecation_date": "2026-08-10",
-    "parent": "gpt-5.2",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
     "available_providers": [
       "openai",
       "azure"
     ]
   },
-  "gpt-5.2-codex": {
+  "chat-latest": {
     "format": "openai",
     "flavor": "chat",
     "multimodal": true,
-    "input_cost_per_mil_tokens": 1.75,
-    "output_cost_per_mil_tokens": 14,
-    "input_cache_read_cost_per_mil_tokens": 0.175,
-    "displayName": "GPT-5.2 Codex",
-    "reasoning": true,
-    "deprecation_date": "2026-07-23",
-    "parent": "gpt-5.2",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.2-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 21,
-    "output_cost_per_mil_tokens": 168,
-    "displayName": "GPT-5.2 Pro",
-    "reasoning": true,
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.2-pro-2025-12-11": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 21,
-    "output_cost_per_mil_tokens": 168,
-    "displayName": "GPT-5.2 Pro (2025-12-11)",
-    "reasoning": true,
-    "parent": "gpt-5.2-pro",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.1": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5.1",
-    "reasoning": true,
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.1-2025-11-13": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5.1 (2025-11-13)",
-    "reasoning": true,
-    "parent": "gpt-5.1",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.1-chat-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5.1 chat",
-    "reasoning": true,
-    "deprecation_date": "2026-07-23",
-    "parent": "gpt-5.1",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.1-codex": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5.1 Codex",
-    "reasoning": true,
-    "deprecation_date": "2026-07-23",
-    "parent": "gpt-5.1",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.1-codex-max": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "reasoning": true,
-    "deprecation_date": "2026-07-23",
-    "parent": "gpt-5.1",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5.1-codex-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 2,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "displayName": "GPT-5.1 Codex Mini",
-    "reasoning": true,
-    "deprecation_date": "2026-07-23",
-    "parent": "gpt-5.1",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5",
-    "reasoning": true,
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-2025-08-07": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5 (2025-08-07)",
-    "reasoning": true,
-    "deprecation_date": "2026-12-11",
-    "parent": "gpt-5",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-chat-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5 chat",
-    "reasoning": true,
-    "deprecation_date": "2026-07-23",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-codex": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5 Codex",
-    "reasoning": true,
-    "deprecation_date": "2026-07-23",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 2,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "displayName": "GPT-5 mini",
-    "reasoning": true,
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-mini-2025-08-07": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.25,
-    "output_cost_per_mil_tokens": 2,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "displayName": "GPT-5 mini (2025-08-07)",
-    "reasoning": true,
-    "deprecation_date": "2026-12-11",
-    "parent": "gpt-5-mini",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-nano": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.05,
-    "output_cost_per_mil_tokens": 0.4,
-    "input_cache_read_cost_per_mil_tokens": 0.005,
-    "displayName": "GPT-5 nano",
-    "reasoning": true,
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-nano-2025-08-07": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.05,
-    "output_cost_per_mil_tokens": 0.4,
-    "input_cache_read_cost_per_mil_tokens": 0.005,
-    "displayName": "GPT-5 nano (2025-08-07)",
-    "reasoning": true,
-    "parent": "gpt-5-nano",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 15,
-    "output_cost_per_mil_tokens": 120,
-    "displayName": "GPT-5 Pro",
-    "reasoning": true,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 272000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-pro-2025-10-06": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 15,
-    "output_cost_per_mil_tokens": 120,
-    "displayName": "GPT-5 Pro (2025-10-06)",
-    "reasoning": true,
-    "parent": "gpt-5-pro",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 272000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-search-api": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5 Search API",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-5-search-api-2025-10-14": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 0.125,
-    "displayName": "GPT-5 Search API (2025-10-14)",
-    "parent": "gpt-5-search-api",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4.1": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 8,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "displayName": "GPT-4.1",
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4.1-2025-04-14": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 8,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "displayName": "GPT-4.1 (2025-04-14)",
-    "parent": "gpt-4.1",
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4.1-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.4,
-    "output_cost_per_mil_tokens": 1.6,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "displayName": "GPT-4.1 mini",
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4.1-mini-2025-04-14": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.4,
-    "output_cost_per_mil_tokens": 1.6,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "displayName": "GPT-4.1 mini (2025-04-14)",
-    "parent": "gpt-4.1-mini",
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4.1-nano": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "displayName": "GPT-4.1 nano",
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4.1-nano-2025-04-14": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "input_cache_read_cost_per_mil_tokens": 0.025,
-    "displayName": "GPT-4.1 nano (2025-04-14)",
-    "parent": "gpt-4.1-nano",
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 30,
-    "output_cost_per_mil_tokens": 60,
-    "displayName": "GPT-4",
-    "max_input_tokens": 8192,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4-turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 10,
+    "input_cost_per_mil_tokens": 5,
     "output_cost_per_mil_tokens": 30,
-    "displayName": "GPT-4 Turbo",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4-turbo-2024-04-09": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 10,
-    "output_cost_per_mil_tokens": 30,
-    "displayName": "GPT-4 Turbo (2024-04-09)",
-    "parent": "gpt-4-turbo",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "displayName": "GPT-4o",
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "displayName": "GPT Chat Latest",
+    "reasoning": true,
     "max_input_tokens": 128000,
     "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-2024-11-20": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "displayName": "GPT-4o (2024-11-20)",
-    "parent": "gpt-4o",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-2024-08-06": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "displayName": "GPT-4o (2024-08-06)",
-    "parent": "gpt-4o",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-2024-05-13": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 15,
-    "displayName": "GPT-4o (2024-05-13)",
-    "deprecation_date": "2026-10-23",
-    "parent": "gpt-4o",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-audio-preview": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "GPT-4o Audio Preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-audio-preview-2025-06-03": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "GPT-4o Audio Preview (2025-06-03)",
-    "parent": "gpt-4o-audio-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-audio-preview-2024-12-17": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "GPT-4o Audio Preview (2024-12-17)",
-    "parent": "gpt-4o-audio-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "input_cache_read_cost_per_mil_tokens": 0.075,
-    "displayName": "GPT-4o mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-2024-07-18": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "input_cache_read_cost_per_mil_tokens": 0.075,
-    "displayName": "GPT-4o mini (2024-07-18)",
-    "parent": "gpt-4o-mini",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-audio-preview": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "GPT-4o mini Audio Preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-audio-preview-2024-12-17": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "GPT-4o mini Audio Preview (2024-12-17)",
-    "parent": "gpt-4o-mini-audio-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-realtime-preview": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "displayName": "GPT-4o mini Realtime Preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-realtime-preview-2024-12-17": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.4,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "displayName": "GPT-4o mini Realtime Preview (2024-12-17)",
-    "parent": "gpt-4o-mini-realtime-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-search-preview": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "input_cache_read_cost_per_mil_tokens": 0.075,
-    "displayName": "GPT-4o mini Search Preview",
-    "experimental": true,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-search-preview-2025-03-11": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "input_cache_read_cost_per_mil_tokens": 0.075,
-    "displayName": "GPT-4o mini Search Preview (2025-03-11)",
-    "experimental": true,
-    "parent": "gpt-4o-mini-search-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-transcribe": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 5,
-    "displayName": "GPT-4o mini Transcribe",
-    "max_input_tokens": 16000,
-    "max_output_tokens": 2000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-transcribe-2025-12-15": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 5,
-    "displayName": "GPT-4o mini Transcribe (2025-12-15)",
-    "parent": "gpt-4o-mini-transcribe",
-    "max_input_tokens": 16000,
-    "max_output_tokens": 2000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-transcribe-2025-03-20": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 5,
-    "displayName": "GPT-4o mini Transcribe (2025-03-20)",
-    "parent": "gpt-4o-mini-transcribe",
-    "max_input_tokens": 16000,
-    "max_output_tokens": 2000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-tts": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "GPT-4o mini TTS",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-tts-2025-12-15": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "GPT-4o mini TTS (2025-12-15)",
-    "parent": "gpt-4o-mini-tts",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-mini-tts-2025-03-20": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "displayName": "GPT-4o mini TTS (2025-03-20)",
-    "parent": "gpt-4o-mini-tts",
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-realtime-preview": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 20,
-    "input_cache_read_cost_per_mil_tokens": 2.5,
-    "displayName": "GPT-4o Realtime Preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-realtime-preview-2025-06-03": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 20,
-    "input_cache_read_cost_per_mil_tokens": 2.5,
-    "displayName": "GPT-4o Realtime Preview (2025-06-03)",
-    "parent": "gpt-4o-realtime-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-realtime-preview-2024-12-17": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 20,
-    "input_cache_read_cost_per_mil_tokens": 2.5,
-    "displayName": "GPT-4o Realtime Preview (2024-12-17)",
-    "parent": "gpt-4o-realtime-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-search-preview": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "displayName": "GPT-4o Search Preview",
-    "experimental": true,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-search-preview-2025-03-11": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "input_cache_read_cost_per_mil_tokens": 1.25,
-    "displayName": "GPT-4o Search Preview (2025-03-11)",
-    "experimental": true,
-    "parent": "gpt-4o-search-preview",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-transcribe": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "max_input_tokens": 16000,
-    "max_output_tokens": 2000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4o-transcribe-diarize": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.5,
-    "output_cost_per_mil_tokens": 10,
-    "max_input_tokens": 16000,
-    "max_output_tokens": 2000,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-4-0613": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 30,
-    "output_cost_per_mil_tokens": 60,
-    "deprecation_date": "2025-06-06",
-    "parent": "gpt-4",
-    "max_input_tokens": 8192,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-3.5-turbo-16k": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 4,
-    "displayName": "GPT 3.5T 16k",
-    "deprecated": true,
-    "max_input_tokens": 16385,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-3.5-turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 1.5,
-    "displayName": "GPT 3.5T",
-    "deprecated": true,
-    "max_input_tokens": 16385,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-3.5-turbo-instruct": {
-    "format": "openai",
-    "flavor": "completion",
-    "input_cost_per_mil_tokens": 1.5,
-    "output_cost_per_mil_tokens": 2,
-    "displayName": "GPT 3.5T Instruct",
-    "deprecated": true,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-3.5-turbo-1106": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 2,
-    "displayName": "GPT 3.5T 1106",
-    "deprecated": true,
-    "deprecation_date": "2026-09-28",
-    "max_input_tokens": 16385,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-3.5-turbo-instruct-0914": {
-    "format": "openai",
-    "flavor": "completion",
-    "input_cost_per_mil_tokens": 1.5,
-    "output_cost_per_mil_tokens": 2,
-    "displayName": "GPT 3.5T Instruct 0914",
-    "deprecated": true,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 4097,
-    "available_providers": [
-      "openai",
-      "azure"
-    ]
-  },
-  "gpt-3.5-turbo-0125": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 1.5,
-    "displayName": "GPT 3.5T 0125",
-    "deprecated": true,
-    "max_input_tokens": 16385,
-    "max_output_tokens": 4096,
     "available_providers": [
       "openai",
       "azure"
@@ -2759,778 +2759,6 @@
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/qwen3p7-plus": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.4,
-    "output_cost_per_mil_tokens": 1.6,
-    "input_cache_read_cost_per_mil_tokens": 0.08,
-    "displayName": "Qwen3.7 Plus",
-    "max_input_tokens": 262144,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/qwq-32b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "displayName": "Qwen QwQ 32B",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/glm-5p2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.4,
-    "output_cost_per_mil_tokens": 4.4,
-    "input_cache_read_cost_per_mil_tokens": 0.14,
-    "displayName": "GLM 5.2",
-    "reasoning": true,
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/kimi-k2p7-code": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.95,
-    "output_cost_per_mil_tokens": 4,
-    "input_cache_read_cost_per_mil_tokens": 0.19,
-    "displayName": "Kimi K2.7 Code",
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/minimax-m3": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 1.2,
-    "input_cache_read_cost_per_mil_tokens": 0.06,
-    "displayName": "MiniMax M3",
-    "max_input_tokens": 512000,
-    "max_output_tokens": 512000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3-70b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama4-maverick-instruct-basic": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.22,
-    "output_cost_per_mil_tokens": 0.88,
-    "displayName": "Llama 4 Maverick Instruct (Basic)",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-70b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mixtral-8x22b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 65536,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mistral-7b-instruct-4k": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/gemma-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/yi-34b-200k-capybara": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 200000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/phi-3-mini-128k-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/chronos-hermes-13b-v2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-qwen-1p5-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 65536,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/codegemma-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/cogito-671b-v2-p1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/cogito-v1-preview-llama-70b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/dbrx-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/devstral-small-2505": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/dobby-mini-unhinged-plus-llama-3-1-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/dobby-unhinged-llama-3-3-70b-new": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/dolphin-2-9-2-qwen2-72b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/ernie-4p5-300b-a47b-pt": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/fare-20b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/firefunction-v2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/firellava-13b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/firesearch-ocr-v6": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks-ai-56b-to-176b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/fireworks-asr-v2": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/flux-1-dev-fp8": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.0005,
-    "output_cost_per_mil_tokens": 0.0005,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/flux-kontext-max": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.08,
-    "output_cost_per_mil_tokens": 0.08,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/gpt-oss-120b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "input_cache_read_cost_per_mil_tokens": 0.015,
-    "displayName": "GPT-OSS (120B)",
-    "reasoning": true,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks_ai/thenlper/gte-base": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.008,
-    "max_input_tokens": 512,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks_ai/thenlper/gte-large": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.016,
-    "max_input_tokens": 512,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/hermes-2-pro-mistral-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/internvl3-78b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/japanese-stable-diffusion-xl": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.00013,
-    "output_cost_per_mil_tokens": 0.00013,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/kat-coder": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/kat-dev-72b-exp": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-guard-3-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llamaguard-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llava-yi-34b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/ministral-3-14b-instruct-2512": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mistral-large-3-fp8": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mistral-nemo-base-2407": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mistral-small-24b-instruct-2501": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "displayName": "Mistral Small 3 Instruct",
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mythomax-l2-13b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nemotron-nano-v2-12b-vl": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks_ai/nomic-ai/nomic-embed-text-v1.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.008,
-    "max_input_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nous-capybara-7b-v1p9": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nous-hermes-llama2-70b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nvidia-nemotron-nano-12b-v2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/openchat-3p5-0106-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/openhermes-2-mistral-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/openorca-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/phind-code-llama-34b-v2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/playground-v2-5-1024px-aesthetic": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.00013,
-    "output_cost_per_mil_tokens": 0.00013,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/pythia-12b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 2048,
-    "max_output_tokens": 2048,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/rolm-ocr": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/snorkel-mistral-7b-pairrm-dpo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/SSD-1B": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.00013,
-    "output_cost_per_mil_tokens": 0.00013,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/stable-diffusion-xl-1024-v1-0": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.00013,
-    "output_cost_per_mil_tokens": 0.00013,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/stablecode-3b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/starcoder-16b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/toppy-m-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks_ai/WhereIsAI/UAE-Large-V1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.016,
-    "max_input_tokens": 512,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/whisper-v3": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/yi-large": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 3,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/zephyr-7b-beta": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
   "accounts/fireworks/models/deepseek-v4-pro": {
     "format": "openai",
     "flavor": "chat",
@@ -3540,395 +2768,6 @@
     "displayName": "DeepSeek V4 Pro",
     "max_input_tokens": 1048576,
     "max_output_tokens": 384000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/qwen3p6-plus": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 3,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "displayName": "Qwen3.6 Plus",
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/glm-5p1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.4,
-    "output_cost_per_mil_tokens": 4.4,
-    "input_cache_read_cost_per_mil_tokens": 0.26,
-    "displayName": "GLM 5.1",
-    "reasoning": true,
-    "max_input_tokens": 202800,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/kimi-k2p6": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.95,
-    "output_cost_per_mil_tokens": 4,
-    "input_cache_read_cost_per_mil_tokens": 0.16,
-    "displayName": "Kimi K2.6",
-    "reasoning": true,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/minimax-m2p7": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 1.2,
-    "input_cache_read_cost_per_mil_tokens": 0.06,
-    "displayName": "MiniMax M2.7",
-    "max_input_tokens": 196608,
-    "max_output_tokens": 196608,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3-70b-instruct-hf": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama4-scout-instruct-basic": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "Llama 4 Scout Instruct (Basic)",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-70b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mixtral-8x22b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "displayName": "Mixtral MoE 8x22B Instruct",
-    "max_input_tokens": 65536,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mistral-7b-instruct-v3": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/gemma-7b-it": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/yi-34b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/phi-3-vision-128k-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "displayName": "Phi 3.5 Vision Instruct",
-    "max_input_tokens": 32064,
-    "max_output_tokens": 32064,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/codegemma-2b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/cogito-v1-preview-qwen-32b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/dolphin-2p6-mixtral-8x7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/ernie-4p5-21b-a3b-pt": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/firefunction-v1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks-ai-moe-up-to-56b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/fireworks-asr-large": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/flux-1-schnell-fp8": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.00035,
-    "output_cost_per_mil_tokens": 0.00035,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/flux-kontext-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.04,
-    "output_cost_per_mil_tokens": 0.04,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/gpt-oss-safeguard-120b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/internvl3-38b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/kat-dev-32b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-guard-3-1b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/ministral-3-8b-instruct-2512": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mistral-nemo-instruct-2407": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks_ai/nomic-ai/nomic-embed-text-v1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.008,
-    "max_input_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nous-hermes-2-yi-34b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nvidia-nemotron-nano-9b-v2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/openhermes-2p5-mistral-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/phind-code-llama-34b-python-v1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/playground-v2-1024px-aesthetic": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.00013,
-    "output_cost_per_mil_tokens": 0.00013,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/starcoder-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/whisper-v3-turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
     "available_providers": [
       "fireworks"
     ]
@@ -3945,244 +2784,6 @@
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/qwen3-coder-480b-a35b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.45,
-    "output_cost_per_mil_tokens": 1.8,
-    "displayName": "Qwen3 Coder 480B A35B Instruct",
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/glm-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 3.2,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "displayName": "GLM 5",
-    "max_input_tokens": 202752,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/kimi-k2p5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 3,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "displayName": "Kimi K2.5",
-    "reasoning": true,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/minimax-m2p5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 1.2,
-    "input_cache_read_cost_per_mil_tokens": 0.03,
-    "displayName": "MiniMax M2.5",
-    "max_input_tokens": 196608,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-70b-python": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mixtral-8x22b-instruct-hf": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 65536,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mistral-7b-instruct-v0p2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/gemma-3-27b-it": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/yi-34b-chat": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/phi-2-3b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 2048,
-    "max_output_tokens": 2048,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/cogito-v1-preview-qwen-14b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks-ai-above-16b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/flux-1-dev": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/gpt-oss-20b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.07,
-    "output_cost_per_mil_tokens": 0.3,
-    "input_cache_read_cost_per_mil_tokens": 0.035,
-    "displayName": "GPT-OSS (20B)",
-    "reasoning": true,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/internvl3-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-guard-2-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/ministral-3-3b-instruct-2512": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nous-hermes-llama2-13b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/phind-code-llama-34b-v1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/starcoder2-15b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
   "accounts/fireworks/models/deepseek-v3p1": {
     "format": "openai",
     "flavor": "chat",
@@ -4191,183 +2792,6 @@
     "reasoning": true,
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/qwen3-coder-480b-instruct-bf16": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/glm-4p7": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.2,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "reasoning": true,
-    "max_input_tokens": 202800,
-    "max_output_tokens": 202800,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/kimi-k2-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.5,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/minimax-m2p1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 1.2,
-    "input_cache_read_cost_per_mil_tokens": 0.03,
-    "max_input_tokens": 204800,
-    "max_output_tokens": 204800,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3-8b-instruct-hf": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-34b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mixtral-8x7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mistral-7b-v0p2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/gemma2-9b-it": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/yi-6b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/cogito-v1-preview-llama-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks-ai-4.1b-to-16b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/flux-1-dev-controlnet-union": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.001,
-    "output_cost_per_mil_tokens": 0.001,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/gpt-oss-safeguard-20b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nous-hermes-2-mixtral-8x7b-dpo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/starcoder2-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
     "available_providers": [
       "fireworks"
     ]
@@ -4384,164 +2808,6 @@
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/qwen3-235b-a22b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.22,
-    "output_cost_per_mil_tokens": 0.88,
-    "displayName": "Qwen3 235B A22B",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/glm-4p6": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.55,
-    "output_cost_per_mil_tokens": 2.19,
-    "reasoning": true,
-    "max_input_tokens": 202800,
-    "max_output_tokens": 202800,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/kimi-k2-thinking": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.5,
-    "displayName": "Kimi K2 Thinking",
-    "reasoning": true,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/minimax-m2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3p3-70b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "displayName": "Llama 3.3 70B Instruct",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-34b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mixtral-8x7b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "displayName": "Mixtral MoE 8x7B Instruct",
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mistral-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/gemma-2b-it": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/cogito-v1-preview-llama-3b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks-ai-up-to-4b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/flux-1-schnell": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/nous-hermes-llama2-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/starcoder2-3b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
   "accounts/fireworks/models/deepseek-v3": {
     "format": "openai",
     "flavor": "chat",
@@ -4550,93 +2816,6 @@
     "displayName": "DeepSeek V3",
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/qwen3-vl-235b-a22b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.22,
-    "output_cost_per_mil_tokens": 0.88,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/glm-4p5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.55,
-    "output_cost_per_mil_tokens": 2.19,
-    "reasoning": true,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 96000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/kimi-k2-instruct-0905": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.5,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/minimax-m1-80k": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3p2-90b-vision-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "displayName": "Llama 3.2 90B Vision Instruct",
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-34b-python": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/mixtral-8x7b-instruct-hf": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "fireworks-ai-default": {
-    "format": "openai",
-    "flavor": "chat",
     "available_providers": [
       "fireworks"
     ]
@@ -4653,53 +2832,6 @@
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/qwen3-vl-235b-a22b-thinking": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.22,
-    "output_cost_per_mil_tokens": 0.88,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/glm-4p5-air": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.22,
-    "output_cost_per_mil_tokens": 0.88,
-    "reasoning": true,
-    "max_input_tokens": 128000,
-    "max_output_tokens": 96000,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3p2-11b-vision-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "displayName": "Llama 3.2 11B Vision Instruct",
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-13b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
   "accounts/fireworks/models/deepseek-v2p5": {
     "format": "openai",
     "flavor": "chat",
@@ -4707,52 +2839,6 @@
     "output_cost_per_mil_tokens": 1.2,
     "max_input_tokens": 32768,
     "max_output_tokens": 32768,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/qwen3-235b-a22b-instruct-2507": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.22,
-    "output_cost_per_mil_tokens": 0.88,
-    "displayName": "Qwen3 235B A22B Instruct 2507",
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/glm-4p5v": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "reasoning": true,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3p2-3b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-13b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
     "available_providers": [
       "fireworks"
     ]
@@ -4768,78 +2854,11 @@
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/qwen3-235b-a22b-thinking-2507": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.22,
-    "output_cost_per_mil_tokens": 0.88,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3p2-3b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "displayName": "Llama 3.2 3B Instruct",
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-13b-python": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
   "accounts/fireworks/models/deepseek-coder-33b-instruct": {
     "format": "openai",
     "flavor": "chat",
     "input_cost_per_mil_tokens": 0.9,
     "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/qwen3-next-80b-a3b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3p2-1b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
     "max_input_tokens": 16384,
     "max_output_tokens": 16384,
     "available_providers": [
@@ -4857,18 +2876,150 @@
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/qwen3-next-80b-a3b-thinking": {
+  "accounts/fireworks/models/deepseek-coder-7b-instruct-v1p5": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
     "max_input_tokens": 4096,
     "max_output_tokens": 4096,
     "available_providers": [
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/llama-v3p2-1b-instruct": {
+  "accounts/fireworks/models/deepseek-coder-7b-base": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-coder-v2-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 65536,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-coder-v2-lite-base": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-coder-v2-lite-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-prover-v2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-r1-distill-llama-70b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-r1-distill-qwen-32b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-r1-distill-qwen-14b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-r1-distill-llama-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-r1-distill-qwen-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-r1-0528-distill-qwen3-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-r1-distill-qwen-1p5b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-coder-1b-base": {
     "format": "openai",
     "flavor": "chat",
     "input_cost_per_mil_tokens": 0.1,
@@ -4879,22 +3030,161 @@
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/code-llama-7b-instruct": {
+  "accounts/fireworks/models/deepseek-r1": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 8,
+    "displayName": "DeepSeek R1 (Fast)",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 20480,
     "available_providers": [
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/deepseek-coder-7b-instruct-v1p5": {
+  "accounts/fireworks/models/deepseek-r1-basic": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
+    "input_cost_per_mil_tokens": 0.55,
+    "output_cost_per_mil_tokens": 2.19,
+    "displayName": "DeepSeek R1 Basic",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 20480,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/deepseek-r1-0528": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 8,
+    "max_input_tokens": 160000,
+    "max_output_tokens": 160000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/qwen3p7-plus": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.4,
+    "output_cost_per_mil_tokens": 1.6,
+    "input_cache_read_cost_per_mil_tokens": 0.08,
+    "displayName": "Qwen3.7 Plus",
+    "max_input_tokens": 262144,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/qwen3p6-plus": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 3,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "displayName": "Qwen3.6 Plus",
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/qwen3-coder-480b-a35b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.45,
+    "output_cost_per_mil_tokens": 1.8,
+    "displayName": "Qwen3 Coder 480B A35B Instruct",
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/qwen3-coder-480b-instruct-bf16": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/qwen3-235b-a22b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.22,
+    "output_cost_per_mil_tokens": 0.88,
+    "displayName": "Qwen3 235B A22B",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/qwen3-vl-235b-a22b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.22,
+    "output_cost_per_mil_tokens": 0.88,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/qwen3-vl-235b-a22b-thinking": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.22,
+    "output_cost_per_mil_tokens": 0.88,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/qwen3-235b-a22b-instruct-2507": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.22,
+    "output_cost_per_mil_tokens": 0.88,
+    "displayName": "Qwen3 235B A22B Instruct 2507",
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/qwen3-235b-a22b-thinking-2507": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.22,
+    "output_cost_per_mil_tokens": 0.88,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/qwen3-next-80b-a3b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/qwen3-next-80b-a3b-thinking": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
     "max_input_tokens": 4096,
     "max_output_tokens": 4096,
     "available_providers": [
@@ -4913,40 +3203,6 @@
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/llama-v3p1-405b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 3,
-    "displayName": "Llama 3.1 405B Instruct",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/code-llama-7b-python": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-coder-7b-base": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
   "accounts/fireworks/models/qwen3-vl-32b-instruct": {
     "format": "openai",
     "flavor": "chat",
@@ -4954,29 +3210,6 @@
     "output_cost_per_mil_tokens": 0.9,
     "max_input_tokens": 4096,
     "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3p1-405b-instruct-long": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "displayName": "Llama 3.1 405B Instruct Long",
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-coder-v2-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 65536,
-    "max_output_tokens": 65536,
     "available_providers": [
       "fireworks"
     ]
@@ -4993,28 +3226,6 @@
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/llama-v3p1-70b-instruct-1b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-coder-v2-lite-base": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
   "accounts/fireworks/models/qwen3-coder-30b-a3b-instruct": {
     "format": "openai",
     "flavor": "chat",
@@ -5022,29 +3233,6 @@
     "output_cost_per_mil_tokens": 0.6,
     "max_input_tokens": 262144,
     "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3p1-70b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "displayName": "Llama 3.1 70B Instruct",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-coder-v2-lite-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 0.5,
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
     "available_providers": [
       "fireworks"
     ]
@@ -5060,28 +3248,6 @@
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/llama-v3p1-nemotron-70b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-prover-v2": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
   "accounts/fireworks/models/qwen3-vl-30b-a3b-thinking": {
     "format": "openai",
     "flavor": "chat",
@@ -5089,29 +3255,6 @@
     "output_cost_per_mil_tokens": 0.6,
     "max_input_tokens": 262144,
     "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v3p1-8b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "displayName": "Llama 3.1 8B Instruct",
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-r1-distill-llama-70b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
     "available_providers": [
       "fireworks"
     ]
@@ -5127,28 +3270,6 @@
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/llama-v2-70b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-r1-distill-qwen-32b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
   "accounts/fireworks/models/qwen3-30b-a3b-thinking-2507": {
     "format": "openai",
     "flavor": "chat",
@@ -5160,28 +3281,6 @@
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/llama-v2-70b-chat": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.9,
-    "output_cost_per_mil_tokens": 0.9,
-    "max_input_tokens": 2048,
-    "max_output_tokens": 2048,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-r1-distill-qwen-14b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
   "accounts/fireworks/models/qwen3-14b": {
     "format": "openai",
     "flavor": "chat",
@@ -5189,28 +3288,6 @@
     "output_cost_per_mil_tokens": 0.2,
     "max_input_tokens": 40960,
     "max_output_tokens": 40960,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v2-13b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-r1-distill-llama-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
     "available_providers": [
       "fireworks"
     ]
@@ -5227,55 +3304,11 @@
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/llama-v2-13b-chat": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-r1-distill-qwen-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
   "accounts/fireworks/models/qwen3-reranker-8b": {
     "format": "openai",
     "flavor": "chat",
     "max_input_tokens": 40960,
     "max_output_tokens": 40960,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/llama-v2-7b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-r1-0528-distill-qwen3-8b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
     "available_providers": [
       "fireworks"
     ]
@@ -5291,28 +3324,6 @@
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/llama-v2-7b-chat": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-r1-distill-qwen-1p5b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
   "accounts/fireworks/models/qwen3-4b": {
     "format": "openai",
     "flavor": "chat",
@@ -5320,17 +3331,6 @@
     "output_cost_per_mil_tokens": 0.2,
     "max_input_tokens": 40960,
     "max_output_tokens": 40960,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-coder-1b-base": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
     "available_providers": [
       "fireworks"
     ]
@@ -5344,18 +3344,6 @@
       "fireworks"
     ]
   },
-  "accounts/fireworks/models/deepseek-r1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 8,
-    "displayName": "DeepSeek R1 (Fast)",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 20480,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
   "accounts/fireworks/models/qwen3-4b-instruct-2507": {
     "format": "openai",
     "flavor": "chat",
@@ -5363,18 +3351,6 @@
     "output_cost_per_mil_tokens": 0.2,
     "max_input_tokens": 262144,
     "max_output_tokens": 262144,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-r1-basic": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.55,
-    "output_cost_per_mil_tokens": 2.19,
-    "displayName": "DeepSeek R1 Basic",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 20480,
     "available_providers": [
       "fireworks"
     ]
@@ -5397,17 +3373,6 @@
     "output_cost_per_mil_tokens": 0.1,
     "max_input_tokens": 131072,
     "max_output_tokens": 131072,
-    "available_providers": [
-      "fireworks"
-    ]
-  },
-  "accounts/fireworks/models/deepseek-r1-0528": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 8,
-    "max_input_tokens": 160000,
-    "max_output_tokens": 160000,
     "available_providers": [
       "fireworks"
     ]
@@ -5866,6 +3831,2041 @@
       "fireworks"
     ]
   },
+  "accounts/fireworks/models/qwq-32b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "displayName": "Qwen QwQ 32B",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/glm-5p2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.4,
+    "output_cost_per_mil_tokens": 4.4,
+    "input_cache_read_cost_per_mil_tokens": 0.14,
+    "displayName": "GLM 5.2",
+    "reasoning": true,
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/glm-5p1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.4,
+    "output_cost_per_mil_tokens": 4.4,
+    "input_cache_read_cost_per_mil_tokens": 0.26,
+    "displayName": "GLM 5.1",
+    "reasoning": true,
+    "max_input_tokens": 202800,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/glm-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 3.2,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "displayName": "GLM 5",
+    "max_input_tokens": 202752,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/glm-4p7": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.2,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "reasoning": true,
+    "max_input_tokens": 202800,
+    "max_output_tokens": 202800,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/glm-4p6": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.55,
+    "output_cost_per_mil_tokens": 2.19,
+    "reasoning": true,
+    "max_input_tokens": 202800,
+    "max_output_tokens": 202800,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/glm-4p5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.55,
+    "output_cost_per_mil_tokens": 2.19,
+    "reasoning": true,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 96000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/glm-4p5-air": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.22,
+    "output_cost_per_mil_tokens": 0.88,
+    "reasoning": true,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 96000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/glm-4p5v": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "reasoning": true,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/kimi-k2p7-code": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.95,
+    "output_cost_per_mil_tokens": 4,
+    "input_cache_read_cost_per_mil_tokens": 0.19,
+    "displayName": "Kimi K2.7 Code",
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/kimi-k2p6": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.95,
+    "output_cost_per_mil_tokens": 4,
+    "input_cache_read_cost_per_mil_tokens": 0.16,
+    "displayName": "Kimi K2.6",
+    "reasoning": true,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/kimi-k2p5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 3,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "displayName": "Kimi K2.5",
+    "reasoning": true,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/kimi-k2-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.5,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/kimi-k2-thinking": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.5,
+    "displayName": "Kimi K2 Thinking",
+    "reasoning": true,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/kimi-k2-instruct-0905": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.5,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/minimax-m3": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 1.2,
+    "input_cache_read_cost_per_mil_tokens": 0.06,
+    "displayName": "MiniMax M3",
+    "max_input_tokens": 512000,
+    "max_output_tokens": 512000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/minimax-m2p7": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 1.2,
+    "input_cache_read_cost_per_mil_tokens": 0.06,
+    "displayName": "MiniMax M2.7",
+    "max_input_tokens": 196608,
+    "max_output_tokens": 196608,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/minimax-m2p5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 1.2,
+    "input_cache_read_cost_per_mil_tokens": 0.03,
+    "displayName": "MiniMax M2.5",
+    "max_input_tokens": 196608,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/minimax-m2p1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 1.2,
+    "input_cache_read_cost_per_mil_tokens": 0.03,
+    "max_input_tokens": 204800,
+    "max_output_tokens": 204800,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/minimax-m2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/minimax-m1-80k": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3-70b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3-70b-instruct-hf": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3-8b-instruct-hf": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3p3-70b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "displayName": "Llama 3.3 70B Instruct",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3p2-90b-vision-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "displayName": "Llama 3.2 90B Vision Instruct",
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3p2-11b-vision-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "displayName": "Llama 3.2 11B Vision Instruct",
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3p2-3b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3p2-3b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "displayName": "Llama 3.2 3B Instruct",
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3p2-1b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3p2-1b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3p1-405b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 3,
+    "displayName": "Llama 3.1 405B Instruct",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3p1-405b-instruct-long": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "displayName": "Llama 3.1 405B Instruct Long",
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3p1-70b-instruct-1b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3p1-70b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "displayName": "Llama 3.1 70B Instruct",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3p1-nemotron-70b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v3p1-8b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "displayName": "Llama 3.1 8B Instruct",
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v2-70b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v2-70b-chat": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 2048,
+    "max_output_tokens": 2048,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v2-13b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v2-13b-chat": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v2-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-v2-7b-chat": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama4-maverick-instruct-basic": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.22,
+    "output_cost_per_mil_tokens": 0.88,
+    "displayName": "Llama 4 Maverick Instruct (Basic)",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama4-scout-instruct-basic": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "Llama 4 Scout Instruct (Basic)",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-70b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-70b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-70b-python": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-34b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-34b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-34b-python": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-13b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-13b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-13b-python": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-7b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-llama-7b-python": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mixtral-8x22b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 65536,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mixtral-8x22b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "displayName": "Mixtral MoE 8x22B Instruct",
+    "max_input_tokens": 65536,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mixtral-8x22b-instruct-hf": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 65536,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mixtral-8x7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mixtral-8x7b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "displayName": "Mixtral MoE 8x7B Instruct",
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mixtral-8x7b-instruct-hf": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-7b-instruct-4k": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-7b-instruct-v3": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-7b-instruct-v0p2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-7b-v0p2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gemma-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gemma-7b-it": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gemma-3-27b-it": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gemma2-9b-it": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gemma-2b-it": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/yi-34b-200k-capybara": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 200000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/yi-34b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/yi-34b-chat": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/yi-6b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/phi-3-mini-128k-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/phi-3-vision-128k-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "displayName": "Phi 3.5 Vision Instruct",
+    "max_input_tokens": 32064,
+    "max_output_tokens": 32064,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/phi-2-3b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 2048,
+    "max_output_tokens": 2048,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/chronos-hermes-13b-v2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/code-qwen-1p5-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 65536,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/codegemma-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/codegemma-2b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/cogito-671b-v2-p1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/cogito-v1-preview-llama-70b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/cogito-v1-preview-qwen-32b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/cogito-v1-preview-qwen-14b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/cogito-v1-preview-llama-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/cogito-v1-preview-llama-3b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/dbrx-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/devstral-small-2505": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/dobby-mini-unhinged-plus-llama-3-1-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/dobby-unhinged-llama-3-3-70b-new": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/dolphin-2-9-2-qwen2-72b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/dolphin-2p6-mixtral-8x7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/ernie-4p5-300b-a47b-pt": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/ernie-4p5-21b-a3b-pt": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/fare-20b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/firefunction-v2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/firefunction-v1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/firellava-13b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/firesearch-ocr-v6": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks-ai-56b-to-176b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks-ai-moe-up-to-56b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks-ai-above-16b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks-ai-4.1b-to-16b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks-ai-up-to-4b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks-ai-default": {
+    "format": "openai",
+    "flavor": "chat",
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/fireworks-asr-v2": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/fireworks-asr-large": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/flux-1-dev-fp8": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.0005,
+    "output_cost_per_mil_tokens": 0.0005,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/flux-1-schnell-fp8": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.00035,
+    "output_cost_per_mil_tokens": 0.00035,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/flux-1-dev": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/flux-1-dev-controlnet-union": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.001,
+    "output_cost_per_mil_tokens": 0.001,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/flux-1-schnell": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/flux-kontext-max": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.08,
+    "output_cost_per_mil_tokens": 0.08,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/flux-kontext-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.04,
+    "output_cost_per_mil_tokens": 0.04,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gpt-oss-120b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "input_cache_read_cost_per_mil_tokens": 0.015,
+    "displayName": "GPT-OSS (120B)",
+    "reasoning": true,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gpt-oss-safeguard-120b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gpt-oss-20b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.07,
+    "output_cost_per_mil_tokens": 0.3,
+    "input_cache_read_cost_per_mil_tokens": 0.035,
+    "displayName": "GPT-OSS (20B)",
+    "reasoning": true,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/gpt-oss-safeguard-20b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks_ai/thenlper/gte-base": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.008,
+    "max_input_tokens": 512,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks_ai/thenlper/gte-large": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.016,
+    "max_input_tokens": 512,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/hermes-2-pro-mistral-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/internvl3-78b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/internvl3-38b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/internvl3-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/japanese-stable-diffusion-xl": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.00013,
+    "output_cost_per_mil_tokens": 0.00013,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/kat-coder": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/kat-dev-72b-exp": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/kat-dev-32b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-guard-3-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-guard-3-1b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llama-guard-2-8b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llamaguard-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/llava-yi-34b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/ministral-3-14b-instruct-2512": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/ministral-3-8b-instruct-2512": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/ministral-3-3b-instruct-2512": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-large-3-fp8": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-nemo-base-2407": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-nemo-instruct-2407": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mistral-small-24b-instruct-2501": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "displayName": "Mistral Small 3 Instruct",
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/mythomax-l2-13b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nemotron-nano-v2-12b-vl": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks_ai/nomic-ai/nomic-embed-text-v1.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.008,
+    "max_input_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks_ai/nomic-ai/nomic-embed-text-v1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.008,
+    "max_input_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nous-capybara-7b-v1p9": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nous-hermes-llama2-70b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nous-hermes-2-yi-34b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nous-hermes-llama2-13b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nous-hermes-2-mixtral-8x7b-dpo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 0.5,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nous-hermes-llama2-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nvidia-nemotron-nano-12b-v2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/nvidia-nemotron-nano-9b-v2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/openchat-3p5-0106-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/openhermes-2-mistral-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/openhermes-2p5-mistral-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/openorca-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/phind-code-llama-34b-v2": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/phind-code-llama-34b-python-v1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/phind-code-llama-34b-v1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.9,
+    "output_cost_per_mil_tokens": 0.9,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/playground-v2-5-1024px-aesthetic": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.00013,
+    "output_cost_per_mil_tokens": 0.00013,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/playground-v2-1024px-aesthetic": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.00013,
+    "output_cost_per_mil_tokens": 0.00013,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/pythia-12b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 2048,
+    "max_output_tokens": 2048,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/rolm-ocr": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/snorkel-mistral-7b-pairrm-dpo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/SSD-1B": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.00013,
+    "output_cost_per_mil_tokens": 0.00013,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/stable-diffusion-xl-1024-v1-0": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.00013,
+    "output_cost_per_mil_tokens": 0.00013,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/stablecode-3b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/starcoder-16b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/starcoder-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/starcoder2-15b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/starcoder2-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/starcoder2-3b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/toppy-m-7b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "fireworks_ai/WhereIsAI/UAE-Large-V1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.016,
+    "max_input_tokens": 512,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/whisper-v3": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/whisper-v3-turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/yi-large": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 3,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
+  "accounts/fireworks/models/zephyr-7b-beta": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "fireworks"
+    ]
+  },
   "gpt-oss-120b": {
     "format": "openai",
     "flavor": "chat",
@@ -5922,51 +5922,6 @@
       "baseten"
     ]
   },
-  "meta-llama/llama-4-scout-17b-16e-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.11,
-    "output_cost_per_mil_tokens": 0.34,
-    "displayName": "Llama 4 Scout (17Bx16E)",
-    "experimental": true,
-    "deprecation_date": "2026-07-17",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "groq"
-    ]
-  },
-  "qwen/qwen3.6-27b": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 3,
-    "displayName": "Qwen 3.6 27B",
-    "experimental": true,
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "available_providers": [
-      "groq"
-    ]
-  },
-  "groq/compound": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "groq"
-    ]
-  },
-  "groq/compound-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "groq"
-    ]
-  },
   "openai/gpt-oss-20b": {
     "format": "openai",
     "flavor": "chat",
@@ -5982,6 +5937,33 @@
       "together"
     ]
   },
+  "openai/gpt-oss-safeguard-20b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.075,
+    "output_cost_per_mil_tokens": 0.3,
+    "displayName": "GPT-OSS Safeguard (20B)",
+    "experimental": true,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "groq"
+    ]
+  },
+  "meta-llama/llama-4-scout-17b-16e-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.11,
+    "output_cost_per_mil_tokens": 0.34,
+    "displayName": "Llama 4 Scout (17Bx16E)",
+    "experimental": true,
+    "deprecation_date": "2026-07-17",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "groq"
+    ]
+  },
   "llama-3.3-70b-versatile": {
     "format": "openai",
     "flavor": "chat",
@@ -5990,6 +5972,31 @@
     "displayName": "Llama 3.3 70B Versatile 128k",
     "deprecation_date": "2026-08-16",
     "max_input_tokens": 128000,
+    "max_output_tokens": 32768,
+    "available_providers": [
+      "groq"
+    ]
+  },
+  "llama-3.1-8b-instant": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.05,
+    "output_cost_per_mil_tokens": 0.08,
+    "displayName": "Llama 3.1 8B Instant 128k",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "groq"
+    ]
+  },
+  "qwen/qwen3.6-27b": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 3,
+    "displayName": "Qwen 3.6 27B",
+    "experimental": true,
+    "max_input_tokens": 131072,
     "max_output_tokens": 32768,
     "available_providers": [
       "groq"
@@ -6010,27 +6017,20 @@
       "groq"
     ]
   },
-  "openai/gpt-oss-safeguard-20b": {
+  "groq/compound": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.075,
-    "output_cost_per_mil_tokens": 0.3,
-    "displayName": "GPT-OSS Safeguard (20B)",
-    "experimental": true,
     "max_input_tokens": 131072,
-    "max_output_tokens": 65536,
+    "max_output_tokens": 8192,
     "available_providers": [
       "groq"
     ]
   },
-  "llama-3.1-8b-instant": {
+  "groq/compound-mini": {
     "format": "openai",
     "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.05,
-    "output_cost_per_mil_tokens": 0.08,
-    "displayName": "Llama 3.1 8B Instant 128k",
     "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
+    "max_output_tokens": 8192,
     "available_providers": [
       "groq"
     ]
@@ -7220,120 +7220,6 @@
       "vertex"
     ]
   },
-  "gemini-pro": {
-    "format": "google",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 1.5,
-    "displayName": "Gemini Pro",
-    "deprecated": true,
-    "max_input_tokens": 32760,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-fable-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 10,
-    "output_cost_per_mil_tokens": 50,
-    "input_cache_read_cost_per_mil_tokens": 1,
-    "input_cache_write_cost_per_mil_tokens": 12.5,
-    "displayName": "Claude Fable 5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-opus-4-8": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "displayName": "Claude Opus 4.8",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-sonnet-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "displayName": "Claude Sonnet 5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-haiku-4-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 5,
-    "input_cache_read_cost_per_mil_tokens": 0.1,
-    "input_cache_write_cost_per_mil_tokens": 1.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 1.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 2,
-    "displayName": "Claude Haiku 4.5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/mistralai/models/mistral-large-2411": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 6,
-    "displayName": "Mistral Large (24.11)",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/mistralai/models/codestral-2501": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 0.9,
-    "displayName": "Codestral (25.01)",
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-embedding-2": {
-    "format": "google",
-    "flavor": "embedding",
-    "multimodal": true,
-    "displayName": "Gemini embedding 2",
-    "available_providers": [
-      "vertex"
-    ]
-  },
   "publishers/google/models/gemini-3.1-flash-image": {
     "format": "google",
     "flavor": "chat",
@@ -7350,52 +7236,6 @@
       "vertex"
     ]
   },
-  "publishers/anthropic/models/claude-opus-4-7": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 10,
-    "displayName": "Claude Opus 4.7",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-sonnet-4-6": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "displayName": "Claude Sonnet 4.6",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/google/models/gemini-embedding-001": {
-    "format": "google",
-    "flavor": "embedding",
-    "displayName": "Gemini embedding 001",
-    "available_providers": [
-      "vertex"
-    ]
-  },
   "publishers/google/models/gemini-3.1-flash-image-preview": {
     "format": "google",
     "flavor": "chat",
@@ -7408,42 +7248,6 @@
     ],
     "max_input_tokens": 131072,
     "max_output_tokens": 32768,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-opus-4-6": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 5,
-    "output_cost_per_mil_tokens": 25,
-    "input_cache_read_cost_per_mil_tokens": 0.5,
-    "input_cache_write_cost_per_mil_tokens": 6.25,
-    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
-    "input_cache_write_1h_cost_per_mil_tokens": 10,
-    "displayName": "Claude Opus 4.6",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "vertex"
-    ]
-  },
-  "publishers/anthropic/models/claude-sonnet-4-5": {
-    "format": "anthropic",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 15,
-    "input_cache_read_cost_per_mil_tokens": 0.3,
-    "input_cache_write_cost_per_mil_tokens": 3.75,
-    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
-    "input_cache_write_1h_cost_per_mil_tokens": 6,
-    "displayName": "Claude Sonnet 4.5",
-    "reasoning": true,
-    "reasoning_budget": true,
     "available_providers": [
       "vertex"
     ]
@@ -7643,22 +7447,6 @@
       "vertex"
     ]
   },
-  "publishers/google/models/gemini-2.5-flash-lite-preview-09-2025": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "reasoning": true,
-    "reasoning_budget": true,
-    "experimental": true,
-    "parent": "publishers/google/models/gemini-2.5-flash-lite",
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "available_providers": [
-      "vertex"
-    ]
-  },
   "gemini-2.5-flash-preview-09-2025": {
     "format": "google",
     "flavor": "chat",
@@ -7676,6 +7464,22 @@
     "supported_regions": [
       "global"
     ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-flash-lite-preview-09-2025": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "reasoning": true,
+    "reasoning_budget": true,
+    "experimental": true,
+    "parent": "publishers/google/models/gemini-2.5-flash-lite",
     "max_input_tokens": 1048576,
     "max_output_tokens": 65535,
     "available_providers": [
@@ -7870,17 +7674,6 @@
       "vertex"
     ]
   },
-  "publishers/google/models/gemini-2.5-pro-exp-03-25": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 2.5 Pro Experimental",
-    "experimental": true,
-    "parent": "publishers/google/models/gemini-2.5-pro",
-    "available_providers": [
-      "vertex"
-    ]
-  },
   "gemini-2.5-pro-preview-03-25": {
     "format": "google",
     "flavor": "chat",
@@ -7899,6 +7692,17 @@
     ],
     "max_input_tokens": 1048576,
     "max_output_tokens": 65535,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-2.5-pro-exp-03-25": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 2.5 Pro Experimental",
+    "experimental": true,
+    "parent": "publishers/google/models/gemini-2.5-pro",
     "available_providers": [
       "vertex"
     ]
@@ -8104,15 +7908,6 @@
       "vertex"
     ]
   },
-  "publishers/google/models/gemini-1.5-flash-002": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "parent": "publishers/google/models/gemini-1.5-flash",
-    "available_providers": [
-      "vertex"
-    ]
-  },
   "gemini-1.5-pro-002": {
     "format": "google",
     "flavor": "chat",
@@ -8126,6 +7921,15 @@
     ],
     "max_input_tokens": 2097152,
     "max_output_tokens": 8192,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-1.5-flash-002": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "parent": "publishers/google/models/gemini-1.5-flash",
     "available_providers": [
       "vertex"
     ]
@@ -8158,15 +7962,6 @@
       "vertex"
     ]
   },
-  "publishers/google/models/gemini-1.5-flash-001": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "parent": "publishers/google/models/gemini-1.5-flash",
-    "available_providers": [
-      "vertex"
-    ]
-  },
   "gemini-1.5-pro-001": {
     "format": "google",
     "flavor": "chat",
@@ -8180,6 +7975,15 @@
     ],
     "max_input_tokens": 1000000,
     "max_output_tokens": 8192,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-1.5-flash-001": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "parent": "publishers/google/models/gemini-1.5-flash",
     "available_providers": [
       "vertex"
     ]
@@ -8210,20 +8014,20 @@
       "vertex"
     ]
   },
-  "publishers/google/models/gemini-1.5-pro": {
-    "format": "google",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 1.5 Pro",
-    "available_providers": [
-      "vertex"
-    ]
-  },
   "publishers/google/models/gemini-1.5-flash": {
     "format": "google",
     "flavor": "chat",
     "multimodal": true,
     "displayName": "Gemini 1.5 Flash",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-1.5-pro": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 1.5 Pro",
     "available_providers": [
       "vertex"
     ]
@@ -8248,6 +8052,202 @@
     "format": "google",
     "flavor": "chat",
     "displayName": "Gemini 1.0 Pro",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "gemini-pro": {
+    "format": "google",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 1.5,
+    "displayName": "Gemini Pro",
+    "deprecated": true,
+    "max_input_tokens": 32760,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-fable-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 10,
+    "output_cost_per_mil_tokens": 50,
+    "input_cache_read_cost_per_mil_tokens": 1,
+    "input_cache_write_cost_per_mil_tokens": 12.5,
+    "displayName": "Claude Fable 5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-opus-4-8": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "displayName": "Claude Opus 4.8",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-opus-4-7": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 10,
+    "displayName": "Claude Opus 4.7",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-opus-4-6": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 5,
+    "output_cost_per_mil_tokens": 25,
+    "input_cache_read_cost_per_mil_tokens": 0.5,
+    "input_cache_write_cost_per_mil_tokens": 6.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 6.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 10,
+    "displayName": "Claude Opus 4.6",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-sonnet-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "displayName": "Claude Sonnet 5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-sonnet-4-6": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "displayName": "Claude Sonnet 4.6",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-sonnet-4-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 15,
+    "input_cache_read_cost_per_mil_tokens": 0.3,
+    "input_cache_write_cost_per_mil_tokens": 3.75,
+    "input_cache_write_5m_cost_per_mil_tokens": 3.75,
+    "input_cache_write_1h_cost_per_mil_tokens": 6,
+    "displayName": "Claude Sonnet 4.5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/anthropic/models/claude-haiku-4-5": {
+    "format": "anthropic",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 5,
+    "input_cache_read_cost_per_mil_tokens": 0.1,
+    "input_cache_write_cost_per_mil_tokens": 1.25,
+    "input_cache_write_5m_cost_per_mil_tokens": 1.25,
+    "input_cache_write_1h_cost_per_mil_tokens": 2,
+    "displayName": "Claude Haiku 4.5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/mistralai/models/mistral-large-2411": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 6,
+    "displayName": "Mistral Large (24.11)",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/mistralai/models/codestral-2501": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 0.9,
+    "displayName": "Codestral (25.01)",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-embedding-2": {
+    "format": "google",
+    "flavor": "embedding",
+    "multimodal": true,
+    "displayName": "Gemini embedding 2",
+    "available_providers": [
+      "vertex"
+    ]
+  },
+  "publishers/google/models/gemini-embedding-001": {
+    "format": "google",
+    "flavor": "embedding",
+    "displayName": "Gemini embedding 001",
     "available_providers": [
       "vertex"
     ]
@@ -9919,6 +9919,30 @@
       "baseten"
     ]
   },
+  "deepseek-ai/DeepSeek-V3": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.25,
+    "output_cost_per_mil_tokens": 1.25,
+    "displayName": "DeepSeek V3",
+    "max_input_tokens": 65536,
+    "max_output_tokens": 8192,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "deepseek-ai/DeepSeek-R1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 3,
+    "output_cost_per_mil_tokens": 7,
+    "displayName": "DeepSeek R1",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 20480,
+    "available_providers": [
+      "together"
+    ]
+  },
   "Qwen/Qwen3.7-Max": {
     "format": "openai",
     "flavor": "chat",
@@ -9928,6 +9952,95 @@
     "displayName": "Qwen3.7 Max",
     "reasoning": true,
     "max_input_tokens": 1000000,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "Qwen/Qwen3.7-Plus": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.32,
+    "output_cost_per_mil_tokens": 1.28,
+    "displayName": "Qwen 3.7 Plus",
+    "max_input_tokens": 1000000,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "Qwen/Qwen3.6-Plus": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 3,
+    "displayName": "Qwen3.6 Plus",
+    "max_input_tokens": 1000000,
+    "supports_streaming": true,
+    "streaming_only": true,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "Qwen/Qwen3.5-397B-A17B": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 3.6,
+    "input_cache_read_cost_per_mil_tokens": 0.35,
+    "displayName": "Qwen3.5 397B A17B",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "Qwen/Qwen3.5-9B": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.17,
+    "output_cost_per_mil_tokens": 0.25,
+    "displayName": "Qwen3.5 9B",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "Qwen/Qwen3-235B-A22B-Instruct-2507-tput": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "Qwen3 235B A22B Instruct 2507 (Throughput)",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "Qwen/Qwen3-Coder-Next-FP8": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 1.2,
+    "displayName": "Qwen3 Coder Next FP8",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "Qwen/Qwen2.5-72B-Instruct-Turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.2,
+    "output_cost_per_mil_tokens": 1.2,
+    "displayName": "Qwen 2.5 72B Instruct Turbo",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "Qwen/Qwen2.5-7B-Instruct-Turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 0.3,
+    "displayName": "Qwen 2.5 7B Instruct Turbo",
     "available_providers": [
       "together"
     ]
@@ -9945,6 +10058,16 @@
       "baseten"
     ]
   },
+  "moonshotai/Kimi-K2-Instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1,
+    "output_cost_per_mil_tokens": 3,
+    "displayName": "Kimi K2 Instruct",
+    "available_providers": [
+      "together"
+    ]
+  },
   "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
     "format": "openai",
     "flavor": "chat",
@@ -9952,6 +10075,44 @@
     "input_cost_per_mil_tokens": 0.27,
     "output_cost_per_mil_tokens": 0.85,
     "displayName": "Llama 4 Maverick Instruct (17Bx128E)",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.18,
+    "output_cost_per_mil_tokens": 0.59,
+    "displayName": "Llama 4 Scout Instruct (17Bx16E)",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "meta-llama/Llama-3.3-70B-Instruct-Turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.04,
+    "output_cost_per_mil_tokens": 1.04,
+    "displayName": "Llama 3.3 70B Instruct Turbo",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "meta-llama/Llama-3.3-70B-Instruct-Turbo-Free": {
+    "format": "openai",
+    "flavor": "chat",
+    "displayName": "Llama 3.3 70B Instruct Turbo Free",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "meta-llama/Llama-3.2-3B-Instruct-Turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.06,
+    "output_cost_per_mil_tokens": 0.06,
+    "displayName": "Llama 3.2 3B Instruct Turbo",
     "available_providers": [
       "together"
     ]
@@ -9966,6 +10127,26 @@
       "together"
     ]
   },
+  "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.88,
+    "output_cost_per_mil_tokens": 0.88,
+    "displayName": "Llama 3.1 70B Instruct Turbo",
+    "available_providers": [
+      "together"
+    ]
+  },
+  "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.18,
+    "output_cost_per_mil_tokens": 0.18,
+    "displayName": "Llama 3.1 8B Instruct Turbo",
+    "available_providers": [
+      "together"
+    ]
+  },
   "MiniMaxAI/MiniMax-M3": {
     "format": "openai",
     "flavor": "chat",
@@ -9974,6 +10155,18 @@
     "input_cache_read_cost_per_mil_tokens": 0.06,
     "displayName": "MiniMax M3",
     "max_input_tokens": 524288,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "MiniMaxAI/MiniMax-M2.7": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 1.2,
+    "input_cache_read_cost_per_mil_tokens": 0.06,
+    "displayName": "MiniMax M2.7",
+    "max_input_tokens": 202752,
     "available_providers": [
       "together"
     ]
@@ -10010,12 +10203,34 @@
       "together"
     ]
   },
+  "google/gemma-3n-E4B-it": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.06,
+    "output_cost_per_mil_tokens": 0.12,
+    "displayName": "Gemma 3n E4B IT",
+    "max_input_tokens": 32768,
+    "available_providers": [
+      "together"
+    ]
+  },
   "LiquidAI/LFM2-24B-A2B": {
     "format": "openai",
     "flavor": "chat",
     "input_cost_per_mil_tokens": 0.03,
     "output_cost_per_mil_tokens": 0.12,
     "displayName": "LFM2 24B A2B",
+    "max_input_tokens": 32768,
+    "available_providers": [
+      "together"
+    ]
+  },
+  "LiquidAI/LFM2.5-8B-A1B": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.03,
+    "output_cost_per_mil_tokens": 0.12,
+    "displayName": "LFM2.5 8B A1B",
     "max_input_tokens": 32768,
     "available_providers": [
       "together"
@@ -10072,221 +10287,6 @@
     "output_cost_per_mil_tokens": 0.15,
     "displayName": "RNJ-1 Instruct",
     "max_input_tokens": 32768,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "deepseek-ai/DeepSeek-V3": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.25,
-    "output_cost_per_mil_tokens": 1.25,
-    "displayName": "DeepSeek V3",
-    "max_input_tokens": 65536,
-    "max_output_tokens": 8192,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "Qwen/Qwen3.7-Plus": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.32,
-    "output_cost_per_mil_tokens": 1.28,
-    "displayName": "Qwen 3.7 Plus",
-    "max_input_tokens": 1000000,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "moonshotai/Kimi-K2-Instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1,
-    "output_cost_per_mil_tokens": 3,
-    "displayName": "Kimi K2 Instruct",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.18,
-    "output_cost_per_mil_tokens": 0.59,
-    "displayName": "Llama 4 Scout Instruct (17Bx16E)",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.88,
-    "output_cost_per_mil_tokens": 0.88,
-    "displayName": "Llama 3.1 70B Instruct Turbo",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "MiniMaxAI/MiniMax-M2.7": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 1.2,
-    "input_cache_read_cost_per_mil_tokens": 0.06,
-    "displayName": "MiniMax M2.7",
-    "max_input_tokens": 202752,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "google/gemma-3n-E4B-it": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.06,
-    "output_cost_per_mil_tokens": 0.12,
-    "displayName": "Gemma 3n E4B IT",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "LiquidAI/LFM2.5-8B-A1B": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.03,
-    "output_cost_per_mil_tokens": 0.12,
-    "displayName": "LFM2.5 8B A1B",
-    "max_input_tokens": 32768,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "deepseek-ai/DeepSeek-R1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 3,
-    "output_cost_per_mil_tokens": 7,
-    "displayName": "DeepSeek R1",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 20480,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "Qwen/Qwen3.6-Plus": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 3,
-    "displayName": "Qwen3.6 Plus",
-    "max_input_tokens": 1000000,
-    "supports_streaming": true,
-    "streaming_only": true,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta-llama/Llama-3.3-70B-Instruct-Turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.04,
-    "output_cost_per_mil_tokens": 1.04,
-    "displayName": "Llama 3.3 70B Instruct Turbo",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.18,
-    "output_cost_per_mil_tokens": 0.18,
-    "displayName": "Llama 3.1 8B Instruct Turbo",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "Qwen/Qwen3.5-397B-A17B": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 3.6,
-    "input_cache_read_cost_per_mil_tokens": 0.35,
-    "displayName": "Qwen3.5 397B A17B",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta-llama/Llama-3.3-70B-Instruct-Turbo-Free": {
-    "format": "openai",
-    "flavor": "chat",
-    "displayName": "Llama 3.3 70B Instruct Turbo Free",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "Qwen/Qwen3.5-9B": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.17,
-    "output_cost_per_mil_tokens": 0.25,
-    "displayName": "Qwen3.5 9B",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "meta-llama/Llama-3.2-3B-Instruct-Turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.06,
-    "output_cost_per_mil_tokens": 0.06,
-    "displayName": "Llama 3.2 3B Instruct Turbo",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "Qwen/Qwen3-235B-A22B-Instruct-2507-tput": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "Qwen3 235B A22B Instruct 2507 (Throughput)",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "Qwen/Qwen3-Coder-Next-FP8": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 1.2,
-    "displayName": "Qwen3 Coder Next FP8",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "together"
-    ]
-  },
-  "Qwen/Qwen2.5-72B-Instruct-Turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.2,
-    "output_cost_per_mil_tokens": 1.2,
-    "displayName": "Qwen 2.5 72B Instruct Turbo",
-    "available_providers": [
-      "together"
-    ]
-  },
-  "Qwen/Qwen2.5-7B-Instruct-Turbo": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 0.3,
-    "displayName": "Qwen 2.5 7B Instruct Turbo",
     "available_providers": [
       "together"
     ]
@@ -10360,6 +10360,42 @@
       "together"
     ]
   },
+  "zai-org/GLM-5.1": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 1.3,
+    "output_cost_per_mil_tokens": 4.3,
+    "input_cache_read_cost_per_mil_tokens": 0.26,
+    "displayName": "GLM 5.1",
+    "reasoning": true,
+    "max_input_tokens": 202752,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "baseten",
+      "together"
+    ]
+  },
+  "zai-org/GLM-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.95,
+    "output_cost_per_mil_tokens": 3.15,
+    "input_cache_read_cost_per_mil_tokens": 0.2,
+    "available_providers": [
+      "baseten",
+      "together"
+    ]
+  },
+  "zai-org/GLM-4.7": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 2.2,
+    "input_cache_read_cost_per_mil_tokens": 0.12,
+    "available_providers": [
+      "baseten"
+    ]
+  },
   "moonshotai/Kimi-K2.6": {
     "format": "openai",
     "flavor": "chat",
@@ -10367,6 +10403,17 @@
     "output_cost_per_mil_tokens": 4,
     "input_cache_read_cost_per_mil_tokens": 0.16,
     "displayName": "Kimi K2.6",
+    "available_providers": [
+      "baseten",
+      "together"
+    ]
+  },
+  "moonshotai/Kimi-K2.5": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.6,
+    "output_cost_per_mil_tokens": 3,
+    "input_cache_read_cost_per_mil_tokens": 0.12,
     "available_providers": [
       "baseten",
       "together"
@@ -10395,53 +10442,6 @@
       "baseten"
     ]
   },
-  "zai-org/GLM-5.1": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 1.3,
-    "output_cost_per_mil_tokens": 4.3,
-    "input_cache_read_cost_per_mil_tokens": 0.26,
-    "displayName": "GLM 5.1",
-    "reasoning": true,
-    "max_input_tokens": 202752,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "baseten",
-      "together"
-    ]
-  },
-  "moonshotai/Kimi-K2.5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 3,
-    "input_cache_read_cost_per_mil_tokens": 0.12,
-    "available_providers": [
-      "baseten",
-      "together"
-    ]
-  },
-  "zai-org/GLM-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.95,
-    "output_cost_per_mil_tokens": 3.15,
-    "input_cache_read_cost_per_mil_tokens": 0.2,
-    "available_providers": [
-      "baseten",
-      "together"
-    ]
-  },
-  "zai-org/GLM-4.7": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.6,
-    "output_cost_per_mil_tokens": 2.2,
-    "input_cache_read_cost_per_mil_tokens": 0.12,
-    "available_providers": [
-      "baseten"
-    ]
-  },
   "mistral-large-latest": {
     "format": "openai",
     "flavor": "chat",
@@ -10450,6 +10450,19 @@
     "displayName": "Mistral Large",
     "max_input_tokens": 262144,
     "max_output_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-large-2512": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 1.5,
+    "displayName": "Mistral Large (2512)",
+    "parent": "mistral-large-latest",
+    "max_input_tokens": 262144,
     "available_providers": [
       "mistral"
     ]
@@ -10468,6 +10481,89 @@
       "mistral"
     ]
   },
+  "mistral-medium-3": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.5,
+    "output_cost_per_mil_tokens": 7.5,
+    "displayName": "Mistral Medium 3",
+    "parent": "mistral-medium-3.5",
+    "max_input_tokens": 256000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-medium": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2.7,
+    "output_cost_per_mil_tokens": 8.1,
+    "displayName": "Mistral Medium",
+    "deprecated": true,
+    "max_input_tokens": 32000,
+    "max_output_tokens": 8191,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-medium-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.5,
+    "output_cost_per_mil_tokens": 7.5,
+    "displayName": "Mistral Medium 3.5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 256000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-medium-2604": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 1.5,
+    "output_cost_per_mil_tokens": 7.5,
+    "displayName": "Mistral Medium 3.5 (2604)",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "parent": "mistral-medium-latest",
+    "max_input_tokens": 256000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-medium-2508": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.4,
+    "output_cost_per_mil_tokens": 2,
+    "displayName": "Mistral Medium (2508)",
+    "deprecation_date": "2026-05-22",
+    "parent": "mistral-medium-latest",
+    "max_input_tokens": 128000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-medium-2505": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.4,
+    "output_cost_per_mil_tokens": 2,
+    "deprecation_date": "2026-05-22",
+    "parent": "mistral-medium-latest",
+    "max_input_tokens": 131072,
+    "max_output_tokens": 8191,
+    "available_providers": [
+      "mistral"
+    ]
+  },
   "magistral-medium-latest": {
     "format": "openai",
     "flavor": "chat",
@@ -10480,6 +10576,19 @@
       "mistral"
     ]
   },
+  "magistral-medium-2509": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 2,
+    "output_cost_per_mil_tokens": 5,
+    "displayName": "Magistral Medium (2509)",
+    "deprecation_date": "2026-07-31",
+    "parent": "magistral-medium-latest",
+    "max_input_tokens": 128000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
   "codestral-2508": {
     "format": "openai",
     "flavor": "chat",
@@ -10488,6 +10597,19 @@
     "displayName": "Codestral 2508",
     "parent": "codestral-latest",
     "max_input_tokens": 256000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "codestral-2501": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.3,
+    "output_cost_per_mil_tokens": 0.9,
+    "parent": "codestral-latest",
+    "fallback_models": [
+      "publishers/mistralai/models/codestral-2501"
+    ],
     "available_providers": [
       "mistral"
     ]
@@ -10562,6 +10684,34 @@
       "mistral"
     ]
   },
+  "mistral-small-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "Mistral Small",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 131072,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "mistral-small-2603": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.6,
+    "displayName": "Mistral Small (2603)",
+    "parent": "mistral-small-latest",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
   "magistral-small-latest": {
     "format": "openai",
     "flavor": "chat",
@@ -10570,6 +10720,19 @@
     "displayName": "Magistral Small Latest",
     "max_input_tokens": 128000,
     "max_output_tokens": 40000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "magistral-small-2509": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.5,
+    "output_cost_per_mil_tokens": 1.5,
+    "displayName": "Magistral Small (2509)",
+    "deprecation_date": "2026-07-31",
+    "parent": "magistral-small-latest",
+    "max_input_tokens": 128000,
     "available_providers": [
       "mistral"
     ]
@@ -10599,6 +10762,17 @@
       "mistral"
     ]
   },
+  "voxtral-small-2507": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.4,
+    "max_input_tokens": 32000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
   "ministral-14b-latest": {
     "format": "openai",
     "flavor": "chat",
@@ -10607,6 +10781,68 @@
     "output_cost_per_mil_tokens": 0.2,
     "displayName": "Ministral 14B",
     "max_input_tokens": 256000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "ministral-14b-2512": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0.2,
+    "displayName": "Ministral 14B 2512",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "ministral-8b-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.15,
+    "displayName": "Ministral 8B",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "ministral-8b-2512": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.15,
+    "displayName": "Ministral 8B (2512)",
+    "parent": "ministral-8b-latest",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "ministral-3b-latest": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "displayName": "Ministral 3B",
+    "max_input_tokens": 262144,
+    "available_providers": [
+      "mistral"
+    ]
+  },
+  "ministral-3b-2512": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0.1,
+    "displayName": "Ministral 3B (2512)",
+    "parent": "ministral-3b-latest",
+    "max_input_tokens": 262144,
     "available_providers": [
       "mistral"
     ]
@@ -10637,6 +10873,18 @@
       "mistral"
     ]
   },
+  "open-mistral-nemo-2407": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0.15,
+    "deprecation_date": "2026-07-31",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "mistral"
+    ]
+  },
   "open-mixtral-8x22b": {
     "format": "openai",
     "flavor": "chat",
@@ -10655,254 +10903,6 @@
     "flavor": "chat",
     "displayName": "Leanstral 1.5",
     "max_input_tokens": 256000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-large-2512": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 1.5,
-    "displayName": "Mistral Large (2512)",
-    "parent": "mistral-large-latest",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-medium-3": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.5,
-    "output_cost_per_mil_tokens": 7.5,
-    "displayName": "Mistral Medium 3",
-    "parent": "mistral-medium-3.5",
-    "max_input_tokens": 256000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "magistral-medium-2509": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2,
-    "output_cost_per_mil_tokens": 5,
-    "displayName": "Magistral Medium (2509)",
-    "deprecation_date": "2026-07-31",
-    "parent": "magistral-medium-latest",
-    "max_input_tokens": 128000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "codestral-2501": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.3,
-    "output_cost_per_mil_tokens": 0.9,
-    "parent": "codestral-latest",
-    "fallback_models": [
-      "publishers/mistralai/models/codestral-2501"
-    ],
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-small-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "Mistral Small",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 262144,
-    "max_output_tokens": 131072,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "magistral-small-2509": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.5,
-    "output_cost_per_mil_tokens": 1.5,
-    "displayName": "Magistral Small (2509)",
-    "deprecation_date": "2026-07-31",
-    "parent": "magistral-small-latest",
-    "max_input_tokens": 128000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "voxtral-small-2507": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.4,
-    "max_input_tokens": 32000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "ministral-14b-2512": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.2,
-    "output_cost_per_mil_tokens": 0.2,
-    "displayName": "Ministral 14B 2512",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "open-mistral-nemo-2407": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.15,
-    "deprecation_date": "2026-07-31",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-medium": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 2.7,
-    "output_cost_per_mil_tokens": 8.1,
-    "displayName": "Mistral Medium",
-    "deprecated": true,
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8191,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-small-2603": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.6,
-    "displayName": "Mistral Small (2603)",
-    "parent": "mistral-small-latest",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "ministral-8b-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.15,
-    "displayName": "Ministral 8B",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-medium-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.5,
-    "output_cost_per_mil_tokens": 7.5,
-    "displayName": "Mistral Medium 3.5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 256000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "ministral-8b-2512": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.15,
-    "output_cost_per_mil_tokens": 0.15,
-    "displayName": "Ministral 8B (2512)",
-    "parent": "ministral-8b-latest",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-medium-2604": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 1.5,
-    "output_cost_per_mil_tokens": 7.5,
-    "displayName": "Mistral Medium 3.5 (2604)",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "parent": "mistral-medium-latest",
-    "max_input_tokens": 256000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "ministral-3b-latest": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "displayName": "Ministral 3B",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-medium-2508": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.4,
-    "output_cost_per_mil_tokens": 2,
-    "displayName": "Mistral Medium (2508)",
-    "deprecation_date": "2026-05-22",
-    "parent": "mistral-medium-latest",
-    "max_input_tokens": 128000,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "ministral-3b-2512": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.1,
-    "output_cost_per_mil_tokens": 0.1,
-    "displayName": "Ministral 3B (2512)",
-    "parent": "ministral-3b-latest",
-    "max_input_tokens": 262144,
-    "available_providers": [
-      "mistral"
-    ]
-  },
-  "mistral-medium-2505": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 0.4,
-    "output_cost_per_mil_tokens": 2,
-    "deprecation_date": "2026-05-22",
-    "parent": "mistral-medium-latest",
-    "max_input_tokens": 131072,
-    "max_output_tokens": 8191,
     "available_providers": [
       "mistral"
     ]
@@ -10927,19 +10927,6 @@
       "vertex"
     ]
   },
-  "gemini-embedding-2": {
-    "format": "google",
-    "flavor": "embedding",
-    "multimodal": true,
-    "displayName": "Gemini embedding 2",
-    "fallback_models": [
-      "publishers/google/models/gemini-embedding-2"
-    ],
-    "available_providers": [
-      "google",
-      "vertex"
-    ]
-  },
   "gemini-3.1-flash-image": {
     "format": "google",
     "flavor": "chat",
@@ -10955,18 +10942,6 @@
     ],
     "max_input_tokens": 131072,
     "max_output_tokens": 32768,
-    "available_providers": [
-      "google",
-      "vertex"
-    ]
-  },
-  "gemini-embedding-001": {
-    "format": "google",
-    "flavor": "embedding",
-    "displayName": "Gemini embedding 001",
-    "fallback_models": [
-      "publishers/google/models/gemini-embedding-001"
-    ],
     "available_providers": [
       "google",
       "vertex"
@@ -11427,6 +11402,31 @@
     ],
     "max_input_tokens": 1048576,
     "max_output_tokens": 8192,
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-embedding-2": {
+    "format": "google",
+    "flavor": "embedding",
+    "multimodal": true,
+    "displayName": "Gemini embedding 2",
+    "fallback_models": [
+      "publishers/google/models/gemini-embedding-2"
+    ],
+    "available_providers": [
+      "google",
+      "vertex"
+    ]
+  },
+  "gemini-embedding-001": {
+    "format": "google",
+    "flavor": "embedding",
+    "displayName": "Gemini embedding 001",
+    "fallback_models": [
+      "publishers/google/models/gemini-embedding-001"
+    ],
     "available_providers": [
       "google",
       "vertex"
@@ -11969,12 +11969,284 @@
       "databricks"
     ]
   },
+  "databricks-claude-sonnet-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Sonnet 5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-opus-4-8": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Opus 4.8",
+    "reasoning": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-opus-4-7": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Opus 4.7",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-opus-4-6": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Opus 4.6",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-sonnet-4-6": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Sonnet 4.6",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-haiku-4-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Haiku 4.5",
+    "max_input_tokens": 200000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-opus-4-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Opus 4.5",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 32000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-sonnet-4-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Sonnet 4.5",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-opus-4-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Opus 4.1",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 32000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-sonnet-4": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Claude Sonnet 4",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-claude-3-7-sonnet": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 2.99999,
+    "output_cost_per_mil_tokens": 15.00002,
+    "displayName": "Claude Sonnet 3.7",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "deprecation_date": "2026-02-19",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
   "databricks-gpt-oss-120b": {
     "format": "openai",
     "flavor": "chat",
     "displayName": "GPT-OSS 120B",
     "reasoning": true,
     "max_input_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-oss-20b": {
+    "format": "openai",
+    "flavor": "chat",
+    "displayName": "GPT-OSS 20B",
+    "reasoning": true,
+    "max_input_tokens": 131072,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-6-luna": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.6 Luna",
+    "reasoning": true,
+    "max_input_tokens": 400000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-6-sol": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.6 Sol",
+    "reasoning": true,
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-6-terra": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.6 Terra",
+    "reasoning": true,
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.5",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-4": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.4",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-4-nano": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.4 nano",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-2": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.2",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-1": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5.1",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-mini": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5 mini",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gpt-5-nano": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "GPT-5 nano",
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
     "available_providers": [
       "databricks"
     ]
@@ -11990,6 +12262,47 @@
       "databricks"
     ]
   },
+  "databricks-gemini-3-1-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 3.1 Pro",
+    "max_input_tokens": 1000000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gemini-3-flash": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 3 Flash",
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gemini-2-5-flash": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 2.5 Flash",
+    "max_input_tokens": 1000000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-gemini-2-5-pro": {
+    "format": "openai",
+    "flavor": "chat",
+    "multimodal": true,
+    "displayName": "Gemini 2.5 Pro",
+    "max_input_tokens": 1000000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
   "databricks-meta-llama-3-3-70b-instruct": {
     "format": "openai",
     "flavor": "chat",
@@ -11997,6 +12310,30 @@
     "output_cost_per_mil_tokens": 1.50003,
     "displayName": "Llama 3.3 70B Instruct",
     "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-meta-llama-3-1-405b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 5.00003,
+    "output_cost_per_mil_tokens": 15.00002,
+    "displayName": "Llama 3.1 405B Instruct",
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "available_providers": [
+      "databricks"
+    ]
+  },
+  "databricks-meta-llama-3-1-8b-instruct": {
+    "format": "openai",
+    "flavor": "chat",
+    "input_cost_per_mil_tokens": 0.15001,
+    "output_cost_per_mil_tokens": 0.45003,
+    "displayName": "Llama 3.1 8B Instruct",
+    "max_input_tokens": 200000,
     "max_output_tokens": 128000,
     "available_providers": [
       "databricks"
@@ -12024,51 +12361,6 @@
       "databricks"
     ]
   },
-  "databricks-claude-sonnet-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Sonnet 5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-oss-20b": {
-    "format": "openai",
-    "flavor": "chat",
-    "displayName": "GPT-OSS 20B",
-    "reasoning": true,
-    "max_input_tokens": 131072,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gemini-3-1-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 3.1 Pro",
-    "max_input_tokens": 1000000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-meta-llama-3-1-405b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 5.00003,
-    "output_cost_per_mil_tokens": 15.00002,
-    "displayName": "Llama 3.1 405B Instruct",
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
   "databricks-qwen3-next-80b-a3b-instruct": {
     "format": "openai",
     "flavor": "chat",
@@ -12076,298 +12368,6 @@
     "experimental": true,
     "max_input_tokens": 262144,
     "max_output_tokens": 16384,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-opus-4-8": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Opus 4.8",
-    "reasoning": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-6-luna": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.6 Luna",
-    "reasoning": true,
-    "max_input_tokens": 400000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gemini-3-flash": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 3 Flash",
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-meta-llama-3-1-8b-instruct": {
-    "format": "openai",
-    "flavor": "chat",
-    "input_cost_per_mil_tokens": 0.15001,
-    "output_cost_per_mil_tokens": 0.45003,
-    "displayName": "Llama 3.1 8B Instruct",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-opus-4-7": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Opus 4.7",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-6-sol": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.6 Sol",
-    "reasoning": true,
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gemini-2-5-flash": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 2.5 Flash",
-    "max_input_tokens": 1000000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-opus-4-6": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Opus 4.6",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-6-terra": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.6 Terra",
-    "reasoning": true,
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gemini-2-5-pro": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Gemini 2.5 Pro",
-    "max_input_tokens": 1000000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-sonnet-4-6": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Sonnet 4.6",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.5",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-haiku-4-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Haiku 4.5",
-    "max_input_tokens": 200000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-4": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.4",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-opus-4-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Opus 4.5",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 32000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-4-nano": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.4 nano",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-sonnet-4-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Sonnet 4.5",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-2": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.2",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-opus-4-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Opus 4.1",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 32000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-1": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5.1",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-sonnet-4": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "Claude Sonnet 4",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-claude-3-7-sonnet": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "input_cost_per_mil_tokens": 2.99999,
-    "output_cost_per_mil_tokens": 15.00002,
-    "displayName": "Claude Sonnet 3.7",
-    "reasoning": true,
-    "reasoning_budget": true,
-    "deprecation_date": "2026-02-19",
-    "max_input_tokens": 200000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-mini": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5 mini",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "available_providers": [
-      "databricks"
-    ]
-  },
-  "databricks-gpt-5-nano": {
-    "format": "openai",
-    "flavor": "chat",
-    "multimodal": true,
-    "displayName": "GPT-5 nano",
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
     "available_providers": [
       "databricks"
     ]

--- a/packages/proxy/scripts/sync_model_catalog.test.ts
+++ b/packages/proxy/scripts/sync_model_catalog.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   compareModelOrdering,
+  compareModelsForProvider,
   getFallbackCompleteOrdering,
   getProviderMappingForModel,
   getRemoteAccessProvider,
   matchesProviderFilter,
+  orderModelsByProviderAndClass,
 } from "./sync_model_catalog";
 
 describe("sync_model_catalog", () => {
@@ -99,5 +101,90 @@ describe("sync_model_catalog", () => {
       "accounts/fireworks/models/qwen2p5-coder-32b-instruct",
       "accounts/fireworks/models/qwen2-72b-instruct",
     ]);
+  });
+
+  it("orders separated date snapshots by full release date across year boundaries", () => {
+    expect(
+      compareModelOrdering("gpt-4.1-2025-01-31", "gpt-4.1-2024-11-20"),
+    ).toBeLessThan(0);
+    expect(
+      compareModelOrdering("gpt-4o-2025-01-01", "gpt-4o-2024-11-20"),
+    ).toBeLessThan(0);
+    expect(
+      compareModelOrdering(
+        "gpt-image-1.5-2026-01-05",
+        "gpt-image-1.5-2025-12-16",
+      ),
+    ).toBeLessThan(0);
+  });
+
+  it("orders atomic and separated date snapshots consistently within a class", () => {
+    expect(
+      compareModelOrdering(
+        "claude-opus-4-5-20251101",
+        "claude-opus-4-5-20250805",
+      ),
+    ).toBeLessThan(0);
+    expect(
+      ["gpt-4.1-2024-11-20", "gpt-4.1-2025-04-14", "gpt-4.1-2025-01-31"].sort(
+        compareModelOrdering,
+      ),
+    ).toEqual([
+      "gpt-4.1-2025-04-14",
+      "gpt-4.1-2025-01-31",
+      "gpt-4.1-2024-11-20",
+    ]);
+  });
+
+  it("keeps the undated stable alias ahead of its dated snapshot after date collapsing", () => {
+    expect(
+      compareModelOrdering("claude-opus-4-6-2026-02-05", "claude-opus-4-6"),
+    ).toBeGreaterThan(0);
+  });
+
+  it("orders anthropic classes by capability tier, not alphabetically", () => {
+    expect(
+      orderModelsByProviderAndClass({
+        "claude-haiku-4-5": { available_providers: ["anthropic"] },
+        "claude-opus-4-8": { available_providers: ["anthropic"] },
+        "claude-sonnet-4-6": { available_providers: ["anthropic"] },
+        "claude-fable-5": { available_providers: ["anthropic"] },
+        "claude-sonnet-5": { available_providers: ["anthropic"] },
+        "claude-opus-4-7": { available_providers: ["anthropic"] },
+      }),
+    ).toEqual([
+      "claude-fable-5",
+      "claude-opus-4-8",
+      "claude-opus-4-7",
+      "claude-sonnet-5",
+      "claude-sonnet-4-6",
+      "claude-haiku-4-5",
+    ]);
+  });
+
+  it("keeps provider blocks contiguous in first-appearance order", () => {
+    expect(
+      orderModelsByProviderAndClass({
+        "claude-haiku-4-5": { available_providers: ["anthropic"] },
+        "gpt-4o": { available_providers: ["openai", "azure"] },
+        "claude-opus-4-8": { available_providers: ["anthropic"] },
+        "gpt-5.6": { available_providers: ["openai", "azure"] },
+      }),
+    ).toEqual(["claude-opus-4-8", "claude-haiku-4-5", "gpt-5.6", "gpt-4o"]);
+  });
+
+  it("sorts unlisted classes after tiered ones and leaves untabled providers untouched", () => {
+    expect(compareModelsForProvider("openai", "gpt-5.6", "o3")).toBeLessThan(0);
+    expect(
+      compareModelsForProvider("openai", "dall-e-3", "sora-2"),
+    ).toBeLessThan(0);
+    expect(
+      orderModelsByProviderAndClass({
+        "amazon.titan-text-express": { available_providers: ["bedrock"] },
+        "us.anthropic.claude-3-5-sonnet": {
+          available_providers: ["bedrock"],
+        },
+      }),
+    ).toEqual(["amazon.titan-text-express", "us.anthropic.claude-3-5-sonnet"]);
   });
 });

--- a/packages/proxy/scripts/sync_model_catalog.test.ts
+++ b/packages/proxy/scripts/sync_model_catalog.test.ts
@@ -183,6 +183,18 @@ describe("sync_model_catalog", () => {
     ]);
   });
 
+  it("keeps a version-series family (openai gpt) contiguous, newest-first", () => {
+    expect(
+      orderModelsByProviderAndClass({
+        "gpt-4o": { available_providers: ["openai", "azure"] },
+        "gpt-5.6": { available_providers: ["openai", "azure"] },
+        "gpt-5.6-luna": { available_providers: ["openai", "azure"] },
+        "gpt-5.5": { available_providers: ["openai", "azure"] },
+        o3: { available_providers: ["openai", "azure"] },
+      }),
+    ).toEqual(["gpt-5.6", "gpt-5.6-luna", "gpt-5.5", "gpt-4o", "o3"]);
+  });
+
   it("keeps provider blocks contiguous in first-appearance order", () => {
     expect(
       orderModelsByProviderAndClass({

--- a/packages/proxy/scripts/sync_model_catalog.test.ts
+++ b/packages/proxy/scripts/sync_model_catalog.test.ts
@@ -223,20 +223,26 @@ describe("sync_model_catalog", () => {
     ).toEqual(["gpt-5.6", "o3", "dall-e-3", "sora-2"]);
   });
 
-  it("tiers publisher-format no-provider models and leaves others in place", () => {
+  it("folds publisher-format no-provider models into the vertex block", () => {
     expect(
       orderModelsByProviderAndClass({
+        "publishers/anthropic/models/claude-opus-4-8": {
+          available_providers: ["vertex"],
+        },
+        "publishers/anthropic/models/claude-opus-4-6": {
+          available_providers: ["vertex"],
+        },
+        "publishers/anthropic/models/claude-opus-4-5@20251101": {},
+        "publishers/google/models/gemini-3.5-flash": {
+          available_providers: ["vertex"],
+        },
         "some-legacy-model": {},
-        "publishers/anthropic/models/claude-sonnet-4-5@20250929": {},
-        "publishers/google/models/gemini-1.0-pro-002": {},
-        "publishers/anthropic/models/claude-opus-4@20250514": {},
-        "publishers/anthropic/models/claude-haiku-4-5@20251001": {},
       }),
     ).toEqual([
-      "publishers/google/models/gemini-1.0-pro-002",
-      "publishers/anthropic/models/claude-opus-4@20250514",
-      "publishers/anthropic/models/claude-sonnet-4-5@20250929",
-      "publishers/anthropic/models/claude-haiku-4-5@20251001",
+      "publishers/google/models/gemini-3.5-flash",
+      "publishers/anthropic/models/claude-opus-4-8",
+      "publishers/anthropic/models/claude-opus-4-6",
+      "publishers/anthropic/models/claude-opus-4-5@20251101",
       "some-legacy-model",
     ]);
   });

--- a/packages/proxy/scripts/sync_model_catalog.test.ts
+++ b/packages/proxy/scripts/sync_model_catalog.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
   compareModelOrdering,
-  compareModelsForProvider,
   getFallbackCompleteOrdering,
   getProviderMappingForModel,
   getRemoteAccessProvider,
@@ -142,7 +141,7 @@ describe("sync_model_catalog", () => {
     ).toBeGreaterThan(0);
   });
 
-  it("orders anthropic classes by capability tier, not alphabetically", () => {
+  it("interleaves anthropic families column-major by capability tier", () => {
     expect(
       orderModelsByProviderAndClass({
         "claude-haiku-4-5": { available_providers: ["anthropic"] },
@@ -155,10 +154,32 @@ describe("sync_model_catalog", () => {
     ).toEqual([
       "claude-fable-5",
       "claude-opus-4-8",
-      "claude-opus-4-7",
       "claude-sonnet-5",
-      "claude-sonnet-4-6",
       "claude-haiku-4-5",
+      "claude-opus-4-7",
+      "claude-sonnet-4-6",
+    ]);
+  });
+
+  it("glues a dated snapshot to its alias within the same interleave slot", () => {
+    expect(
+      orderModelsByProviderAndClass({
+        "claude-opus-4-5": { available_providers: ["anthropic"] },
+        "claude-opus-4-5-20251101": { available_providers: ["anthropic"] },
+        "claude-opus-4-1": { available_providers: ["anthropic"] },
+        "claude-sonnet-5": { available_providers: ["anthropic"] },
+        "claude-sonnet-4-5": { available_providers: ["anthropic"] },
+        "claude-sonnet-4-5-20250929": { available_providers: ["anthropic"] },
+        "claude-haiku-4-5": { available_providers: ["anthropic"] },
+      }),
+    ).toEqual([
+      "claude-opus-4-5",
+      "claude-opus-4-5-20251101",
+      "claude-sonnet-5",
+      "claude-haiku-4-5",
+      "claude-opus-4-1",
+      "claude-sonnet-4-5",
+      "claude-sonnet-4-5-20250929",
     ]);
   });
 
@@ -173,11 +194,15 @@ describe("sync_model_catalog", () => {
     ).toEqual(["claude-opus-4-8", "claude-haiku-4-5", "gpt-5.6", "gpt-4o"]);
   });
 
-  it("sorts unlisted classes after tiered ones and leaves untabled providers untouched", () => {
-    expect(compareModelsForProvider("openai", "gpt-5.6", "o3")).toBeLessThan(0);
+  it("orders tiered classes ahead of unlisted ones and leaves untabled providers untouched", () => {
     expect(
-      compareModelsForProvider("openai", "dall-e-3", "sora-2"),
-    ).toBeLessThan(0);
+      orderModelsByProviderAndClass({
+        o3: { available_providers: ["openai", "azure"] },
+        "gpt-5.6": { available_providers: ["openai", "azure"] },
+        "sora-2": { available_providers: ["openai", "azure"] },
+        "dall-e-3": { available_providers: ["openai", "azure"] },
+      }),
+    ).toEqual(["gpt-5.6", "o3", "dall-e-3", "sora-2"]);
     expect(
       orderModelsByProviderAndClass({
         "amazon.titan-text-express": { available_providers: ["bedrock"] },

--- a/packages/proxy/scripts/sync_model_catalog.test.ts
+++ b/packages/proxy/scripts/sync_model_catalog.test.ts
@@ -135,6 +135,12 @@ describe("sync_model_catalog", () => {
     ]);
   });
 
+  it("treats a bare major version + date as major + snapshot, not a minor version", () => {
+    expect(
+      compareModelOrdering("claude-sonnet-4-6", "claude-sonnet-4-20250514"),
+    ).toBeLessThan(0);
+  });
+
   it("keeps the undated stable alias ahead of its dated snapshot after date collapsing", () => {
     expect(
       compareModelOrdering("claude-opus-4-6-2026-02-05", "claude-opus-4-6"),
@@ -206,7 +212,7 @@ describe("sync_model_catalog", () => {
     ).toEqual(["claude-opus-4-8", "claude-haiku-4-5", "gpt-5.6", "gpt-4o"]);
   });
 
-  it("orders tiered classes ahead of unlisted ones and leaves untabled providers untouched", () => {
+  it("orders tiered classes ahead of unlisted ones for a block provider", () => {
     expect(
       orderModelsByProviderAndClass({
         o3: { available_providers: ["openai", "azure"] },
@@ -215,13 +221,31 @@ describe("sync_model_catalog", () => {
         "dall-e-3": { available_providers: ["openai", "azure"] },
       }),
     ).toEqual(["gpt-5.6", "o3", "dall-e-3", "sora-2"]);
+  });
+
+  it("tier-orders bedrock claude models within each region", () => {
     expect(
       orderModelsByProviderAndClass({
-        "amazon.titan-text-express": { available_providers: ["bedrock"] },
-        "us.anthropic.claude-3-5-sonnet": {
+        "us.anthropic.claude-sonnet-4-6": { available_providers: ["bedrock"] },
+        "us.anthropic.claude-opus-4-8": { available_providers: ["bedrock"] },
+        "us.anthropic.claude-haiku-4-5": { available_providers: ["bedrock"] },
+        "us.anthropic.claude-sonnet-5": { available_providers: ["bedrock"] },
+        "us.meta.llama3-70b": { available_providers: ["bedrock"] },
+        "global.anthropic.claude-opus-4-7": {
+          available_providers: ["bedrock"],
+        },
+        "global.anthropic.claude-opus-4-8": {
           available_providers: ["bedrock"],
         },
       }),
-    ).toEqual(["amazon.titan-text-express", "us.anthropic.claude-3-5-sonnet"]);
+    ).toEqual([
+      "us.anthropic.claude-opus-4-8",
+      "us.anthropic.claude-sonnet-5",
+      "us.anthropic.claude-sonnet-4-6",
+      "us.anthropic.claude-haiku-4-5",
+      "us.meta.llama3-70b",
+      "global.anthropic.claude-opus-4-8",
+      "global.anthropic.claude-opus-4-7",
+    ]);
   });
 });

--- a/packages/proxy/scripts/sync_model_catalog.test.ts
+++ b/packages/proxy/scripts/sync_model_catalog.test.ts
@@ -223,6 +223,24 @@ describe("sync_model_catalog", () => {
     ).toEqual(["gpt-5.6", "o3", "dall-e-3", "sora-2"]);
   });
 
+  it("tiers publisher-format no-provider models and leaves others in place", () => {
+    expect(
+      orderModelsByProviderAndClass({
+        "some-legacy-model": {},
+        "publishers/anthropic/models/claude-sonnet-4-5@20250929": {},
+        "publishers/google/models/gemini-1.0-pro-002": {},
+        "publishers/anthropic/models/claude-opus-4@20250514": {},
+        "publishers/anthropic/models/claude-haiku-4-5@20251001": {},
+      }),
+    ).toEqual([
+      "publishers/google/models/gemini-1.0-pro-002",
+      "publishers/anthropic/models/claude-opus-4@20250514",
+      "publishers/anthropic/models/claude-sonnet-4-5@20250929",
+      "publishers/anthropic/models/claude-haiku-4-5@20251001",
+      "some-legacy-model",
+    ]);
+  });
+
   it("tier-orders bedrock claude models within each region", () => {
     expect(
       orderModelsByProviderAndClass({

--- a/packages/proxy/scripts/sync_model_catalog.ts
+++ b/packages/proxy/scripts/sync_model_catalog.ts
@@ -562,13 +562,12 @@ function getFamilySlots(names: string[]): string[][] {
   return [...slots.values()];
 }
 
-// Interleave a provider's families column-major: the newest slot of every
-// family (ordered by class tier, then alphabetically) first, then the next slot
-// of each family, and so on. Families that run out are skipped in later rows.
-export function interleaveProviderFamilies(
+// Group a provider's models by family and order the families by class tier,
+// then alphabetically for families outside the tier.
+function orderProviderFamilies(
   provider: string,
   names: string[],
-): string[] {
+): { group: string; models: string[] }[] {
   const families = new Map<string, string[]>();
   for (const name of names) {
     const group = getOrderingGroup(name);
@@ -581,17 +580,40 @@ export function interleaveProviderFamilies(
   }
 
   const order = PROVIDER_CLASS_ORDER[provider];
-  const familyGroups = [...families.keys()].sort((a, b) => {
-    const rankA = getClassRank(order, a);
-    const rankB = getClassRank(order, b);
-    if (rankA !== rankB) {
-      return rankA - rankB;
-    }
-    return a.localeCompare(b);
-  });
+  return [...families.keys()]
+    .sort((a, b) => {
+      const rankA = getClassRank(order, a);
+      const rankB = getClassRank(order, b);
+      if (rankA !== rankB) {
+        return rankA - rankB;
+      }
+      return a.localeCompare(b);
+    })
+    .map((group) => ({ group, models: families.get(group) ?? [] }));
+}
 
-  const slotsByFamily = familyGroups.map((group) =>
-    getFamilySlots(families.get(group) ?? []),
+// Block layout: each family stays contiguous (newest-first), families emitted
+// in class-tier order. Used for providers whose families are independent
+// version series (e.g. openai gpt/o/image) rather than parallel tiers.
+function blockProviderFamilies(provider: string, names: string[]): string[] {
+  const ordered: string[] = [];
+  for (const { models } of orderProviderFamilies(provider, names)) {
+    ordered.push(...[...models].sort(compareModelOrdering));
+  }
+  return ordered;
+}
+
+// Interleave layout: column-major across families — the newest slot of every
+// family (in class-tier order) first, then the next slot of each, and so on.
+// Snapshots stay glued to their alias within a slot. Used for providers with
+// genuine parallel tiers released as generations (e.g. anthropic
+// fable/opus/sonnet/haiku).
+function interleaveProviderFamilies(
+  provider: string,
+  names: string[],
+): string[] {
+  const slotsByFamily = orderProviderFamilies(provider, names).map(
+    ({ models }) => getFamilySlots(models),
   );
   const rowCount = Math.max(0, ...slotsByFamily.map((slots) => slots.length));
 
@@ -612,12 +634,18 @@ export function getPrimaryProvider(spec: {
   return spec.available_providers?.[0];
 }
 
+// Providers whose families are genuine parallel tiers released as generations,
+// so they read best interleaved column-major (newest of each tier together).
+// Every other tiered provider keeps each family as a contiguous version-series
+// block.
+const INTERLEAVE_PROVIDERS = new Set(["anthropic"]);
+
 // Full catalog ordering: partition models into provider blocks (by their
-// primary access provider, in first-appearance order). Within each block that
-// has a class tier, interleave the families column-major so the newest model of
-// each family sits together, then the next of each, and so on. Blocks for
-// providers without a tier (bedrock, or models with no providers) keep their
-// existing relative order.
+// primary access provider, in first-appearance order). Within a block that has
+// a class tier, either interleave the families column-major (parallel-tier
+// providers) or lay each family out as a contiguous newest-first block, with
+// families in class-tier order. Blocks for providers without a tier (bedrock,
+// or models with no providers) keep their existing relative order.
 export function orderModelsByProviderAndClass(
   catalog: Record<string, { available_providers?: readonly string[] | null }>,
 ): string[] {
@@ -640,7 +668,11 @@ export function orderModelsByProviderAndClass(
   for (const provider of providerOrder) {
     const names = blocks.get(provider) ?? [];
     if (provider !== noProviderKey && PROVIDER_CLASS_ORDER[provider]) {
-      ordered.push(...interleaveProviderFamilies(provider, names));
+      ordered.push(
+        ...(INTERLEAVE_PROVIDERS.has(provider)
+          ? interleaveProviderFamilies(provider, names)
+          : blockProviderFamilies(provider, names)),
+      );
     } else {
       ordered.push(...names);
     }

--- a/packages/proxy/scripts/sync_model_catalog.ts
+++ b/packages/proxy/scripts/sync_model_catalog.ts
@@ -738,13 +738,29 @@ function orderBedrockModels(names: string[]): string[] {
 // block.
 const INTERLEAVE_PROVIDERS = new Set(["anthropic"]);
 
+// Publisher-format ids ("publishers/<vendor>/models/<model>") carry a clear
+// class even without an available_providers tag, so tier them like their vertex
+// counterparts. Other models with no provider keep their original order.
+function orderNoProviderModels(names: string[]): string[] {
+  const publisherFormat: string[] = [];
+  const other: string[] = [];
+  for (const name of names) {
+    if (/^publishers\/[^/]+\/models\//.test(name)) {
+      publisherFormat.push(name);
+    } else {
+      other.push(name);
+    }
+  }
+  return [...blockProviderFamilies("vertex", publisherFormat), ...other];
+}
+
 // Full catalog ordering: partition models into provider blocks (by their
 // primary access provider, in first-appearance order). Within a block that has
 // a class tier, either interleave the families column-major (parallel-tier
 // providers) or lay each family out as a contiguous newest-first block, with
 // families in class-tier order. Bedrock is partitioned by region and then
 // class-tiered within each region. Models with no provider keep their existing
-// relative order.
+// relative order, except publisher-format ids, which are tiered like vertex.
 export function orderModelsByProviderAndClass(
   catalog: Record<string, { available_providers?: readonly string[] | null }>,
 ): string[] {
@@ -768,7 +784,9 @@ export function orderModelsByProviderAndClass(
     const names = blocks.get(provider) ?? [];
     if (provider === "bedrock") {
       ordered.push(...orderBedrockModels(names));
-    } else if (provider !== noProviderKey && PROVIDER_CLASS_ORDER[provider]) {
+    } else if (provider === noProviderKey) {
+      ordered.push(...orderNoProviderModels(names));
+    } else if (PROVIDER_CLASS_ORDER[provider]) {
       ordered.push(
         ...(INTERLEAVE_PROVIDERS.has(provider)
           ? interleaveProviderFamilies(provider, names)

--- a/packages/proxy/scripts/sync_model_catalog.ts
+++ b/packages/proxy/scripts/sync_model_catalog.ts
@@ -131,7 +131,10 @@ function extractLeadingSemanticNumbers(baseName: string): {
   remaining: string;
 } {
   const patterns = [
-    /^(claude-(?:opus|sonnet|haiku)-)(\d+)(?:-(\d+))?/,
+    // The minor version is 1-2 digits and must not be followed by more digits,
+    // so a date snapshot (e.g. claude-sonnet-4-20250514) is not mistaken for a
+    // minor version (4.20250514) instead of major 4 + date.
+    /^(claude-(?:fable|opus|sonnet|haiku)-)(\d+)(?:-(\d{1,2})(?!\d))?/,
     /^(grok-)(\d+)(?:-(\d+))?/,
     /^(qwen(?:-?v?)?)(\d+)(?:[.p](\d+))?/,
     /^(kimi-k)(\d+)(?:[.p](\d+))?/,
@@ -634,6 +637,101 @@ export function getPrimaryProvider(spec: {
   return spec.available_providers?.[0];
 }
 
+// AWS region prefixes on bedrock ids ("us.anthropic.claude-...", etc.). The
+// vendor prefixes (anthropic., amazon., meta., ...) are handled separately.
+const BEDROCK_REGION_PREFIXES = [
+  "us-gov",
+  "us",
+  "eu",
+  "apac",
+  "au",
+  "jp",
+  "global",
+];
+
+// Class tier for bedrock, keyed on the class group derived from the model name
+// with its region + vendor prefixes stripped.
+const BEDROCK_CLASS_ORDER = [
+  "claude-fable",
+  "claude-opus",
+  "claude-sonnet",
+  "claude-haiku",
+];
+
+// The leading AWS region token of a bedrock id, or "" when the id starts
+// directly with the vendor (e.g. "anthropic.claude-...").
+function getBedrockRegion(name: string): string {
+  const lower = name.toLowerCase();
+  for (const region of BEDROCK_REGION_PREFIXES) {
+    if (lower.startsWith(`${region}.`)) {
+      return region;
+    }
+  }
+  return "";
+}
+
+// The class model name inside a bedrock id, with region + vendor prefixes
+// removed (e.g. "us.anthropic.claude-opus-4-8" -> "claude-opus-4-8"). Only used
+// to derive the ordering group/version; the id itself is never rewritten.
+function getBedrockClassName(name: string): string {
+  const lower = name.toLowerCase();
+  const region = getBedrockRegion(lower);
+  const withoutRegion = region ? lower.slice(region.length + 1) : lower;
+  const dot = withoutRegion.indexOf(".");
+  return dot === -1 ? withoutRegion : withoutRegion.slice(dot + 1);
+}
+
+// Bedrock ordering: partition by region (first-appearance order), then within
+// each region lay families out in class-tier order (claude fable/opus/sonnet/
+// haiku first, others alphabetically), newest-first within a class.
+function orderBedrockModels(names: string[]): string[] {
+  const regionOrder: string[] = [];
+  const byRegion = new Map<string, string[]>();
+  for (const name of names) {
+    const region = getBedrockRegion(name);
+    const bucket = byRegion.get(region);
+    if (bucket) {
+      bucket.push(name);
+    } else {
+      byRegion.set(region, [name]);
+      regionOrder.push(region);
+    }
+  }
+
+  const ordered: string[] = [];
+  for (const region of regionOrder) {
+    const byClass = new Map<string, string[]>();
+    for (const name of byRegion.get(region) ?? []) {
+      const group = getOrderingGroup(getBedrockClassName(name));
+      const bucket = byClass.get(group);
+      if (bucket) {
+        bucket.push(name);
+      } else {
+        byClass.set(group, [name]);
+      }
+    }
+
+    const classGroups = [...byClass.keys()].sort((a, b) => {
+      const rankA = getClassRank(BEDROCK_CLASS_ORDER, a);
+      const rankB = getClassRank(BEDROCK_CLASS_ORDER, b);
+      if (rankA !== rankB) {
+        return rankA - rankB;
+      }
+      return a.localeCompare(b);
+    });
+
+    for (const group of classGroups) {
+      const classNames = byClass.get(group) ?? [];
+      ordered.push(
+        ...[...classNames].sort((a, b) =>
+          compareModelOrdering(getBedrockClassName(a), getBedrockClassName(b)),
+        ),
+      );
+    }
+  }
+  return ordered;
+}
+
 // Providers whose families are genuine parallel tiers released as generations,
 // so they read best interleaved column-major (newest of each tier together).
 // Every other tiered provider keeps each family as a contiguous version-series
@@ -644,8 +742,9 @@ const INTERLEAVE_PROVIDERS = new Set(["anthropic"]);
 // primary access provider, in first-appearance order). Within a block that has
 // a class tier, either interleave the families column-major (parallel-tier
 // providers) or lay each family out as a contiguous newest-first block, with
-// families in class-tier order. Blocks for providers without a tier (bedrock,
-// or models with no providers) keep their existing relative order.
+// families in class-tier order. Bedrock is partitioned by region and then
+// class-tiered within each region. Models with no provider keep their existing
+// relative order.
 export function orderModelsByProviderAndClass(
   catalog: Record<string, { available_providers?: readonly string[] | null }>,
 ): string[] {
@@ -667,7 +766,9 @@ export function orderModelsByProviderAndClass(
   const ordered: string[] = [];
   for (const provider of providerOrder) {
     const names = blocks.get(provider) ?? [];
-    if (provider !== noProviderKey && PROVIDER_CLASS_ORDER[provider]) {
+    if (provider === "bedrock") {
+      ordered.push(...orderBedrockModels(names));
+    } else if (provider !== noProviderKey && PROVIDER_CLASS_ORDER[provider]) {
       ordered.push(
         ...(INTERLEAVE_PROVIDERS.has(provider)
           ? interleaveProviderFamilies(provider, names)

--- a/packages/proxy/scripts/sync_model_catalog.ts
+++ b/packages/proxy/scripts/sync_model_catalog.ts
@@ -738,29 +738,19 @@ function orderBedrockModels(names: string[]): string[] {
 // block.
 const INTERLEAVE_PROVIDERS = new Set(["anthropic"]);
 
-// Publisher-format ids ("publishers/<vendor>/models/<model>") carry a clear
-// class even without an available_providers tag, so tier them like their vertex
-// counterparts. Other models with no provider keep their original order.
-function orderNoProviderModels(names: string[]): string[] {
-  const publisherFormat: string[] = [];
-  const other: string[] = [];
-  for (const name of names) {
-    if (/^publishers\/[^/]+\/models\//.test(name)) {
-      publisherFormat.push(name);
-    } else {
-      other.push(name);
-    }
-  }
-  return [...blockProviderFamilies("vertex", publisherFormat), ...other];
-}
+// Publisher-format ids ("publishers/<vendor>/models/<model>") are vertex models
+// even when they carry no available_providers tag, so they are grouped with the
+// vertex block (see orderModelsByProviderAndClass) and tiered alongside it.
+const PUBLISHER_FORMAT_RE = /^publishers\/[^/]+\/models\//;
 
 // Full catalog ordering: partition models into provider blocks (by their
 // primary access provider, in first-appearance order). Within a block that has
 // a class tier, either interleave the families column-major (parallel-tier
 // providers) or lay each family out as a contiguous newest-first block, with
 // families in class-tier order. Bedrock is partitioned by region and then
-// class-tiered within each region. Models with no provider keep their existing
-// relative order, except publisher-format ids, which are tiered like vertex.
+// class-tiered within each region. Publisher-format ids with no provider are
+// folded into the vertex block so they tier alongside real vertex models; any
+// other no-provider models keep their existing relative order.
 export function orderModelsByProviderAndClass(
   catalog: Record<string, { available_providers?: readonly string[] | null }>,
 ): string[] {
@@ -769,7 +759,9 @@ export function orderModelsByProviderAndClass(
   const blocks = new Map<string, string[]>();
 
   for (const name of Object.keys(catalog)) {
-    const provider = getPrimaryProvider(catalog[name]) ?? noProviderKey;
+    const primary = getPrimaryProvider(catalog[name]);
+    const provider =
+      primary ?? (PUBLISHER_FORMAT_RE.test(name) ? "vertex" : noProviderKey);
     const existing = blocks.get(provider);
     if (existing) {
       existing.push(name);
@@ -784,9 +776,7 @@ export function orderModelsByProviderAndClass(
     const names = blocks.get(provider) ?? [];
     if (provider === "bedrock") {
       ordered.push(...orderBedrockModels(names));
-    } else if (provider === noProviderKey) {
-      ordered.push(...orderNoProviderModels(names));
-    } else if (PROVIDER_CLASS_ORDER[provider]) {
+    } else if (provider !== noProviderKey && PROVIDER_CLASS_ORDER[provider]) {
       ordered.push(
         ...(INTERLEAVE_PROVIDERS.has(provider)
           ? interleaveProviderFamilies(provider, names)

--- a/packages/proxy/scripts/sync_model_catalog.ts
+++ b/packages/proxy/scripts/sync_model_catalog.ts
@@ -100,7 +100,7 @@ function getOrderingBaseName(modelName: string): string {
 function getOrderingGroup(modelName: string): string {
   const baseName = getOrderingBaseName(modelName);
   const matchers = [
-    /^(claude-(?:opus|sonnet|haiku))/,
+    /^(claude-(?:fable|opus|sonnet|haiku))/,
     /^(gpt-(?:image|audio|realtime))/,
     /^(gpt)/,
     /^(dall-e)/,
@@ -163,12 +163,25 @@ function extractLeadingSemanticNumbers(baseName: string): {
   };
 }
 
+// Collapse separated release-date stamps into the atomic YYYYMMDD / YYYYMM form
+// so a full date compares as a single chronological value. Without this, the
+// tokenizer buckets the year (>= 4 digits) as `dateish` and the month/day
+// (<= 3 digits) as `semantic`, and `compareModelOrdering` weighs `semantic`
+// before `dateish` — inverting chronology across a year boundary (e.g. a
+// 2024-11 snapshot would outrank a 2025-01 one). Gated on a 20xx year so
+// version pairs like `4-6` are never mistaken for a date.
+function collapseDateStamps(name: string): string {
+  return name
+    .replace(/(?<![0-9])(20\d{2})-(\d{2})-(\d{2})(?![0-9])/g, "$1$2$3")
+    .replace(/(?<![0-9])(20\d{2})-(\d{2})(?![0-9-])/g, "$1$2");
+}
+
 function getOrderingNumberGroups(modelName: string): {
   version: number[];
   semantic: number[];
   dateish: number[];
 } {
-  const normalized = getOrderingBaseName(modelName).replace(
+  const normalized = collapseDateStamps(getOrderingBaseName(modelName)).replace(
     /(\d)p(\d)/g,
     "$1.$2",
   );
@@ -412,4 +425,182 @@ export function getFallbackCompleteOrdering(
   }
 
   return orderedModels;
+}
+
+// Ordered class (model-family group) ranking within each provider, keyed by the
+// provider's primary access name (available_providers[0]). Groups are the
+// prefixes produced by getOrderingGroup. A group not listed for its provider
+// sorts after every listed group, keeping its existing alphabetical order.
+// Providers without an entry (e.g. bedrock, whose ids group by region/vendor
+// prefix rather than model class) keep their current order untouched.
+export const PROVIDER_CLASS_ORDER: Record<string, string[]> = {
+  anthropic: ["claude-fable", "claude-opus", "claude-sonnet", "claude-haiku"],
+  openai: [
+    "gpt",
+    "o",
+    "chatgpt",
+    "gpt-audio",
+    "gpt-realtime",
+    "gpt-image",
+    "chatgpt-image",
+    "dall-e",
+    "sora",
+    "tts",
+    "whisper",
+    "omni-moderation",
+    "text-moderation",
+    "babbage",
+    "davinci",
+    "ft",
+    "container",
+  ],
+  google: ["gemini", "gemini-pro", "gemini-embedding"],
+  xAI: ["grok"],
+  mistral: [
+    "mistral-large",
+    "mistral-medium",
+    "magistral-medium",
+    "codestral",
+    "codestral-latest",
+    "devstral-medium",
+    "devstral",
+    "devstral-latest",
+    "devstral-small",
+    "mistral-small",
+    "magistral-small",
+    "pixtral",
+    "voxtral-small",
+    "ministral",
+    "mistral-tiny",
+    "open-mistral",
+    "open-mixtral",
+    "labs-leanstral",
+  ],
+  perplexity: ["sonar-pro", "sonar-reasoning", "sonar-deep", "sonar"],
+  vertex: [
+    "gemini",
+    "gemini-pro",
+    "claude-fable",
+    "claude-opus",
+    "claude-sonnet",
+    "claude-haiku",
+    "mistral-large",
+    "codestral",
+    "gemini-embedding",
+  ],
+  fireworks: [
+    "deepseek",
+    "qwen",
+    "qwq",
+    "glm",
+    "kimi",
+    "minimax-m",
+    "llama-v",
+    "llama",
+    "code-llama",
+    "mixtral",
+    "mistral",
+    "gemma",
+    "yi",
+    "phi",
+  ],
+  together: [
+    "deepseek",
+    "qwen",
+    "glm",
+    "kimi",
+    "llama",
+    "meta-llama",
+    "minimax-m",
+    "gpt",
+    "mistral",
+    "gemma",
+    "lfm",
+  ],
+  baseten: ["deepseek", "glm", "kimi", "gpt", "nemotron", "nvidia-nemotron"],
+  groq: ["gpt", "llama", "qwen", "compound", "compound-mini"],
+  cerebras: ["gpt", "zai-glm", "gemma"],
+  databricks: [
+    "databricks-claude",
+    "databricks-gpt",
+    "databricks-gemini",
+    "databricks-meta",
+    "databricks-llama",
+    "databricks-qwen",
+  ],
+};
+
+function getClassRank(order: string[] | undefined, group: string): number {
+  if (!order) {
+    return Number.POSITIVE_INFINITY;
+  }
+  const index = order.indexOf(group);
+  return index === -1 ? Number.POSITIVE_INFINITY : index;
+}
+
+// Compare two model ids within a single provider block: order by the provider's
+// class tier first, then chronological/version ordering within the same class.
+export function compareModelsForProvider(
+  provider: string | undefined,
+  a: string,
+  b: string,
+): number {
+  const groupA = getOrderingGroup(a);
+  const groupB = getOrderingGroup(b);
+
+  if (groupA !== groupB) {
+    const order = provider ? PROVIDER_CLASS_ORDER[provider] : undefined;
+    const rankA = getClassRank(order, groupA);
+    const rankB = getClassRank(order, groupB);
+    if (rankA !== rankB) {
+      return rankA - rankB;
+    }
+    return a.localeCompare(b);
+  }
+
+  return compareModelOrdering(a, b);
+}
+
+export function getPrimaryProvider(spec: {
+  available_providers?: readonly string[] | null;
+}): string | undefined {
+  return spec.available_providers?.[0];
+}
+
+// Full catalog ordering: partition models into provider blocks (by their
+// primary access provider, in first-appearance order), then within each block
+// with a class tier, order by tier and then newest-release-first within a
+// class. Blocks for providers without a tier (bedrock, or models with no
+// providers) keep their existing relative order.
+export function orderModelsByProviderAndClass(
+  catalog: Record<string, { available_providers?: readonly string[] | null }>,
+): string[] {
+  const noProviderKey = " no-provider";
+  const providerOrder: string[] = [];
+  const blocks = new Map<string, string[]>();
+
+  for (const name of Object.keys(catalog)) {
+    const provider = getPrimaryProvider(catalog[name]) ?? noProviderKey;
+    const existing = blocks.get(provider);
+    if (existing) {
+      existing.push(name);
+    } else {
+      blocks.set(provider, [name]);
+      providerOrder.push(provider);
+    }
+  }
+
+  const ordered: string[] = [];
+  for (const provider of providerOrder) {
+    const names = blocks.get(provider) ?? [];
+    if (provider !== noProviderKey && PROVIDER_CLASS_ORDER[provider]) {
+      ordered.push(
+        ...[...names].sort((a, b) => compareModelsForProvider(provider, a, b)),
+      );
+    } else {
+      ordered.push(...names);
+    }
+  }
+
+  return ordered;
 }

--- a/packages/proxy/scripts/sync_model_catalog.ts
+++ b/packages/proxy/scripts/sync_model_catalog.ts
@@ -538,27 +538,72 @@ function getClassRank(order: string[] | undefined, group: string): number {
   return index === -1 ? Number.POSITIVE_INFINITY : index;
 }
 
-// Compare two model ids within a single provider block: order by the provider's
-// class tier first, then chronological/version ordering within the same class.
-export function compareModelsForProvider(
-  provider: string | undefined,
-  a: string,
-  b: string,
-): number {
-  const groupA = getOrderingGroup(a);
-  const groupB = getOrderingGroup(b);
+// The de-dated base id used to glue a dated snapshot to its stable alias so
+// they occupy the same interleaving slot (e.g. claude-opus-4-5 and
+// claude-opus-4-5-20251101 stay adjacent within one row).
+function getSlotBaseKey(name: string): string {
+  const base = collapseDateStamps(getOrderingBaseName(name));
+  return base.replace(/[-@](\d{8}|\d{6})$/, "");
+}
 
-  if (groupA !== groupB) {
-    const order = provider ? PROVIDER_CLASS_ORDER[provider] : undefined;
-    const rankA = getClassRank(order, groupA);
-    const rankB = getClassRank(order, groupB);
+// Group one family's models into slots: each slot holds a stable alias plus any
+// dated snapshots of it, ordered newest-first.
+function getFamilySlots(names: string[]): string[][] {
+  const slots = new Map<string, string[]>();
+  for (const name of [...names].sort(compareModelOrdering)) {
+    const key = getSlotBaseKey(name);
+    const slot = slots.get(key);
+    if (slot) {
+      slot.push(name);
+    } else {
+      slots.set(key, [name]);
+    }
+  }
+  return [...slots.values()];
+}
+
+// Interleave a provider's families column-major: the newest slot of every
+// family (ordered by class tier, then alphabetically) first, then the next slot
+// of each family, and so on. Families that run out are skipped in later rows.
+export function interleaveProviderFamilies(
+  provider: string,
+  names: string[],
+): string[] {
+  const families = new Map<string, string[]>();
+  for (const name of names) {
+    const group = getOrderingGroup(name);
+    const family = families.get(group);
+    if (family) {
+      family.push(name);
+    } else {
+      families.set(group, [name]);
+    }
+  }
+
+  const order = PROVIDER_CLASS_ORDER[provider];
+  const familyGroups = [...families.keys()].sort((a, b) => {
+    const rankA = getClassRank(order, a);
+    const rankB = getClassRank(order, b);
     if (rankA !== rankB) {
       return rankA - rankB;
     }
     return a.localeCompare(b);
-  }
+  });
 
-  return compareModelOrdering(a, b);
+  const slotsByFamily = familyGroups.map((group) =>
+    getFamilySlots(families.get(group) ?? []),
+  );
+  const rowCount = Math.max(0, ...slotsByFamily.map((slots) => slots.length));
+
+  const ordered: string[] = [];
+  for (let row = 0; row < rowCount; row++) {
+    for (const slots of slotsByFamily) {
+      if (row < slots.length) {
+        ordered.push(...slots[row]);
+      }
+    }
+  }
+  return ordered;
 }
 
 export function getPrimaryProvider(spec: {
@@ -568,10 +613,11 @@ export function getPrimaryProvider(spec: {
 }
 
 // Full catalog ordering: partition models into provider blocks (by their
-// primary access provider, in first-appearance order), then within each block
-// with a class tier, order by tier and then newest-release-first within a
-// class. Blocks for providers without a tier (bedrock, or models with no
-// providers) keep their existing relative order.
+// primary access provider, in first-appearance order). Within each block that
+// has a class tier, interleave the families column-major so the newest model of
+// each family sits together, then the next of each, and so on. Blocks for
+// providers without a tier (bedrock, or models with no providers) keep their
+// existing relative order.
 export function orderModelsByProviderAndClass(
   catalog: Record<string, { available_providers?: readonly string[] | null }>,
 ): string[] {
@@ -594,9 +640,7 @@ export function orderModelsByProviderAndClass(
   for (const provider of providerOrder) {
     const names = blocks.get(provider) ?? [];
     if (provider !== noProviderKey && PROVIDER_CLASS_ORDER[provider]) {
-      ordered.push(
-        ...[...names].sort((a, b) => compareModelsForProvider(provider, a, b)),
-      );
+      ordered.push(...interleaveProviderFamilies(provider, names));
     } else {
       ordered.push(...names);
     }

--- a/packages/proxy/scripts/sync_models.ts
+++ b/packages/proxy/scripts/sync_models.ts
@@ -21,6 +21,7 @@ import {
   getFallbackCompleteOrdering,
   getProviderMappingForModel,
   matchesProviderFilter,
+  orderModelsByProviderAndClass,
 } from "./sync_model_catalog";
 import {
   fetchVertexSupportedRegions,
@@ -2219,8 +2220,6 @@ async function addModelsCommand(argv: any) {
       },
     );
 
-    const newModelNames = modelsToAdd.map((m) => m.name);
-
     // Prepare provider mapping data
     const providerMappingData = missingInLocal.map(
       ({ translatedName, remoteModel, mergedProviders }) => ({
@@ -2241,11 +2240,12 @@ async function addModelsCommand(argv: any) {
         localModels,
       );
     } else {
-      console.log("Using smart fallback ordering");
-      completeModelOrder = getFallbackCompleteOrdering(
-        Object.keys(localModels),
-        newModelNames,
-      );
+      console.log("Using provider/class ordering");
+      const mergedCatalog = { ...localModels };
+      for (const { name, model } of modelsToAdd) {
+        mergedCatalog[name] = model;
+      }
+      completeModelOrder = orderModelsByProviderAndClass(mergedCatalog);
     }
 
     // Rebuild the entire model list in the optimal order
@@ -2423,11 +2423,11 @@ async function syncBasetenModelsCommand(argv: any) {
     }
 
     // Rebuild the model list with new models inserted in a stable order.
-    const newModelNames = modelsToAdd.map((m) => m.name);
-    const completeModelOrder = getFallbackCompleteOrdering(
-      Object.keys(localModels),
-      newModelNames,
-    );
+    const mergedCatalog = { ...localModels };
+    for (const { name, model } of modelsToAdd) {
+      mergedCatalog[name] = model;
+    }
+    const completeModelOrder = orderModelsByProviderAndClass(mergedCatalog);
     const updatedModels: LocalModelList = {};
     for (const modelName of completeModelOrder) {
       if (localModels[modelName]) {


### PR DESCRIPTION
The model ordering we have currently comes across as a bit sloppy, this fixes it via our scripts: https://model-ordering-by-release-and-tier.preview.braintrust.dev/app/Braintrust%20CI/p/Erin%20Test/playgrounds/erin

<img width="643" height="339" alt="Screenshot 2026-07-14 at 2 44 27 PM" src="https://github.com/user-attachments/assets/4c7a0e1f-b498-45b1-a357-5db99ae226db" />
<img width="673" height="348" alt="Screenshot 2026-07-14 at 10 22 53 AM" src="https://github.com/user-attachments/assets/ec185541-643f-4469-a6e3-486c8b67c96e" />

