### PR TITLE
Add OpenAI embedding models to proxy catalog

### DIFF
--- a/packages/proxy/schema/model_list.json
+++ b/packages/proxy/schema/model_list.json
@@ -7555,6 +7555,42 @@
     "displayName": "Text Davinci 003",
     "deprecated": true
   },
+  "text-embedding-3-small": {
+    "format": "openai",
+    "flavor": "embedding",
+    "input_cost_per_mil_tokens": 0.02,
+    "output_cost_per_mil_tokens": 0,
+    "displayName": "Text Embedding 3 Small",
+    "max_input_tokens": 8191,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "text-embedding-3-large": {
+    "format": "openai",
+    "flavor": "embedding",
+    "input_cost_per_mil_tokens": 0.13,
+    "output_cost_per_mil_tokens": 0,
+    "displayName": "Text Embedding 3 Large",
+    "max_input_tokens": 8191,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
+  "text-embedding-ada-002": {
+    "format": "openai",
+    "flavor": "embedding",
+    "input_cost_per_mil_tokens": 0.1,
+    "output_cost_per_mil_tokens": 0,
+    "displayName": "Text Embedding Ada 002",
+    "max_input_tokens": 8191,
+    "available_providers": [
+      "openai",
+      "azure"
+    ]
+  },
   "claude-instant-1.2": {
     "format": "anthropic",
     "flavor": "chat",

--- a/packages/proxy/src/proxy-org-selection.test.ts
+++ b/packages/proxy/src/proxy-org-selection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { proxyV1 } from "./proxy";
+import { BillingEvent, proxyV1 } from "./proxy";
 
 describe("proxy org selection", () => {
   it("rejects conflicting header and path org selectors before secret lookup", async () => {
@@ -26,5 +26,79 @@ describe("proxy org selection", () => {
         digest: async (message: string) => message,
       }),
     ).rejects.toThrow(/Conflicting organization selectors/);
+  });
+
+  it("forwards embedding prompt tokens to billing events", async () => {
+    const billingEvents: BillingEvent[] = [];
+    let resolveStreamClosed: () => void = () => {};
+    const streamClosed = new Promise<void>((resolve) => {
+      resolveStreamClosed = resolve;
+    });
+
+    await proxyV1({
+      method: "POST",
+      url: "/embeddings",
+      proxyHeaders: {
+        authorization: "Bearer test-token",
+        "cache-control": "no-store",
+      },
+      body: JSON.stringify({
+        model: "text-embedding-3-small",
+        input: "hello",
+      }),
+      setHeader: () => {},
+      setStatusCode: () => {},
+      res: new WritableStream<Uint8Array>({
+        write() {},
+        close() {
+          resolveStreamClosed();
+        },
+      }),
+      getApiSecrets: async () => [
+        {
+          secret: "provider-token",
+          type: "openai",
+        },
+      ],
+      cacheGet: async () => null,
+      cachePut: async () => {},
+      digest: async (message: string) => message,
+      customFetch: async () =>
+        new Response(
+          JSON.stringify({
+            object: "list",
+            data: [
+              {
+                object: "embedding",
+                embedding: [0.1, 0.2, 0.3],
+                index: 0,
+              },
+            ],
+            model: "text-embedding-3-small",
+            usage: {
+              prompt_tokens: 7,
+              total_tokens: 7,
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      onBillingEvent: (event) => {
+        billingEvents.push(event);
+      },
+    });
+
+    await streamClosed;
+
+    expect(billingEvents).toHaveLength(1);
+    expect(billingEvents[0]).toMatchObject({
+      event_name: "NativeInferenceTokenUsageEvent",
+      auth_token: "test-token",
+      model: "text-embedding-3-small",
+      input_tokens: 7,
+    });
+    expect(billingEvents[0].output_tokens).toBeUndefined();
   });
 });

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -1196,6 +1196,7 @@ export async function proxyV1({
               case "embedding":
                 {
                   const data = dataRaw as CreateEmbeddingResponse;
+                  inputTokens = sanitizeUsageField(data.usage?.prompt_tokens);
                   spanLogger?.log({
                     output: {
                       embedding_length: data.data?.[0].embedding.length,


### PR DESCRIPTION
## Summary

  Adds built-in catalog entries and pricing for OpenAI embedding models:

  - `text-embedding-3-small`
  - `text-embedding-3-large`
  - `text-embedding-ada-002`

  Each entry is marked with `flavor: "embedding"`, OpenAI/Azure availability, input-token
  pricing, and zero output-token cost.

  ## Test Plan

  - `jq empty packages/proxy/schema/model_list.json`
  - `./node_modules/.bin/vitest run packages/proxy/schema/models.test.ts`