### PR TITLE
New "add model" workflow to use in #new-model-drops

### DIFF
--- a/.github/workflows/add-model.yaml
+++ b/.github/workflows/add-model.yaml
@@ -1,0 +1,286 @@
+name: Add model
+
+on:
+  workflow_dispatch:
+    inputs:
+      provider:
+        description: "Provider serving the model"
+        required: true
+        type: string
+      model_slug:
+        description: "Exact provider model slug"
+        required: true
+        type: string
+
+concurrency:
+  group: add-model
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  add:
+    runs-on: ubuntu-latest
+    env:
+      # Route Claude Code through the Braintrust gateway. The gateway
+      # authenticates with a Braintrust API key (BRAINTRUST_AGENT_SPEND_API_KEY,
+      # passed as anthropic_api_key below) and calls the provider on our behalf.
+      # https://www.braintrust.dev/docs/deploy/gateway
+      ANTHROPIC_BASE_URL: https://gateway.braintrust.dev
+      # Attribute gateway spend to the automations-spend-control project.
+      ANTHROPIC_CUSTOM_HEADERS: |-
+        x-bt-project-name: automations-spend-control
+        x-bt-spend-control-tags: {"job_name":"add-model"}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Validate target model
+        id: target
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        env:
+          INPUT_PROVIDER: ${{ inputs.provider }}
+          INPUT_MODEL_SLUG: ${{ inputs.model_slug }}
+        with:
+          script: |
+            const providers = new Set([
+              "anthropic",
+              "azure",
+              "bedrock",
+              "cerebras",
+              "databricks",
+              "fireworks",
+              "google",
+              "groq",
+              "mistral",
+              "openai",
+              "perplexity",
+              "together",
+              "vertex",
+              "xai",
+            ]);
+            const provider = (process.env.INPUT_PROVIDER || "").trim().toLowerCase();
+            const modelSlug = (process.env.INPUT_MODEL_SLUG || "").trim();
+            if (!providers.has(provider)) {
+              throw new Error(`Unsupported provider: ${provider}`);
+            }
+            if (
+              modelSlug.length === 0 ||
+              modelSlug.length > 160 ||
+              !/^[A-Za-z0-9._:/@+-]+$/.test(modelSlug)
+            ) {
+              throw new Error("Model slug must be 1-160 characters of [A-Za-z0-9._:/@+-]");
+            }
+            const branchSlug = modelSlug
+              .toLowerCase()
+              .replace(/[^a-z0-9]+/g, "-")
+              .replace(/^-+|-+$/g, "")
+              .slice(0, 80);
+            core.setOutput("branch", `chore/add-model-${provider}-${branchSlug}-${context.runId}`);
+            core.setOutput("provider", provider);
+            core.setOutput("model_slug", modelSlug);
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+        with:
+          version: 10.33.0
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Select a priced provider endpoint
+        id: priced_endpoint
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        env:
+          PROVIDER: ${{ steps.target.outputs.provider }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          BASETEN_API_KEY: ${{ secrets.BASETEN_API_KEY }}
+          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+        with:
+          script: |
+            const provider = process.env.PROVIDER;
+            const endpointAvailable =
+              (provider === "groq" && Boolean(process.env.GROQ_API_KEY)) ||
+              (provider === "baseten" && Boolean(process.env.BASETEN_API_KEY)) ||
+              (provider === "xai" && Boolean(process.env.XAI_API_KEY)) ||
+              provider === "cerebras";
+            core.setOutput("available", String(endpointAvailable));
+
+      - name: Add from Groq's priced model endpoint
+        if: steps.target.outputs.provider == 'groq' && steps.priced_endpoint.outputs.available == 'true'
+        shell: bash
+        env:
+          INPUT_MODEL_SLUG: ${{ steps.target.outputs.model_slug }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          pnpm exec tsx packages/proxy/scripts/sync_models.ts sync-groq-model \
+            --model-slug "$INPUT_MODEL_SLUG" \
+            --write
+
+      - name: Add from Baseten's priced model endpoint
+        if: steps.target.outputs.provider == 'baseten' && steps.priced_endpoint.outputs.available == 'true'
+        shell: bash
+        env:
+          INPUT_MODEL_SLUG: ${{ steps.target.outputs.model_slug }}
+          BASETEN_API_KEY: ${{ secrets.BASETEN_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          pnpm exec tsx packages/proxy/scripts/sync_models.ts sync-baseten \
+            --model-slug "$INPUT_MODEL_SLUG" \
+            --write
+
+      - name: Add from xAI's priced model endpoint
+        if: steps.target.outputs.provider == 'xai' && steps.priced_endpoint.outputs.available == 'true'
+        shell: bash
+        env:
+          INPUT_MODEL_SLUG: ${{ steps.target.outputs.model_slug }}
+          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          pnpm exec tsx packages/proxy/scripts/sync_models.ts sync-xai-model \
+            --model-slug "$INPUT_MODEL_SLUG" \
+            --write
+
+      - name: Add from Cerebras's priced model endpoint
+        if: steps.target.outputs.provider == 'cerebras' && steps.priced_endpoint.outputs.available == 'true'
+        shell: bash
+        env:
+          INPUT_MODEL_SLUG: ${{ steps.target.outputs.model_slug }}
+        run: |
+          set -euo pipefail
+
+          pnpm exec tsx packages/proxy/scripts/sync_models.ts sync-cerebras-model \
+            --model-slug "$INPUT_MODEL_SLUG" \
+            --write
+
+      - name: Check whether a priced endpoint added the target
+        id: direct_changes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet -- packages/proxy/schema/model_list.json packages/proxy/schema/index.ts; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Add from official provider sources with Claude Code
+        if: steps.direct_changes.outputs.changed == 'false'
+        timeout-minutes: 12
+        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1.0.140
+        with:
+          anthropic_api_key: ${{ secrets.BRAINTRUST_AGENT_SPEND_API_KEY }}
+          github_token: ${{ github.token }}
+          display_report: "true"
+          claude_args: |
+            --model claude-sonnet-5
+            --max-turns 40
+            --allowedTools "Read,Glob,Grep,LS,WebSearch,WebFetch,Edit,Write"
+            --disallowedTools "Bash,MultiEdit,Replace,NotebookEditCell,mcp__github__create_issue,mcp__github__create_issue_comment,mcp__github__update_issue,mcp__github__create_pr,mcp__github__create_or_update_file,mcp__github__delete_file,mcp__github_file_ops__commit_files,mcp__github_file_ops__delete_files"
+          prompt: |
+            # Goal
+
+            Add exactly one model to the Braintrust proxy catalog.
+
+            - Provider: `${{ steps.target.outputs.provider }}`
+            - Model slug: `${{ steps.target.outputs.model_slug }}`
+
+            # Scope
+
+            - Edit only `packages/proxy/schema/model_list.json` and `packages/proxy/schema/index.ts`.
+            - Do not add, remove, or update any other model, provider mapping, or source file.
+            - If the target slug already exists, do not change it.
+
+            # Research and entry requirements
+
+            1. Read neighboring entries plus `packages/proxy/schema/models.ts` and `packages/proxy/schema/index.ts` to match the catalog schema and provider-mapping conventions.
+            2. Verify that this exact model is publicly available through the requested provider's shared inference surface using official provider sources.
+            3. No priced provider model endpoint added this target. Find the provider's official public on-demand pricing for this exact model. Do not use third-party pricing sources, free tiers, batch pricing, promotional pricing, reserved capacity, or guesses. If pricing cannot be mapped confidently to the local schema, leave the catalog unchanged.
+            4. Add a complete, schema-valid entry using verified values only. Include token limits, capabilities, and lifecycle metadata only when official sources make them clear; omit uncertain fields.
+            5. Add the matching provider mapping in `packages/proxy/schema/index.ts`. Preserve the existing JSON formatting and field ordering; do not manually reorder entries, because the next workflow step applies the repository's canonical model ordering and regenerates the provider index.
+
+            Do not create issues, pull requests, commits, comments, or files outside the two allowed catalog files.
+
+      - name: Check whether the target changed the catalog
+        id: catalog_changes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet -- packages/proxy/schema/model_list.json packages/proxy/schema/index.ts; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Canonicalize model list and provider index
+        if: steps.catalog_changes.outputs.changed == 'true'
+        run: pnpm exec tsx packages/proxy/scripts/sync_models.ts normalize-local-models --write
+
+      - name: Check expected files only
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "$(git status --short)" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          unexpected=$(git status --porcelain | awk '{print $2}' | grep -vE '^(packages/proxy/schema/model_list\.json|packages/proxy/schema/index\.ts)$' || true)
+          if [ -n "$unexpected" ]; then
+            echo "Unexpected files modified:"
+            echo "$unexpected"
+            exit 1
+          fi
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Build proxy package
+        if: steps.changes.outputs.changed == 'true'
+        run: pnpm --filter @braintrust/proxy run build
+
+      - name: Validate model schema
+        if: steps.changes.outputs.changed == 'true'
+        run: pnpm exec vitest run packages/proxy/schema/models.test.ts packages/proxy/schema/index.test.ts packages/proxy/scripts/sync_models.test.ts
+
+      - name: Create PR
+        if: steps.changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        with:
+          token: ${{ github.token }}
+          base: main
+          branch: ${{ steps.target.outputs.branch }}
+          commit-message: "chore: add model to catalog"
+          title: "chore: add model to catalog"
+          body: "Automated targeted model-catalog addition from the model-drop workflow."
+          labels: auto-sync
+          signoff: false

--- a/.github/workflows/add-model.yaml
+++ b/.github/workflows/add-model.yaml
@@ -51,6 +51,7 @@ jobs:
             const providers = new Set([
               "anthropic",
               "azure",
+              "baseten",
               "bedrock",
               "cerebras",
               "databricks",
@@ -215,8 +216,8 @@ jobs:
             # Scope
 
             - Edit only `packages/proxy/schema/model_list.json` and `packages/proxy/schema/index.ts`.
-            - Do not add, remove, or update any other model, provider mapping, or source file.
-            - If the target slug already exists, do not change it.
+            - Do not add, remove, or update any other model or source file.
+            - If the target slug already exists for another provider, verify that the requested provider serves it, then add only that provider to the existing entry and provider mapping. Preserve every other field and provider.
 
             # Research and entry requirements
 

--- a/packages/proxy/scripts/sync_models.test.ts
+++ b/packages/proxy/scripts/sync_models.test.ts
@@ -6,6 +6,9 @@ import {
   applyEquivalentModels,
   canonicalizeLocalModelsContent,
   convertBasetenToLocalModel,
+  convertCerebrasToLocalModel,
+  convertGroqToLocalModel,
+  convertXaiToLocalModel,
   convertCohereToLocalModel,
   applyCohereLiteLLMPricing,
   isSupportedCohereChatModel,
@@ -763,6 +766,89 @@ describe("convertBasetenToLocalModel", () => {
       multimodal: true,
       output_cost_per_mil_tokens: 1,
       available_providers: ["baseten"],
+    });
+  });
+});
+
+describe("convertGroqToLocalModel", () => {
+  it("converts Groq's priced model-list entry to a ModelSpec", () => {
+    expect(
+      convertGroqToLocalModel({
+        id: "qwen/qwen3.8-27b",
+        name: "Qwen/Qwen3.8-27B",
+        active: true,
+        context_length: 131042,
+        max_completion_tokens: 16384,
+        pricing: {
+          prompt: "0.0000008",
+          completion: "0.000004",
+          input_cache_read: "0.0000004",
+        },
+        supported_features: ["tools", "json_mode", "reasoning"],
+        input_modalities: ["text", "image"],
+        output_modalities: ["text"],
+      }),
+    ).toEqual({
+      format: "openai",
+      flavor: "chat",
+      multimodal: true,
+      reasoning: true,
+      input_cost_per_mil_tokens: 0.8,
+      output_cost_per_mil_tokens: 4,
+      input_cache_read_cost_per_mil_tokens: 0.4,
+      displayName: "Qwen/Qwen3.8-27B",
+      max_input_tokens: 131042,
+      max_output_tokens: 16384,
+      available_providers: ["groq"],
+    });
+  });
+});
+
+describe("convertXaiToLocalModel", () => {
+  it("converts xAI cents-per-100M pricing to dollars per million", () => {
+    expect(
+      convertXaiToLocalModel({
+        id: "grok-420-reasoning",
+        context_length: 256000,
+        input_modalities: ["text", "image"],
+        output_modalities: ["text"],
+        prompt_text_token_price: 20000,
+        cached_prompt_text_token_price: 2000,
+        completion_text_token_price: 80000,
+      }),
+    ).toEqual({
+      format: "openai",
+      flavor: "chat",
+      multimodal: true,
+      input_cost_per_mil_tokens: 2,
+      input_cache_read_cost_per_mil_tokens: 0.2,
+      output_cost_per_mil_tokens: 8,
+      max_input_tokens: 256000,
+      available_providers: ["xAI"],
+    });
+  });
+});
+
+describe("convertCerebrasToLocalModel", () => {
+  it("converts Cerebras's public priced model entry to a ModelSpec", () => {
+    expect(
+      convertCerebrasToLocalModel({
+        id: "gpt-oss-120b",
+        name: "OpenAI GPT OSS",
+        pricing: { prompt: "0.00000035", completion: "0.00000075" },
+        capabilities: { vision: false, reasoning: true },
+        limits: { max_context_length: 131072, max_completion_tokens: 40960 },
+      }),
+    ).toEqual({
+      format: "openai",
+      flavor: "chat",
+      reasoning: true,
+      input_cost_per_mil_tokens: 0.35,
+      output_cost_per_mil_tokens: 0.75,
+      displayName: "OpenAI GPT OSS",
+      max_input_tokens: 131072,
+      max_output_tokens: 40960,
+      available_providers: ["cerebras"],
     });
   });
 });

--- a/packages/proxy/scripts/sync_models.ts
+++ b/packages/proxy/scripts/sync_models.ts
@@ -3381,6 +3381,9 @@ async function syncGroqModelCommand(argv: any) {
     }
     await writeLocalModels(orderedModels);
     await syncProviderMappingsForLocalModels(orderedModels, completeModelOrder);
+    if (existingName) {
+      await addProviderToExistingMappings([existingName], "groq");
+    }
     console.log(`✅ Wrote ${LOCAL_MODEL_LIST_PATH}`);
   } catch (error) {
     console.error("Error during sync-groq-model command:", error);
@@ -3429,6 +3432,9 @@ async function writeTargetedProviderModel(args: {
   }
   await writeLocalModels(orderedModels);
   await syncProviderMappingsForLocalModels(orderedModels, completeModelOrder);
+  if (existingName) {
+    await addProviderToExistingMappings([existingName], args.provider);
+  }
   console.log(`✅ Wrote ${LOCAL_MODEL_LIST_PATH}`);
 }
 

--- a/packages/proxy/scripts/sync_models.ts
+++ b/packages/proxy/scripts/sync_models.ts
@@ -472,6 +472,71 @@ const basetenModelListSchema = z
 
 type BasetenModel = z.infer<typeof basetenModelSchema>;
 
+// Groq's authenticated /openai/v1/models response has the same catalog data
+// we need for an automatic entry: per-token pricing, token limits, modalities,
+// and supported features. Keep this direct source separate from LiteLLM so a
+// newly released Groq model does not need an inference-model research pass.
+const GROQ_MODEL_URL = "https://api.groq.com/openai/v1/models";
+
+const groqModelSchema = z
+  .object({
+    id: z.string(),
+    name: z.string().optional(),
+    active: z.boolean().optional(),
+    context_length: z.number().optional(),
+    max_completion_tokens: z.number().optional(),
+    pricing: basetenPricingSchema.optional(),
+    supported_features: z.array(z.string()).optional(),
+    input_modalities: z.array(z.string()).optional(),
+    output_modalities: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
+const groqModelListSchema = z.object({ data: z.array(groqModelSchema) });
+
+type GroqModel = z.infer<typeof groqModelSchema>;
+
+const XAI_MODEL_URL = "https://api.x.ai/v1/language-models";
+const xaiModelSchema = z
+  .object({
+    id: z.string(),
+    context_length: z.number().optional(),
+    input_modalities: z.array(z.string()).optional(),
+    output_modalities: z.array(z.string()).optional(),
+    prompt_text_token_price: z.number().optional(),
+    cached_prompt_text_token_price: z.number().optional(),
+    completion_text_token_price: z.number().optional(),
+  })
+  .passthrough();
+const xaiModelListSchema = z.object({ models: z.array(xaiModelSchema) });
+type XaiModel = z.infer<typeof xaiModelSchema>;
+
+const CEREBRAS_MODEL_URL = "https://api.cerebras.ai/public/v1/models";
+const cerebrasModelSchema = z
+  .object({
+    id: z.string(),
+    name: z.string().optional(),
+    pricing: basetenPricingSchema.optional(),
+    capabilities: z
+      .object({
+        vision: z.boolean().optional(),
+        reasoning: z.boolean().optional(),
+      })
+      .optional(),
+    limits: z
+      .object({
+        max_context_length: z.number().optional(),
+        max_completion_tokens: z.number().optional(),
+      })
+      .optional(),
+    deprecated: z.boolean().optional(),
+  })
+  .passthrough();
+const cerebrasModelListSchema = z.object({
+  data: z.array(cerebrasModelSchema),
+});
+type CerebrasModel = z.infer<typeof cerebrasModelSchema>;
+
 async function fetchBasetenModels(apiKey: string): Promise<BasetenModel[]> {
   return new Promise((resolve, reject) => {
     https
@@ -520,6 +585,116 @@ async function fetchBasetenModels(apiKey: string): Promise<BasetenModel[]> {
       )
       .on("error", (err) => {
         reject(new Error("Failed to fetch Baseten models: " + err.message));
+      });
+  });
+}
+
+async function fetchGroqModels(apiKey: string): Promise<GroqModel[]> {
+  return new Promise((resolve, reject) => {
+    https
+      .get(
+        GROQ_MODEL_URL,
+        { headers: { Authorization: `Bearer ${apiKey}` } },
+        (res) => {
+          let data = "";
+          res.on("data", (chunk) => {
+            data += chunk;
+          });
+          res.on("end", () => {
+            if (res.statusCode && res.statusCode >= 400) {
+              reject(
+                new Error(
+                  `Groq /v1/models returned HTTP ${res.statusCode}: ${data.slice(0, 200)}`,
+                ),
+              );
+              return;
+            }
+            try {
+              resolve(groqModelListSchema.parse(JSON.parse(data)).data);
+            } catch (error) {
+              const message =
+                error instanceof Error ? error.message : String(error);
+              reject(new Error(`Failed to parse Groq /v1/models: ${message}`));
+            }
+          });
+        },
+      )
+      .on("error", (error) => {
+        reject(new Error(`Failed to fetch Groq models: ${error.message}`));
+      });
+  });
+}
+
+async function fetchXaiModels(apiKey: string): Promise<XaiModel[]> {
+  return new Promise((resolve, reject) => {
+    https
+      .get(
+        XAI_MODEL_URL,
+        { headers: { Authorization: `Bearer ${apiKey}` } },
+        (res) => {
+          let data = "";
+          res.on("data", (chunk) => {
+            data += chunk;
+          });
+          res.on("end", () => {
+            if (res.statusCode && res.statusCode >= 400) {
+              reject(
+                new Error(
+                  `xAI /v1/language-models returned HTTP ${res.statusCode}`,
+                ),
+              );
+              return;
+            }
+            try {
+              resolve(xaiModelListSchema.parse(JSON.parse(data)).models);
+            } catch (error) {
+              const message =
+                error instanceof Error ? error.message : String(error);
+              reject(
+                new Error(
+                  `Failed to parse xAI /v1/language-models: ${message}`,
+                ),
+              );
+            }
+          });
+        },
+      )
+      .on("error", (error) => {
+        reject(new Error(`Failed to fetch xAI models: ${error.message}`));
+      });
+  });
+}
+
+async function fetchCerebrasModels(): Promise<CerebrasModel[]> {
+  return new Promise((resolve, reject) => {
+    https
+      .get(CEREBRAS_MODEL_URL, (res) => {
+        let data = "";
+        res.on("data", (chunk) => {
+          data += chunk;
+        });
+        res.on("end", () => {
+          if (res.statusCode && res.statusCode >= 400) {
+            reject(
+              new Error(
+                `Cerebras public models returned HTTP ${res.statusCode}`,
+              ),
+            );
+            return;
+          }
+          try {
+            resolve(cerebrasModelListSchema.parse(JSON.parse(data)).data);
+          } catch (error) {
+            const message =
+              error instanceof Error ? error.message : String(error);
+            reject(
+              new Error(`Failed to parse Cerebras public models: ${message}`),
+            );
+          }
+        });
+      })
+      .on("error", (error) => {
+        reject(new Error(`Failed to fetch Cerebras models: ${error.message}`));
       });
   });
 }
@@ -1775,6 +1950,110 @@ export function convertBasetenToLocalModel(model: BasetenModel): ModelSpec {
   return baseModel as ModelSpec;
 }
 
+export function convertGroqToLocalModel(model: GroqModel): ModelSpec {
+  const roundCost = (costPerToken: number): number =>
+    parseFloat((costPerToken * 1_000_000).toFixed(8));
+  const baseModel: Partial<ModelSpec> = { format: "openai", flavor: "chat" };
+
+  if (model.input_modalities?.includes("image")) {
+    baseModel.multimodal = true;
+  }
+  if (model.supported_features?.includes("reasoning")) {
+    baseModel.reasoning = true;
+  }
+
+  const inputCost = getNonZeroNumber(parseBasetenPrice(model.pricing?.prompt));
+  if (inputCost !== undefined) {
+    baseModel.input_cost_per_mil_tokens = roundCost(inputCost);
+  }
+  const outputCost = getNonZeroNumber(
+    parseBasetenPrice(model.pricing?.completion),
+  );
+  if (outputCost !== undefined) {
+    baseModel.output_cost_per_mil_tokens = roundCost(outputCost);
+  }
+  const cacheReadCost = getNonZeroNumber(
+    parseBasetenPrice(model.pricing?.input_cache_read),
+  );
+  if (cacheReadCost !== undefined) {
+    baseModel.input_cache_read_cost_per_mil_tokens = roundCost(cacheReadCost);
+  }
+
+  if (model.name) {
+    baseModel.displayName = model.name;
+  }
+  const maxInputTokens = getNonZeroNumber(model.context_length);
+  if (maxInputTokens !== undefined) {
+    baseModel.max_input_tokens = maxInputTokens;
+  }
+  const maxOutputTokens = getNonZeroNumber(model.max_completion_tokens);
+  if (maxOutputTokens !== undefined) {
+    baseModel.max_output_tokens = maxOutputTokens;
+  }
+
+  baseModel.available_providers = ["groq"];
+  return baseModel as ModelSpec;
+}
+
+export function convertXaiToLocalModel(model: XaiModel): ModelSpec {
+  const costPerMillion = (price: number): number => price / 10_000;
+  const baseModel: Partial<ModelSpec> = { format: "openai", flavor: "chat" };
+  if (model.input_modalities?.includes("image")) {
+    baseModel.multimodal = true;
+  }
+  if (model.prompt_text_token_price !== undefined) {
+    baseModel.input_cost_per_mil_tokens = costPerMillion(
+      model.prompt_text_token_price,
+    );
+  }
+  if (model.completion_text_token_price !== undefined) {
+    baseModel.output_cost_per_mil_tokens = costPerMillion(
+      model.completion_text_token_price,
+    );
+  }
+  if (model.cached_prompt_text_token_price) {
+    baseModel.input_cache_read_cost_per_mil_tokens = costPerMillion(
+      model.cached_prompt_text_token_price,
+    );
+  }
+  if (model.context_length) {
+    baseModel.max_input_tokens = model.context_length;
+  }
+  baseModel.available_providers = ["xAI"];
+  return baseModel as ModelSpec;
+}
+
+export function convertCerebrasToLocalModel(model: CerebrasModel): ModelSpec {
+  const baseModel: Partial<ModelSpec> = { format: "openai", flavor: "chat" };
+  if (model.capabilities?.vision) {
+    baseModel.multimodal = true;
+  }
+  if (model.capabilities?.reasoning) {
+    baseModel.reasoning = true;
+  }
+  const inputCost = getNonZeroNumber(parseBasetenPrice(model.pricing?.prompt));
+  if (inputCost !== undefined) {
+    baseModel.input_cost_per_mil_tokens = inputCost * 1_000_000;
+  }
+  const outputCost = getNonZeroNumber(
+    parseBasetenPrice(model.pricing?.completion),
+  );
+  if (outputCost !== undefined) {
+    baseModel.output_cost_per_mil_tokens = outputCost * 1_000_000;
+  }
+  if (model.name) {
+    baseModel.displayName = model.name;
+  }
+  if (model.limits?.max_context_length) {
+    baseModel.max_input_tokens = model.limits.max_context_length;
+  }
+  if (model.limits?.max_completion_tokens) {
+    baseModel.max_output_tokens = model.limits.max_completion_tokens;
+  }
+  baseModel.available_providers = ["cerebras"];
+  return baseModel as ModelSpec;
+}
+
 // Convert a Cohere /v1/models entry to a catalog spec. Cohere exposes its chat
 // models through an OpenAI-compatible API, so format is "openai". Cohere's models
 // endpoint carries no pricing, so pricing is overlaid from the matching LiteLLM
@@ -2693,6 +2972,13 @@ async function addModelsCommand(argv: any) {
           continue;
         }
       }
+      if (
+        argv.modelSlug &&
+        remoteModelName !== argv.modelSlug &&
+        translatedModelName !== argv.modelSlug
+      ) {
+        continue;
+      }
 
       if (
         isModelExcludedFromSync(translatedModelName) ||
@@ -2883,6 +3169,9 @@ async function syncBasetenModelsCommand(argv: any) {
 
     for (const basetenModel of basetenModels) {
       const id = basetenModel.id;
+      if (argv.modelSlug && id !== argv.modelSlug) {
+        continue;
+      }
       if (!isSupportedTranslatedModelName(id, "baseten")) {
         console.warn(`  [INVALID] Skipping unsupported model id: ${id}`);
         continue;
@@ -3013,6 +3302,193 @@ async function syncBasetenModelsCommand(argv: any) {
     await syncProviderMappingsForLocalModels(updatedModels, completeModelOrder);
   } catch (error) {
     console.error("Error during sync-baseten command:", error);
+    process.exit(1);
+  }
+}
+
+async function syncGroqModelCommand(argv: any) {
+  try {
+    const apiKey = process.env.GROQ_API_KEY;
+    if (!apiKey) {
+      throw new Error(
+        "GROQ_API_KEY environment variable is required to sync Groq models.",
+      );
+    }
+
+    console.log("Fetching Groq models from:", GROQ_MODEL_URL);
+    const target = (await fetchGroqModels(apiKey)).find(
+      (model) => model.id === argv.modelSlug,
+    );
+    if (!target) {
+      console.log(`Groq does not list ${argv.modelSlug}. No changes needed.`);
+      return;
+    }
+    if (
+      target.active !== true ||
+      !target.input_modalities?.includes("text") ||
+      !target.output_modalities?.includes("text")
+    ) {
+      console.log(`${argv.modelSlug} is not an active text/chat Groq model.`);
+      return;
+    }
+    if (!target.pricing?.prompt || !target.pricing.completion) {
+      console.log(
+        `Groq lists ${argv.modelSlug} without input/output pricing. No changes needed.`,
+      );
+      return;
+    }
+    if (isModelExcludedFromSync(target.id)) {
+      console.log(`Skipping excluded Groq model ${target.id}.`);
+      return;
+    }
+
+    const localModels = normalizeLocalModels(
+      await readLocalModels(LOCAL_MODEL_LIST_PATH),
+    ).models;
+    const existingName = getEquivalentLocalModelNames(target.id).find((name) =>
+      Object.prototype.hasOwnProperty.call(localModels, name),
+    );
+    if (existingName) {
+      const existing = localModels[existingName];
+      if (existing.available_providers?.includes("groq")) {
+        console.log(
+          `${target.id} is already listed for Groq. No changes needed.`,
+        );
+        return;
+      }
+      localModels[existingName] = {
+        ...existing,
+        available_providers: [
+          ...(existing.available_providers ?? []),
+          "groq",
+        ] as ModelSpec["available_providers"],
+      };
+      console.log(`Adding Groq to ${existingName}.`);
+    } else {
+      localModels[target.id] = convertGroqToLocalModel(target);
+      console.log(`Adding ${target.id} from Groq's priced model list.`);
+    }
+
+    if (!argv.write) {
+      console.log("Dry run. Re-run with --write to apply.");
+      return;
+    }
+
+    const completeModelOrder = orderModelsByProviderAndClass(localModels);
+    const orderedModels: LocalModelList = {};
+    for (const name of completeModelOrder) {
+      orderedModels[name] = localModels[name];
+    }
+    await writeLocalModels(orderedModels);
+    await syncProviderMappingsForLocalModels(orderedModels, completeModelOrder);
+    console.log(`✅ Wrote ${LOCAL_MODEL_LIST_PATH}`);
+  } catch (error) {
+    console.error("Error during sync-groq-model command:", error);
+    process.exit(1);
+  }
+}
+
+async function writeTargetedProviderModel(args: {
+  modelId: string;
+  provider: NonNullable<ModelSpec["available_providers"]>[number];
+  model: ModelSpec;
+  write: boolean;
+}): Promise<void> {
+  const localModels = normalizeLocalModels(
+    await readLocalModels(LOCAL_MODEL_LIST_PATH),
+  ).models;
+  const existingName = getEquivalentLocalModelNames(args.modelId).find((name) =>
+    Object.prototype.hasOwnProperty.call(localModels, name),
+  );
+  if (existingName) {
+    const existing = localModels[existingName];
+    if (existing.available_providers?.includes(args.provider)) {
+      console.log(`${args.modelId} is already listed for ${args.provider}.`);
+      return;
+    }
+    localModels[existingName] = {
+      ...existing,
+      available_providers: [
+        ...(existing.available_providers ?? []),
+        args.provider,
+      ] as ModelSpec["available_providers"],
+    };
+  } else {
+    localModels[args.modelId] = args.model;
+  }
+
+  if (!args.write) {
+    console.log("Dry run. Re-run with --write to apply.");
+    return;
+  }
+
+  const completeModelOrder = orderModelsByProviderAndClass(localModels);
+  const orderedModels: LocalModelList = {};
+  for (const name of completeModelOrder) {
+    orderedModels[name] = localModels[name];
+  }
+  await writeLocalModels(orderedModels);
+  await syncProviderMappingsForLocalModels(orderedModels, completeModelOrder);
+  console.log(`✅ Wrote ${LOCAL_MODEL_LIST_PATH}`);
+}
+
+async function syncXaiModelCommand(argv: any) {
+  try {
+    const apiKey = process.env.XAI_API_KEY;
+    if (!apiKey) {
+      throw new Error(
+        "XAI_API_KEY environment variable is required to sync xAI models.",
+      );
+    }
+    const target = (await fetchXaiModels(apiKey)).find(
+      (model) => model.id === argv.modelSlug,
+    );
+    if (
+      !target ||
+      !target.input_modalities?.includes("text") ||
+      !target.output_modalities?.includes("text") ||
+      target.prompt_text_token_price === undefined ||
+      target.completion_text_token_price === undefined
+    ) {
+      console.log(`xAI has no priced text model named ${argv.modelSlug}.`);
+      return;
+    }
+    await writeTargetedProviderModel({
+      modelId: target.id,
+      provider: "xAI",
+      model: convertXaiToLocalModel(target),
+      write: argv.write,
+    });
+  } catch (error) {
+    console.error("Error during sync-xai-model command:", error);
+    process.exit(1);
+  }
+}
+
+async function syncCerebrasModelCommand(argv: any) {
+  try {
+    const target = (await fetchCerebrasModels()).find(
+      (model) => model.id === argv.modelSlug,
+    );
+    if (
+      !target ||
+      target.deprecated === true ||
+      !target.pricing?.prompt ||
+      !target.pricing.completion
+    ) {
+      console.log(
+        `Cerebras has no active priced model named ${argv.modelSlug}.`,
+      );
+      return;
+    }
+    await writeTargetedProviderModel({
+      modelId: target.id,
+      provider: "cerebras",
+      model: convertCerebrasToLocalModel(target),
+      write: argv.write,
+    });
+  } catch (error) {
+    console.error("Error during sync-cerebras-model command:", error);
     process.exit(1);
   }
 }
@@ -3579,6 +4055,11 @@ async function main() {
             type: "string",
             description: "Filter models by name substring (e.g., 'gpt-5')",
           })
+          .option("model-slug", {
+            type: "string",
+            description:
+              "Add only this exact remote or translated model id (for targeted automations)",
+          })
           .option("write", {
             type: "boolean",
             description:
@@ -3600,15 +4081,71 @@ async function main() {
       "sync-baseten",
       "Sync the catalog against Baseten's /v1/models (add missing Baseten models and union the baseten provider into existing ids). Requires BASETEN_API_KEY.",
       (y) => {
-        return y.option("write", {
-          type: "boolean",
-          description:
-            "Write the new models and provider mappings to model_list.json / index.ts",
-          default: false,
-        });
+        return y
+          .option("model-slug", {
+            type: "string",
+            description: "Sync only this exact Baseten model id",
+          })
+          .option("write", {
+            type: "boolean",
+            description:
+              "Write the new models and provider mappings to model_list.json / index.ts",
+            default: false,
+          });
       },
       async (argv) => {
         await syncBasetenModelsCommand(argv);
+      },
+    )
+    .command(
+      "sync-groq-model",
+      "Sync one Groq model from Groq's priced /v1/models endpoint. Requires GROQ_API_KEY.",
+      (y) => {
+        return y
+          .option("model-slug", {
+            type: "string",
+            demandOption: true,
+            description: "Exact Groq model id to sync",
+          })
+          .option("write", {
+            type: "boolean",
+            description:
+              "Write the model and provider mapping to model_list.json / index.ts",
+            default: false,
+          });
+      },
+      async (argv) => {
+        await syncGroqModelCommand(argv);
+      },
+    )
+    .command(
+      "sync-xai-model",
+      "Sync one xAI model from xAI's priced /v1/language-models endpoint. Requires XAI_API_KEY.",
+      (y) =>
+        y
+          .option("model-slug", {
+            type: "string",
+            demandOption: true,
+            description: "Exact xAI model id to sync",
+          })
+          .option("write", { type: "boolean", default: false }),
+      async (argv) => {
+        await syncXaiModelCommand(argv);
+      },
+    )
+    .command(
+      "sync-cerebras-model",
+      "Sync one Cerebras model from Cerebras's public priced models endpoint.",
+      (y) =>
+        y
+          .option("model-slug", {
+            type: "string",
+            demandOption: true,
+            description: "Exact Cerebras model id to sync",
+          })
+          .option("write", { type: "boolean", default: false }),
+      async (argv) => {
+        await syncCerebrasModelCommand(argv);
       },
     )
     .command(


### PR DESCRIPTION
This is a more targeted workflow that we will prompt folks to run from #new-model-drops. For providers that output pricing information in their `/models` endpoint, we just update `sync-models.ts` to use that, and otherwise, we send claude on a targeted mission to put together the model entry for the new model passed into this workflow.