### PR TITLE
add gemini 3.8 flash

### DIFF
--- a/packages/proxy/schema/index.ts
+++ b/packages/proxy/schema/index.ts
@@ -1370,6 +1370,8 @@ export const AvailableEndpointTypes: { [name: string]: ModelEndpointType[] } = {
   "zai-glm-5-2": ["mistral"],
   "gemini-3.7-flash": ["google", "vertex", "openrouter"],
   "publishers/google/models/gemini-3.7-flash": ["vertex"],
+  "gemini-3.8-flash": ["google", "vertex"],
+  "publishers/google/models/gemini-3.8-flash": ["vertex"],
   "accounts/fireworks/models/qwen3p8-max": ["fireworks"],
   "databricks-gemini-3-7-flash": ["databricks"],
   "databricks-gemini-3-1-flash-image": ["databricks"],

--- a/packages/proxy/schema/model_list.json
+++ b/packages/proxy/schema/model_list.json
@@ -6247,6 +6247,25 @@
       "vertex"
     ]
   },
+  "publishers/google/models/gemini-3.8-flash": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.75,
+    "output_cost_per_mil_tokens": 3.75,
+    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "displayName": "Gemini 3.8 Flash",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "locations": [
+      "global"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "vertex"
+    ]
+  },
   "publishers/google/models/gemini-3.6-flash": {
     "format": "google",
     "flavor": "chat",
@@ -11689,6 +11708,26 @@
       "google",
       "vertex",
       "openrouter"
+    ]
+  },
+  "gemini-3.8-flash": {
+    "format": "google",
+    "flavor": "chat",
+    "multimodal": true,
+    "input_cost_per_mil_tokens": 0.75,
+    "output_cost_per_mil_tokens": 3.75,
+    "input_cache_read_cost_per_mil_tokens": 0.075,
+    "displayName": "Gemini 3.8 Flash",
+    "reasoning": true,
+    "reasoning_budget": true,
+    "fallback_models": [
+      "publishers/google/models/gemini-3.8-flash"
+    ],
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "available_providers": [
+      "google",
+      "vertex"
     ]
   },
   "gemini-3.6-flash": {


### PR DESCRIPTION
## Summary

  Add Gemini 3.8 Flash to the model catalog for both Gemini API and Vertex AI.

  - Adds gemini-3.8-flash and Vertex alias publishers/google/models/gemini-3.8-flash
  - Configures Gemini and Vertex providers, 1M-token context, 65,536 output tokens, multimodal input, and reasoning
    support

  - Uses launch pricing: $0.75/M input, $3.75/M output, and $0.075/M cached input tokens
  - Does not add Gemini 3.8 Flash Cyber because it is restricted to Google’s Fairwind Program and has no public API/
    Vertex model ID

  ## Validation

  - jq empty packages/proxy/schema/model_list.json
  - git diff --check