### PR TITLE
Realtime Buffer Length Fix

### DIFF
--- a/apis/cloudflare/src/array-buffer.ts
+++ b/apis/cloudflare/src/array-buffer.ts
@@ -1,0 +1,6 @@
+export function exactArrayBuffer(bytes: Uint8Array): ArrayBufferLike {
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  );
+}

--- a/apis/cloudflare/src/realtime-logger.test.ts
+++ b/apis/cloudflare/src/realtime-logger.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "vitest";
+import { exactArrayBuffer } from "./array-buffer";
+
+describe("exactArrayBuffer", () => {
+  test("copies only the decoded Buffer view", () => {
+    const encoded = Buffer.from([1, 2, 3]).toString("base64");
+    const decoded = Buffer.from(encoded, "base64");
+
+    expect(decoded.byteOffset).toBeGreaterThan(0);
+    expect(decoded.buffer.byteLength).toBeGreaterThan(decoded.byteLength);
+
+    const exact = exactArrayBuffer(decoded);
+
+    expect(exact.byteLength).toBe(decoded.byteLength);
+    expect(Array.from(new Uint8Array(exact))).toEqual([1, 2, 3]);
+  });
+});

--- a/apis/cloudflare/src/realtime-logger.ts
+++ b/apis/cloudflare/src/realtime-logger.ts
@@ -5,6 +5,7 @@ import {
   PcmAudioFormat,
   ProxyLoggingParam,
 } from "@braintrust/proxy/schema";
+import { exactArrayBuffer } from "./array-buffer";
 
 // The maximum audio buffer size after pushing.
 const maxAudioBufferBytes = 50 * 1024 * 1024;
@@ -32,7 +33,9 @@ class AudioBuffer {
   }
 
   push(base64AudioBuffer: string): void {
-    const binaryAudioBuffer = Buffer.from(base64AudioBuffer, "base64").buffer;
+    const binaryAudioBuffer = exactArrayBuffer(
+      Buffer.from(base64AudioBuffer, "base64"),
+    );
     this.audioBuffers.push(binaryAudioBuffer);
     this.totalByteLength += binaryAudioBuffer.byteLength;
 


### PR DESCRIPTION
Previously we could return the whole allocated buffer which was not good. Now we ensure we slice the buffer where it starts so only the user-provided audio is logged