### PR TITLE
update gemini embedding model cost metrics

### DIFF
--- a/packages/proxy/schema/model_list.json
+++ b/packages/proxy/schema/model_list.json
@@ -7320,6 +7320,8 @@
     "format": "google",
     "flavor": "embedding",
     "multimodal": true,
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0,
     "displayName": "Gemini embedding 2",
     "available_providers": [
       "vertex"
@@ -7328,6 +7330,8 @@
   "publishers/google/models/gemini-embedding-001": {
     "format": "google",
     "flavor": "embedding",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0,
     "displayName": "Gemini embedding 001",
     "available_providers": [
       "vertex"
@@ -11614,6 +11618,8 @@
     "format": "google",
     "flavor": "embedding",
     "multimodal": true,
+    "input_cost_per_mil_tokens": 0.2,
+    "output_cost_per_mil_tokens": 0,
     "displayName": "Gemini embedding 2",
     "fallback_models": [
       "publishers/google/models/gemini-embedding-2"
@@ -11626,6 +11632,8 @@
   "gemini-embedding-001": {
     "format": "google",
     "flavor": "embedding",
+    "input_cost_per_mil_tokens": 0.15,
+    "output_cost_per_mil_tokens": 0,
     "displayName": "Gemini embedding 001",
     "fallback_models": [
       "publishers/google/models/gemini-embedding-001"


### PR DESCRIPTION
# Add cost metrics to Gemini embedding models

Adds `input_cost_per_mil_tokens` and `output_cost_per_mil_tokens` to the Gemini embedding models in `model_list.json`, covering both the Gemini API entries and the Vertex (`publishers/google/models/...`) entries:

| Model | Input ($/1M tokens) | Output ($/1M tokens) |
|---|---|---|
| `gemini-embedding-001` | 0.15 | 0 |
| `gemini-embedding-2` | 0.20 | 0 |

Pricing verified against the [official Gemini API pricing page](https://ai.google.dev/gemini-api/docs/pricing). Embedding models have no billed output tokens, so output cost is set to 0.

**Note:** `gemini-embedding-2` is multimodal with per-modality input pricing (text $0.20/1M, image $0.45/1M, audio $6.50/1M, video $12.00/1M). The schema only supports a single input cost, so these entries reflect the text rate; non-text embedding inputs will be under-costed until per-modality cost fields exist.