### PR TITLE
proxy: strip upstream Content-Length in proxyV1 response headers

### DIFF
--- a/packages/proxy/src/proxy-org-selection.test.ts
+++ b/packages/proxy/src/proxy-org-selection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { BillingEvent, proxyV1 } from "./proxy";
+import { APISecretSchema } from "../schema";
 
 describe("proxy org selection", () => {
   it("rejects conflicting header and path org selectors before secret lookup", async () => {
@@ -100,5 +101,71 @@ describe("proxy org selection", () => {
       input_tokens: 7,
     });
     expect(billingEvents[0].output_tokens).toBeUndefined();
+  });
+
+  it("does not forward provider content-length onto a fake-streamed SSE response", async () => {
+    let streamClosed: () => void = () => {};
+    const closed = new Promise<void>((resolve) => {
+      streamClosed = resolve;
+    });
+
+    const forwardedHeaders: Record<string, string> = {};
+    const nonStreamingSecret = APISecretSchema.parse({
+      type: "openai",
+      name: "non-streaming-openai",
+      secret: "provider-token",
+      metadata: { supportsStreaming: false },
+    });
+    const providerBody = JSON.stringify({
+      id: "chatcmpl-1",
+      object: "chat.completion",
+      model: "gpt-fake",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: "hi" },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    });
+
+    await proxyV1({
+      method: "POST",
+      url: "/chat/completions",
+      proxyHeaders: { authorization: "Bearer test-token" },
+      body: JSON.stringify({
+        model: "gpt-fake",
+        messages: [{ role: "user", content: "hi" }],
+        stream: true,
+      }),
+      setHeader: (name, value) => {
+        forwardedHeaders[name.toLowerCase()] = value;
+      },
+      setStatusCode: () => {},
+      res: new WritableStream<Uint8Array>({
+        write() {},
+        close() {
+          streamClosed();
+        },
+      }),
+      getApiSecrets: async () => [nonStreamingSecret],
+      cacheGet: async () => null,
+      cachePut: async () => {},
+      digest: async (message: string) => message,
+      customFetch: async () =>
+        new Response(providerBody, {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length": String(Buffer.byteLength(providerBody)),
+          },
+        }),
+    });
+
+    await closed;
+
+    expect(forwardedHeaders["content-length"]).toBeUndefined();
+    expect(forwardedHeaders["content-type"]).toContain("text/event-stream");
   });
 });

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -772,6 +772,7 @@ export async function proxyV1({
       const lowerName = name.toLowerCase();
       if (
         lowerName === "transfer-encoding" ||
+        lowerName === "content-length" ||
         lowerName === "connection" ||
         lowerName === "keep-alive" ||
         lowerName === "date" ||


### PR DESCRIPTION
## Problem

On the legacy `proxyV1` path, when a custom provider is configured with `supportsStreaming: false` and the client sends `stream: true`, the proxy makes a single non-streaming request to the provider and re-encodes that one JSON response into SSE. In doing so it forwarded the provider's `Content-Length` header onto the `text/event-stream` response instead of stripping it. The browser's SSE reader then breaks against the mismatched length and hangs; Chrome surfaces this ~60s later as a spurious `ERR_FAILED` / CORS error, shown in-product as "network error".

Reported by a self-hosted Enterprise customer running v2.7.1 — Pylon #20474 / GATE-32. Present on this path in every released version checked (v2.7.1, v2.10.0, latest).

## Fix

Add `content-length` to the `proxyResponseHeaders` strip list in `proxyV1`. The response body is always re-streamed (and may be transformed or decompressed), so an upstream `Content-Length` is never reliable — this mirrors the Rust gateway's `apply_upstream_headers`, which already strips it unconditionally. Also fixes a latent mismatch for compressed non-stream responses (the list already drops `content-encoding` under `decompressFetch` but was leaving a now-wrong `content-length`).

## Test

Added a regression test in `proxy-org-selection.test.ts` that drives `proxyV1` with a `supportsStreaming: false` OpenAI provider + `stream: true`, stubs a provider JSON response carrying `Content-Length`, and asserts the client response is `text/event-stream` with no `content-length`. Fails without the fix (forwards `content-length`), passes with it.

## Blast radius

Low — contained to the `proxyV1` response-header forwarding block. Responses through this path no longer advertise the upstream `Content-Length`; bodies are served chunked/streamed as the streaming paths already are.

Fixes GATE-32.