### PR TITLE
fix_bot_issue: tolerate model_specs emitted as an array

### DIFF
--- a/packages/proxy/scripts/fix_bot_issue.test.ts
+++ b/packages/proxy/scripts/fix_bot_issue.test.ts
@@ -3,6 +3,8 @@ import {
   applyAvailableEndpointTypeMappings,
   buildUpdatedLocalModel,
   isDateWithinDays,
+  issueMetadataSchema,
+  normalizeModelSpecs,
   UPCOMING_DEPRECATION_WINDOW_DAYS,
 } from "./fix_bot_issue";
 
@@ -100,6 +102,66 @@ describe("fix_bot_issue", () => {
           },
         ),
       ).toThrow("without explicit location metadata");
+    });
+  });
+
+  describe("model_specs array tolerance", () => {
+    it("normalizes an array of { id, ...spec } into a record keyed by id", () => {
+      expect(
+        normalizeModelSpecs([
+          {
+            id: "deepseek-ai/DeepSeek-V4-Pro-0813",
+            format: "openai",
+            flavor: "chat",
+            available_providers: ["baseten"],
+          },
+        ]),
+      ).toEqual({
+        "deepseek-ai/DeepSeek-V4-Pro-0813": {
+          format: "openai",
+          flavor: "chat",
+          available_providers: ["baseten"],
+        },
+      });
+    });
+
+    it("leaves a record-form value untouched", () => {
+      const record = {
+        "publishers/google/models/gemini-3.1-pro-preview": {
+          format: "google",
+          flavor: "chat",
+        },
+      };
+      expect(normalizeModelSpecs(record)).toBe(record);
+    });
+
+    it("parses issue metadata emitted with model_specs as an array", () => {
+      const parsed = issueMetadataSchema.parse({
+        kind: "missing_model",
+        provider: "baseten",
+        models: ["deepseek-ai/DeepSeek-V4-Pro-0813"],
+        model_specs: [
+          {
+            id: "deepseek-ai/DeepSeek-V4-Pro-0813",
+            format: "openai",
+            flavor: "chat",
+            input_cost_per_mil_tokens: 1.32,
+            output_cost_per_mil_tokens: 3.96,
+            max_input_tokens: 1048576,
+            reasoning: true,
+            available_providers: ["baseten"],
+          },
+        ],
+      });
+
+      expect(
+        parsed.model_specs?.["deepseek-ai/DeepSeek-V4-Pro-0813"],
+      ).toMatchObject({
+        format: "openai",
+        flavor: "chat",
+        input_cost_per_mil_tokens: 1.32,
+        available_providers: ["baseten"],
+      });
     });
   });
 });

--- a/packages/proxy/scripts/fix_bot_issue.ts
+++ b/packages/proxy/scripts/fix_bot_issue.ts
@@ -23,7 +23,32 @@ import {
 
 const partialModelSchema = ModelSchema.partial();
 export const UPCOMING_DEPRECATION_WINDOW_DAYS = 90;
-const issueMetadataSchema = z.object({
+
+// The gap-audit agent is instructed to emit `model_specs` as a record keyed by
+// model id, but it sometimes deviates and emits an array of `{ id, ...spec }`
+// objects instead. Normalize that array form back into the documented record so
+// the issue still resolves instead of being dropped as unparsable metadata.
+export function normalizeModelSpecs(value: unknown): unknown {
+  if (!Array.isArray(value)) {
+    return value;
+  }
+  const record: Record<string, unknown> = {};
+  for (const entry of value) {
+    if (
+      entry === null ||
+      typeof entry !== "object" ||
+      Array.isArray(entry) ||
+      !("id" in entry) ||
+      typeof entry.id !== "string"
+    ) {
+      continue;
+    }
+    const { id, ...spec } = entry;
+    record[id] = spec;
+  }
+  return record;
+}
+export const issueMetadataSchema = z.object({
   kind: z.enum(["missing_model", "stale_metadata"]).optional(),
   provider: z.string().optional(),
   model: z.string().optional(),
@@ -41,7 +66,9 @@ const issueMetadataSchema = z.object({
     .optional(),
   deprecation_date: z.string().optional(),
   model_spec: partialModelSchema.optional(),
-  model_specs: z.record(partialModelSchema).optional(),
+  model_specs: z
+    .preprocess(normalizeModelSpecs, z.record(partialModelSchema))
+    .optional(),
   source_urls: z.array(z.string().url()).optional(),
 });
 const fixResultSchema = z.object({


### PR DESCRIPTION
The gap-audit agent is instructed to emit `model_specs` as a record keyed by model id, but it sometimes deviates and emits an array of `{ id, ...spec }` objects (e.g. issue #1117). The strict `z.record(partialModelSchema)` rejected that, so `parseIssueMetadata` discarded ALL metadata and the resolver bailed with "did not contain parseable bot metadata", labeling the issue `autofix-blocked`.

Add a `normalizeModelSpecs` preprocess that converts the array form back into the documented record (keyed by each item's `id`, stripping `id`), leaving record inputs untouched. Record consumers
(`model_specs?.[targetModel]`) are unchanged.