### PR TITLE
Fix deprecation audit selecting an ineligible provider secret

### DIFF
--- a/packages/proxy/scripts/braintrust_secrets.test.ts
+++ b/packages/proxy/scripts/braintrust_secrets.test.ts
@@ -39,9 +39,14 @@ describe("secretServesDefaultModels", () => {
   });
 
   it("ignores excludeDefaultModels when there are no custom models", () => {
-    expect(secretServesDefaultModels({ excludeDefaultModels: true })).toBe(true);
+    expect(secretServesDefaultModels({ excludeDefaultModels: true })).toBe(
+      true,
+    );
     expect(
-      secretServesDefaultModels({ customModels: {}, excludeDefaultModels: true }),
+      secretServesDefaultModels({
+        customModels: {},
+        excludeDefaultModels: true,
+      }),
     ).toBe(true);
   });
 });
@@ -66,12 +71,18 @@ describe("selectProviderSecretsByType", () => {
     // Regression: the AI-secret reordering surfaced this by putting a custom
     // openai-format provider first, which then falsely 404'd real OpenAI models
     // during the deprecation audit (mirrors braintrust #19487).
-    const selected = selectProviderSecretsByType([customOnlyOpenai, realOpenai]);
+    const selected = selectProviderSecretsByType([
+      customOnlyOpenai,
+      realOpenai,
+    ]);
     expect(selected.get("openai")?.secret).toBe("openai_key");
   });
 
   it("still prefers the real key when it comes first", () => {
-    const selected = selectProviderSecretsByType([realOpenai, customOnlyOpenai]);
+    const selected = selectProviderSecretsByType([
+      realOpenai,
+      customOnlyOpenai,
+    ]);
     expect(selected.get("openai")?.secret).toBe("openai_key");
   });
 

