### PR TITLE
schema: classify transcription models + add gpt-transcribe + audio media types

### DIFF
--- a/packages/proxy/schema/media-types.ts
+++ b/packages/proxy/schema/media-types.ts
@@ -1,4 +1,4 @@
-import type { ModelFormat, ModelName } from "./models";
+import { getAvailableModels, type ModelFormat } from "./models";
 
 const IMAGE_MEDIA_TYPES = [
   "image/jpeg",
@@ -39,6 +39,10 @@ const AUDIO_MEDIA_TYPES = [
   "audio/mpeg",
   "audio/mp4",
   "audio/webm",
+  "audio/flac",
+  "audio/ogg",
+  "audio/m4a",
+  "audio/x-m4a",
 ] as const;
 
 const VIDEO_MEDIA_TYPES = [
@@ -132,20 +136,25 @@ export const ModelFormatMediaTypes: {
 /**
  * Overrides for specific models to support additional media types.
  */
-export const ModelMediaTypeOverrides: {
-  [model in ModelName]?: MediaTypeSupport;
-} = {
+export const ModelMediaTypeOverrides: Partial<
+  Record<string, MediaTypeSupport>
+> = {
   // will be useful for gpt-audio
 };
 
 export function getSupportedMediaTypes(
   format: ModelFormat,
-  model?: ModelName,
+  model?: string,
 ): Set<string> {
   const baseSupport = { ...ModelFormatMediaTypes[format] };
 
   if (model && ModelMediaTypeOverrides[model]) {
     Object.assign(baseSupport, ModelMediaTypeOverrides[model]);
+  }
+
+  // Transcription models take an audio file regardless of provider format.
+  if (model && getAvailableModels()[model]?.transcription) {
+    Object.assign(baseSupport, toMediaTypeSupport(AUDIO_MEDIA_TYPES));
   }
 
   return new Set(
@@ -158,7 +167,7 @@ export function getSupportedMediaTypes(
 export function isMediaTypeSupported(
   mediaType: string,
   format: ModelFormat,
-  model?: ModelName,
+  model?: string,
 ): boolean {
   return getSupportedMediaTypes(format, model).has(mediaType);
 }

--- a/packages/proxy/schema/model_list.json
+++ b/packages/proxy/schema/model_list.json
@@ -940,9 +940,19 @@
       "azure"
     ]
   },
+  "gpt-transcribe": {
+    "format": "openai",
+    "flavor": "chat",
+    "transcription": true,
+    "displayName": "GPT Transcribe",
+    "available_providers": [
+      "openai"
+    ]
+  },
   "gpt-4o-mini-transcribe": {
     "format": "openai",
     "flavor": "chat",
+    "transcription": true,
     "input_cost_per_mil_tokens": 1.25,
     "output_cost_per_mil_tokens": 5,
     "displayName": "GPT-4o mini Transcribe",
@@ -983,6 +993,7 @@
   "gpt-4o-transcribe": {
     "format": "openai",
     "flavor": "chat",
+    "transcription": true,
     "input_cost_per_mil_tokens": 2.5,
     "output_cost_per_mil_tokens": 10,
     "max_input_tokens": 16000,
@@ -995,6 +1006,7 @@
   "gpt-4o-transcribe-diarize": {
     "format": "openai",
     "flavor": "chat",
+    "transcription": true,
     "input_cost_per_mil_tokens": 2.5,
     "output_cost_per_mil_tokens": 10,
     "max_input_tokens": 16000,
@@ -1007,6 +1019,7 @@
   "gpt-4o-mini-transcribe-2025-12-15": {
     "format": "openai",
     "flavor": "chat",
+    "transcription": true,
     "input_cost_per_mil_tokens": 1.25,
     "output_cost_per_mil_tokens": 5,
     "displayName": "GPT-4o mini Transcribe (2025-12-15)",
@@ -1048,6 +1061,7 @@
   "gpt-4o-mini-transcribe-2025-03-20": {
     "format": "openai",
     "flavor": "chat",
+    "transcription": true,
     "input_cost_per_mil_tokens": 1.25,
     "output_cost_per_mil_tokens": 5,
     "displayName": "GPT-4o mini Transcribe (2025-03-20)",
@@ -2401,6 +2415,7 @@
   "whisper-1": {
     "format": "openai",
     "flavor": "chat",
+    "transcription": true,
     "available_providers": [
       "openai",
       "azure"
@@ -5806,6 +5821,7 @@
   "accounts/fireworks/models/whisper-v3": {
     "format": "openai",
     "flavor": "chat",
+    "transcription": true,
     "max_input_tokens": 4096,
     "max_output_tokens": 4096,
     "available_providers": [
@@ -5815,6 +5831,7 @@
   "accounts/fireworks/models/whisper-v3-turbo": {
     "format": "openai",
     "flavor": "chat",
+    "transcription": true,
     "max_input_tokens": 4096,
     "max_output_tokens": 4096,
     "available_providers": [

--- a/packages/proxy/schema/models.ts
+++ b/packages/proxy/schema/models.ts
@@ -47,6 +47,12 @@ export type ModelEndpointType = (typeof ModelEndpointType)[number];
 export const ModelSchema = z.object({
   format: z.enum(ModelFormats),
   flavor: z.enum(ModelFlavors),
+  transcription: z
+    .boolean()
+    .nullish()
+    .describe(
+      "The model is a speech-to-text model served on /audio/transcriptions, not chat/completions.",
+    ),
   multimodal: z.boolean().nullish(),
   input_cost_per_token: z.number().nullish(),
   output_cost_per_token: z.number().nullish(),


### PR DESCRIPTION
Catalog support for speech-to-text transcription models. Paired with the braintrust main-repo branch `paultancre/transcription-endpoint` (gateway `/v1/audio/transcriptions` endpoint + playground support). Tracked in GATE-30.

## Changes
- Additive optional `transcription: boolean` on `ModelSchema` (backwards compatible; avoids widening the closed `flavor` enum, which would break older deployed proxies/SDKs).
- Flag all speech-to-text models (`gpt-4o-transcribe` family, `whisper-1`, fireworks whisper) and add the missing `gpt-transcribe` (per-minute priced, so no per-token cost fields — noted in GATE-30).
- `getSupportedMediaTypes`/`isMediaTypeSupported` include audio when the model is `transcription`, and widen the `model` param to `string`. `AUDIO_MEDIA_TYPES` expanded to OpenAI's full set: wav, mp3, mpeg, mp4, webm, flac, ogg, m4a.

ref - https://github.com/braintrustdata/braintrust/pull/19029