### PR TITLE
Use type-only tsup.config.js

### DIFF
--- a/apis/cloudflare/tsup.config.ts
+++ b/apis/cloudflare/tsup.config.ts
@@ -1,12 +1,12 @@
-import { defineConfig } from "tsup";
+import { type Options } from "tsup";
 
 // https://github.com/egoist/tsup/issues/840 discusses how there can
 // be an infinite loop bug with --watch, and we work around that by
 // calling build with --dts.
-export default defineConfig([
+export default [
   {
     entry: ["src/lib.ts"],
     format: ["esm"],
     outDir: "dist",
   },
-]);
+] satisfies Options[];

--- a/packages/proxy/tsup.config.ts
+++ b/packages/proxy/tsup.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "tsup";
+import { type Options } from "tsup";
 
-export default defineConfig([
+export default [
   {
     entry: ["src/index.ts"],
     format: ["cjs", "esm"],
@@ -43,4 +43,4 @@ export default defineConfig([
     outDir: "providers/dist",
     dts: true,
   },
-]);
+] satisfies Options[];


### PR DESCRIPTION
This allows build tools to analyze vastly fewer files because they don't need to look through all the node module dependencies.