--- a/packages/proxy/scripts/braintrust_secrets.test.ts
+++ b/packages/proxy/scripts/braintrust_secrets.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  secretServesDefaultModels,
+  selectProviderSecretsByType,
+} from "./braintrust_secrets";
+
+describe("secretServesDefaultModels", () => {
+  it("treats a plain provider secret as serving default models", () => {
+    expect(secretServesDefaultModels(undefined)).toBe(true);
+    expect(secretServesDefaultModels(null)).toBe(true);
+    expect(secretServesDefaultModels({})).toBe(true);
+    expect(secretServesDefaultModels({ api_base: "https://example.com" })).toBe(
+      true,
+    );
+  });
+
+  it("treats a custom endpoint that still allows default models as eligible", () => {
+    expect(
+      secretServesDefaultModels({
+        customModels: { "meta-model": { format: "openai", flavor: "chat" } },
+      }),
+    ).toBe(true);
+    expect(
+      secretServesDefaultModels({
+        customModels: { "meta-model": { format: "openai", flavor: "chat" } },
+        excludeDefaultModels: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("treats a custom-only endpoint (excludeDefaultModels) as ineligible", () => {
+    expect(
+      secretServesDefaultModels({
+        api_base: "https://meta.example.com/v1",
+        customModels: { "meta-model": { format: "openai", flavor: "chat" } },
+        excludeDefaultModels: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores excludeDefaultModels when there are no custom models", () => {
+    expect(secretServesDefaultModels({ excludeDefaultModels: true })).toBe(true);
+    expect(
+      secretServesDefaultModels({ customModels: {}, excludeDefaultModels: true }),
+    ).toBe(true);
+  });
+});
+
+describe("selectProviderSecretsByType", () => {
+  const realOpenai = {
+    type: "openai",
+    secret: "openai_key",
+    metadata: {},
+  };
+  const customOnlyOpenai = {
+    type: "openai",
+    secret: "meta_key",
+    metadata: {
+      api_base: "https://meta.example.com/v1",
+      customModels: { "meta-model": { format: "openai", flavor: "chat" } },
+      excludeDefaultModels: true,
+    },
+  };
+
+  it("skips a custom-only secret ordered before the real provider key", () => {
+    // Regression: the AI-secret reordering surfaced this by putting a custom
+    // openai-format provider first, which then falsely 404'd real OpenAI models
+    // during the deprecation audit (mirrors braintrust #19487).
+    const selected = selectProviderSecretsByType([customOnlyOpenai, realOpenai]);
+    expect(selected.get("openai")?.secret).toBe("openai_key");
+  });
+
+  it("still prefers the real key when it comes first", () => {
+    const selected = selectProviderSecretsByType([realOpenai, customOnlyOpenai]);
+    expect(selected.get("openai")?.secret).toBe("openai_key");
+  });
+
+  it("leaves a type absent when only custom-only secrets exist", () => {
+    const selected = selectProviderSecretsByType([customOnlyOpenai]);
+    expect(selected.has("openai")).toBe(false);
+  });
+
+  it("keeps the first eligible secret and ignores entries without a secret", () => {
+    const selected = selectProviderSecretsByType([
+      { type: "openai", metadata: {} },
+      { type: "openai", secret: "first_real", metadata: {} },
+      { type: "openai", secret: "second_real", metadata: {} },
+    ]);
+    expect(selected.get("openai")?.secret).toBe("first_real");
+  });
+});

--- a/packages/proxy/scripts/braintrust_secrets.ts
+++ b/packages/proxy/scripts/braintrust_secrets.ts
@@ -77,9 +77,56 @@ function postJson(
   });
 }
 
+// Whether a secret serves the provider's shared/default models. A custom-only
+// endpoint (its own api_base plus customModels and excludeDefaultModels) points
+// at a different inference surface than the canonical provider, so probing the
+// shared catalog's models against it returns spurious not-found responses. The
+// model-list / deprecation audit must therefore not select such a secret. This
+// mirrors the gateway's routing-secret eligibility rule (braintrust #19487).
+export function secretServesDefaultModels(
+  metadata: Record<string, unknown> | null | undefined,
+): boolean {
+  const meta = metadata ?? {};
+  const customModels = meta.customModels;
+  const hasCustomModels =
+    typeof customModels === "object" &&
+    customModels !== null &&
+    !Array.isArray(customModels) &&
+    Object.keys(customModels).length > 0;
+  return !(hasCustomModels && meta.excludeDefaultModels === true);
+}
+
+// Collapse the raw /api/secret entries to one secret per provider type. Only
+// entries with a non-empty secret are considered. When a type has multiple
+// secrets configured, the first one that serves the provider's default models
+// is used; custom-only endpoints are skipped so they cannot shadow the real
+// provider key and cause false deprecations. A type with no eligible secret is
+// left absent (the provider is then skipped by the audit rather than misprobed).
+export function selectProviderSecretsByType(
+  entries: z.infer<typeof providerSecretListSchema>,
+): Map<string, ProviderSecret> {
+  const byType = new Map<string, ProviderSecret>();
+  for (const entry of entries) {
+    if (!entry.type || !entry.secret) {
+      continue;
+    }
+    if (byType.has(entry.type)) {
+      continue;
+    }
+    if (!secretServesDefaultModels(entry.metadata)) {
+      continue;
+    }
+    byType.set(entry.type, {
+      type: entry.type,
+      secret: entry.secret,
+      metadata: (entry.metadata as Record<string, unknown>) ?? {},
+    });
+  }
+  return byType;
+}
+
 // Fetch provider secrets for the given provider types from Braintrust, keyed by
-// provider type. Only entries with a non-empty secret are returned. When a type
-// has multiple secrets configured, the first one is used.
+// provider type. See selectProviderSecretsByType for the per-type selection rule.
 export async function fetchProviderSecrets(
   braintrustApiKey: string,
   types: string[],
@@ -104,19 +151,5 @@ export async function fetchProviderSecrets(
     );
   }
 
-  const byType = new Map<string, ProviderSecret>();
-  for (const entry of parsed) {
-    if (!entry.type || !entry.secret) {
-      continue;
-    }
-    if (byType.has(entry.type)) {
-      continue;
-    }
-    byType.set(entry.type, {
-      type: entry.type,
-      secret: entry.secret,
-      metadata: (entry.metadata as Record<string, unknown>) ?? {},
-    });
-  }
-  return byType;
+  return selectProviderSecretsByType(parsed);
 }


### PR DESCRIPTION
fetchProviderSecrets collapsed the org's secrets to one-per-type keeping the first entry, with no eligibility check. When an org configures a custom OpenAI-format provider (its own api_base + customModels + excludeDefaultModels) that sorts before the real OpenAI key, the audit listed/probed shared-catalog models against that custom endpoint, got 404s, and flagged live models as deprecated.

Select the first secret that serves the provider's default models, skipping custom-only endpoints, mirroring the gateway's routing-secret eligibility (braintrust #19487). A type with no eligible secret is left absent so the provider is skipped rather than misprobed.